### PR TITLE
perf(dataloader): lazily consume batch indices in _iter_prefetch

### DIFF
--- a/nvalchemi/data/datapipes/dataloader.py
+++ b/nvalchemi/data/datapipes/dataloader.py
@@ -27,6 +27,7 @@ workflows.
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Iterator
 
 import torch
@@ -200,55 +201,57 @@ class DataLoader:
     def _iter_prefetch(self) -> Iterator[Batch]:
         """Iteration with stream-based prefetching.
 
+        Uses a lazy sliding window of size ``prefetch_factor`` over the
+        batch-index generator so that the full epoch plan is never
+        materialised in memory.
+
         Strategy:
 
-        1. Prefetch ``prefetch_factor`` batches worth of samples
-        2. As we yield batches, prefetch more to keep the pipeline full
-        3. Each sample in a batch uses a different stream for overlap
+        1. Fill a window of up to ``prefetch_factor`` batches, submitting
+           each for async prefetch.
+        2. Pop the front batch, yield it, then pull one more batch from
+           the generator and prefetch it (keeping the window full).
+        3. Cleanup runs in a ``finally`` block so that
+           ``cancel_prefetch()`` fires on normal exhaustion, early break,
+           and exceptions.
 
         Yields
         ------
         Batch
             Collated batch of AtomicData.
         """
-        # Collect all batches upfront for prefetch planning
-        all_batches = list(self._generate_batches())
-        if not all_batches:
-            return
-
-        num_prefetch_batches = min(self.prefetch_factor, len(all_batches))
         stream_idx = 0
 
-        # Start initial prefetch
-        prefetched_up_to = 0
-        for batch_idx in range(num_prefetch_batches):
-            for sample_idx in all_batches[batch_idx]:
+        def _prefetch_batch(batch_indices: list[int]) -> None:
+            nonlocal stream_idx
+            for sample_idx in batch_indices:
                 stream = self._streams[stream_idx % self.num_streams]
                 self.dataset.prefetch(sample_idx, stream=stream)
                 stream_idx += 1
-            prefetched_up_to = batch_idx + 1
 
-        # Yield batches and prefetch more
-        for batch_idx, batch_indices in enumerate(all_batches):
-            # Collect samples (uses prefetched if available)
-            samples = [self.dataset[idx] for idx in batch_indices]
-            # Extract AtomicData from (AtomicData, metadata) tuples
-            data_list = [atomic_data for atomic_data, _ in samples]
-            batch = Batch.from_data_list(data_list, skip_validation=True)
+        batch_iter = self._generate_batches()
+        window: deque[list[int]] = deque()
 
-            # Prefetch next batch if available
-            next_prefetch_idx = prefetched_up_to
-            if next_prefetch_idx < len(all_batches):
-                for sample_idx in all_batches[next_prefetch_idx]:
-                    stream = self._streams[stream_idx % self.num_streams]
-                    self.dataset.prefetch(sample_idx, stream=stream)
-                    stream_idx += 1
-                prefetched_up_to += 1
+        try:
+            for _ in range(self.prefetch_factor):
+                batch_indices = next(batch_iter, None)
+                if batch_indices is None:
+                    break
+                window.append(batch_indices)
+                _prefetch_batch(batch_indices)
 
-            yield batch
+            while window:
+                batch_indices = window.popleft()
+                samples = [self.dataset[idx] for idx in batch_indices]
+                data_list = [atomic_data for atomic_data, _ in samples]
+                yield Batch.from_data_list(data_list, skip_validation=True)
 
-        # Clean up any remaining prefetch state
-        self.dataset.cancel_prefetch()
+                next_batch = next(batch_iter, None)
+                if next_batch is not None:
+                    window.append(next_batch)
+                    _prefetch_batch(next_batch)
+        finally:
+            self.dataset.cancel_prefetch()
 
     def set_epoch(self, epoch: int) -> None:
         """Set the epoch for the sampler (used in distributed training).

--- a/test/data/test_zarr_datapipe.py
+++ b/test/data/test_zarr_datapipe.py
@@ -1685,6 +1685,43 @@ class TestDataLoaderPrefetch:
             total_samples = sum(batch.num_graphs for batch in batches)
             assert total_samples == num_samples
 
+    def test_prefetch_consumes_batches_lazily(
+        self, tmp_path: Path, gpu_device: str
+    ) -> None:
+        """Generator is not fully materialised; only the fill window is consumed."""
+        data_list = list(_data_generator(20))
+        writer = AtomicDataZarrWriter(tmp_path / "test.zarr")
+        writer.write(data_list)
+
+        prefetch_factor = 2
+        batch_size = 2
+
+        with AtomicDataZarrReader(tmp_path / "test.zarr") as reader:
+            dataset = Dataset(reader, device=gpu_device)
+            loader = DataLoader(
+                dataset,
+                batch_size=batch_size,
+                prefetch_factor=prefetch_factor,
+                use_streams=True,
+            )
+
+            batches_pulled = 0
+            orig_generate = loader._generate_batches
+
+            def _counting_generate():
+                nonlocal batches_pulled
+                for batch_indices in orig_generate():
+                    batches_pulled += 1
+                    yield batch_indices
+
+            loader._generate_batches = _counting_generate
+
+            gen = loader._iter_prefetch()
+            next(gen)
+
+            assert batches_pulled <= prefetch_factor
+            gen.close()
+
 
 class TestZarrStoreBackends:
     """Verify that zarr internal I/O operations fire correctly through nvalchemi.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

`DataLoader._iter_prefetch()` calls `list(self._generate_batches())` on line 215, converting the entire epoch's batch plan into an in-memory list before yielding a single batch. For a dataset with N samples and batch_size B this allocates N/B lists of B integers upfront, blocks the start of iteration, and prevents lazy evaluation. The method only ever needs `prefetch_factor` batches of lookahead, so a bounded sliding window suffices.

Additionally, `cancel_prefetch()` was only called after full exhaustion. If the caller breaks early or an exception is raised, prefetch state is never cleaned up.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Replace `all_batches = list(self._generate_batches())` with a lazy `collections.deque` sliding window that holds at most `prefetch_factor` batch index lists, pulling from the generator on demand via `next()`.
- Extract a `_prefetch_batch()` local helper to avoid duplicating the stream-round-robin prefetch logic in the fill and refill paths.
- Wrap the generator body in `try/finally` so `self.dataset.cancel_prefetch()` runs on normal exhaustion, early break, and exceptions.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New test in `test/data/test_zarr_datapipe.py::TestDataLoaderPrefetch`:

- `test_prefetch_consumes_batches_lazily` — instruments `_generate_batches` with a side-effect counter, consumes only the first yielded batch, and asserts the generator was advanced at most `prefetch_factor` times (the initial fill window), not the full epoch.

All 16 existing `TestDataLoaderPrefetch` tests pass unchanged.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

External behavior is identical: same batch order, same prefetch semantics, same stream round-robin assignment. The only observable difference is that the generator is consumed lazily and cleanup is guaranteed.
