### PR TITLE
fix: propagate fields in composite ModelCard synthesis

### DIFF
--- a/examples/advanced/07_composable_model_composition.py
+++ b/examples/advanced/07_composable_model_composition.py
@@ -140,7 +140,8 @@ assert lj_model.model_config.compute_forces is True
 assert ewald_model.model_config.compute_forces is True
 print("model_config propagated to both sub-models ✓")
 
-# The synthesised ModelCard reflects the union of sub-model capabilities.
+# The synthesised ModelCard reflects aggregated sub-model requirements,
+# additive capabilities, and metadata.
 card = combined.model_card
 print(
     f"Combined neighbor config: cutoff={card.neighbor_config.cutoff} Å, "

--- a/nvalchemi/models/composable.py
+++ b/nvalchemi/models/composable.py
@@ -142,6 +142,8 @@ class ComposableModelWrapper(nn.Module, BaseModelMixin):
         supports_stresses = all(c.supports_stresses for c in cards)
         supports_pbc = all(c.supports_pbc for c in cards)
         needs_pbc = any(c.needs_pbc for c in cards)
+        needs_node_charges = any(c.needs_node_charges for c in cards)
+        needs_system_charges = any(c.needs_system_charges for c in cards)
         supports_non_batch = all(c.supports_non_batch for c in cards)
 
         # Synthesise neighbor_config from sub-models that have one.
@@ -199,6 +201,18 @@ class ComposableModelWrapper(nn.Module, BaseModelMixin):
                 stacklevel=3,
             )
 
+        includes_dispersion = any(c.includes_dispersion for c in cards)
+        includes_long_range_electrostatics = any(
+            c.includes_long_range_electrostatics for c in cards
+        )
+
+        # supports_node/edge/graph_embeddings: always False. Composite wrappers do not
+        # expose a unified embedding API; compute_embeddings() raises NotImplementedError.
+        # supports_hessians, supports_dipoles: intentionally kept False for now.
+        # Although forward() writes non-additive child outputs back to the batch on a
+        # last-write-wins basis, ComposableModelWrapper does not currently advertise or
+        # return these as first-class composite outputs.
+
         return ModelCard(
             forces_via_autograd=forces_via_autograd,
             supports_energies=supports_energies,
@@ -206,8 +220,12 @@ class ComposableModelWrapper(nn.Module, BaseModelMixin):
             supports_stresses=supports_stresses,
             supports_pbc=supports_pbc,
             needs_pbc=needs_pbc,
+            needs_node_charges=needs_node_charges,
+            needs_system_charges=needs_system_charges,
             supports_non_batch=supports_non_batch,
             neighbor_config=neighbor_config,
+            includes_dispersion=includes_dispersion,
+            includes_long_range_electrostatics=includes_long_range_electrostatics,
         )
 
     @property

--- a/test/models/test_composable.py
+++ b/test/models/test_composable.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import typing
 from collections import OrderedDict
 
 import pytest
@@ -663,6 +664,10 @@ class TestModelCardSynthesis:
             name
             for name, info in ModelCard.model_fields.items()
             if info.annotation is bool
+            or (
+                typing.get_origin(info.annotation) is typing.Annotated
+                and typing.get_args(info.annotation)[0] is bool
+            )
         }
 
         assert _PROPAGATED & _INTENTIONALLY_FALSE == set(), "sets must not overlap"

--- a/test/models/test_composable.py
+++ b/test/models/test_composable.py
@@ -223,6 +223,47 @@ class _NonAutoGradModel(DemoModelWrapper):
         )
 
 
+class _NeedsChargesModel(DemoModelWrapper):
+    """DemoModelWrapper subclass that requires node and system charges."""
+
+    @property
+    def model_card(self) -> ModelCard:
+        return super().model_card.model_copy(
+            update={"needs_node_charges": True, "needs_system_charges": True}
+        )
+
+
+class _DispersionModel(DemoModelWrapper):
+    """DemoModelWrapper subclass that declares includes_dispersion=True."""
+
+    @property
+    def model_card(self) -> ModelCard:
+        return super().model_card.model_copy(update={"includes_dispersion": True})
+
+
+class _LongRangeElecModel(DemoModelWrapper):
+    """DemoModelWrapper subclass that declares includes_long_range_electrostatics=True."""
+
+    @property
+    def model_card(self) -> ModelCard:
+        return super().model_card.model_copy(
+            update={"includes_long_range_electrostatics": True}
+        )
+
+
+class _EmbeddingModel(DemoModelWrapper):
+    """DemoModelWrapper subclass that claims embedding support."""
+
+    @property
+    def model_card(self) -> ModelCard:
+        return super().model_card.model_copy(
+            update={
+                "supports_node_embeddings": True,
+                "supports_graph_embeddings": True,
+            }
+        )
+
+
 # ---------------------------------------------------------------------------
 # Batch factory helper
 # ---------------------------------------------------------------------------
@@ -537,6 +578,100 @@ class TestModelCardSynthesis:
         # Both calls should yield equivalent results
         assert card1.forces_via_autograd == card2.forces_via_autograd
         assert card1.supports_energies == card2.supports_energies
+
+    # -- needs_node_charges / needs_system_charges --
+
+    def test_needs_node_charges_is_any(self):
+        """needs_node_charges: True if any sub-model requires it."""
+        wrapper = ComposableModelWrapper(_NeedsChargesModel(), DemoModelWrapper())
+        assert wrapper.model_card.needs_node_charges is True
+
+    def test_needs_node_charges_false_when_none_need(self):
+        wrapper = ComposableModelWrapper(DemoModelWrapper(), DemoModelWrapper())
+        assert wrapper.model_card.needs_node_charges is False
+
+    def test_needs_system_charges_is_any(self):
+        """needs_system_charges: True if any sub-model requires it."""
+        wrapper = ComposableModelWrapper(_NeedsChargesModel(), DemoModelWrapper())
+        assert wrapper.model_card.needs_system_charges is True
+
+    # -- input_data integration --
+
+    def test_input_data_includes_node_charges(self):
+        """input_data() must list node_charges when a sub-model requires them."""
+        wrapper = ComposableModelWrapper(_NeedsChargesModel(), DemoModelWrapper())
+        assert "node_charges" in wrapper.input_data()
+
+    def test_input_data_includes_graph_charges(self):
+        """input_data() must list graph_charges when a sub-model requires system charges."""
+        wrapper = ComposableModelWrapper(_NeedsChargesModel(), DemoModelWrapper())
+        assert "graph_charges" in wrapper.input_data()
+
+    # -- includes_dispersion / includes_long_range_electrostatics --
+
+    def test_includes_dispersion_propagated(self):
+        """includes_dispersion: True if any sub-model includes it."""
+        wrapper = ComposableModelWrapper(_DispersionModel(), DemoModelWrapper())
+        assert wrapper.model_card.includes_dispersion is True
+
+    def test_includes_long_range_electrostatics_propagated(self):
+        """includes_long_range_electrostatics: True if any sub-model includes it."""
+        wrapper = ComposableModelWrapper(_LongRangeElecModel(), DemoModelWrapper())
+        assert wrapper.model_card.includes_long_range_electrostatics is True
+
+    # -- embedding support stays False on composite --
+
+    def test_embedding_support_stays_false(self):
+        """Composite must not claim embedding support even if a child does."""
+        wrapper = ComposableModelWrapper(_EmbeddingModel(), DemoModelWrapper())
+        card = wrapper.model_card
+        assert card.supports_node_embeddings is False
+        assert card.supports_edge_embeddings is False
+        assert card.supports_graph_embeddings is False
+
+    # -- policy completeness --
+
+    def test_model_card_policy_covers_all_booleans(self):
+        """Every boolean field on ModelCard must be in exactly one policy set.
+
+        If a new boolean field is added to ModelCard, this test will fail,
+        forcing an explicit decision about composite aggregation rather than
+        silently defaulting to False.
+        """
+        _PROPAGATED = {
+            "forces_via_autograd",
+            "supports_energies",
+            "supports_forces",
+            "supports_stresses",
+            "supports_pbc",
+            "needs_pbc",
+            "supports_non_batch",
+            "needs_node_charges",
+            "needs_system_charges",
+            "includes_dispersion",
+            "includes_long_range_electrostatics",
+        }
+        _INTENTIONALLY_FALSE = {
+            "supports_node_embeddings",
+            "supports_edge_embeddings",
+            "supports_graph_embeddings",
+            "supports_hessians",
+            "supports_dipoles",
+        }
+
+        bool_fields = {
+            name
+            for name, info in ModelCard.model_fields.items()
+            if info.annotation is bool
+        }
+
+        assert _PROPAGATED & _INTENTIONALLY_FALSE == set(), "sets must not overlap"
+        assert _PROPAGATED | _INTENTIONALLY_FALSE == bool_fields, (
+            f"ModelCard boolean fields changed. "
+            f"New: {bool_fields - _PROPAGATED - _INTENTIONALLY_FALSE}. "
+            f"Removed: {(_PROPAGATED | _INTENTIONALLY_FALSE) - bool_fields}. "
+            f"Update _PROPAGATED or _INTENTIONALLY_FALSE in this test."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

`ComposableModelWrapper._build_model_card()` only passed 7 of 16 `ModelCard` boolean fields to the synthesized card. The remaining fields silently defaulted to `False`, making `wrapper.input_data()` and `wrapper.model_card` incorrect for composites that include charge-requiring sub-models like PME or Ewald.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Propagate `needs_node_charges` and `needs_system_charges` with `any()` aggregation in `_build_model_card()`, so the composite correctly reports input requirements from sub-models.
- Propagate `includes_dispersion` and `includes_long_range_electrostatics` with `any()` aggregation, so the composite card reflects physics metadata that was already read for double-counting warnings but never written to the synthesized card.
- Add a comment block explaining why `supports_node/edge/graph_embeddings`, `supports_hessians`, and `supports_dipoles` are intentionally kept `False` on composites.
- Update example comment in `examples/advanced/07_composable_model_composition.py` to accurately describe the composite card as "aggregated sub-model requirements, additive capabilities, and metadata" rather than "union of sub-model capabilities."

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New tests in `test/models/test_composable.py::TestModelCardSynthesis`:

- `test_needs_node_charges_is_any` / `test_needs_node_charges_false_when_none_need` / `test_needs_system_charges_is_any` — verify `needs_*` aggregation.
- `test_input_data_includes_node_charges` / `test_input_data_includes_graph_charges` — integration tests verifying `wrapper.input_data()` includes charge fields when a sub-model requires them.
- `test_includes_dispersion_propagated` / `test_includes_long_range_electrostatics_propagated` — verify `includes_*` metadata propagation.
- `test_embedding_support_stays_false` — negative test confirming embedding support is not propagated even when a child model supports it.
- `test_model_card_policy_covers_all_booleans` — future-proofing test that maintains two explicit sets (`_PROPAGATED` and `_INTENTIONALLY_FALSE`) covering every `ModelCard` boolean field. If a new boolean is added to `ModelCard`, this test fails and forces an explicit composite aggregation decision.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The composite's `forward()` dispatches directly to child models, so the missing fields did not break the forward path itself. The bug affected any generic code that inspects the composite's `model_card` or calls `input_data()` to determine required batch fields.

Mock helpers in tests use `model_copy(update={...})` instead of manually rebuilding partial `ModelCard` instances, avoiding accidental field omissions in test setup.
