### PR TITLE
Update release dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11,<3.14"
 license = {file="LICENSE"}
 dependencies = [
     "ase>=3.27.0",
-    "nvalchemi-toolkit-ops[torch]",
+    "nvalchemi-toolkit-ops[torch]>=0.3.0",
     "torch>=2.5.1",
     "loguru",
     "numpy",

--- a/uv.lock
+++ b/uv.lock
@@ -2149,7 +2149,7 @@ dependencies = [
     { name = "jaxtyping" },
     { name = "loguru" },
     { name = "numpy" },
-    { name = "nvalchemi-toolkit-ops" },
+    { name = "nvalchemi-toolkit-ops", extra = ["torch"] },
     { name = "periodictable" },
     { name = "plum-dispatch" },
     { name = "pydantic" },
@@ -2221,7 +2221,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "mace-torch", marker = "extra == 'mace'", specifier = "==0.3.15" },
     { name = "numpy" },
-    { name = "nvalchemi-toolkit-ops", extras = ["torch"] },
+    { name = "nvalchemi-toolkit-ops", extras = ["torch"], specifier = ">=0.3.0" },
     { name = "nvidia-physicsnemo", extras = ["datapipes-extras"], marker = "extra == 'training'", specifier = ">=2.0.0" },
     { name = "periodictable", specifier = "==2.0.2" },
     { name = "plum-dispatch", specifier = ">=2.5.7" },
@@ -2275,15 +2275,19 @@ docs = [
 
 [[package]]
 name = "nvalchemi-toolkit-ops"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch" },
     { name = "warp-lang" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/97/9f57af74dd92fc5c0af6f8d5a7b8459c103e318d16f3d9dbd863826fccf8/nvalchemi_toolkit_ops-0.2.0-py3-none-any.whl", hash = "sha256:d6b41c32f907da3d9b64d4ccc20aac11dfc29b7acadc8def52c874591603e2ee", size = 172603, upload-time = "2025-12-19T15:24:27.752Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a6/b051bda85ee516ff5adb6149a415c7a390485375859af29e14ac7b711a2a/nvalchemi_toolkit_ops-0.3.0-py3-none-any.whl", hash = "sha256:0847509a0279dbb950b9dfc6830dbda098db7ec78f357914100ca13f4ff5f0e8", size = 449100, upload-time = "2026-03-16T17:11:14.212Z" },
+]
+
+[package.optional-dependencies]
+torch = [
+    { name = "torch" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR updates `pyproject.toml` and `uv.lock` to use PyPI versions of either `physicsnemo` and `nvalchemi-toolkit-ops` instead of Github installs.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Update `pyproject.toml` and `uv.lock` to use PyPI installs, instead of Github index

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
