### PR TITLE
fix(examples): correct log filename and device mismatch in geometry optimization

### DIFF
--- a/examples/basic/02_geometry_optimization.py
+++ b/examples/basic/02_geometry_optimization.py
@@ -191,7 +191,9 @@ with LoggingHook(
     fire_opt.register_hook(log_hook)
     batch_opt = fire_opt.run(batch_opt)
 
-print(f"\nCompleted {fire_opt.step_count} FIRE steps. Log: fire_opt.csv")
+print(
+    f"\nCompleted {fire_opt.step_count} FIRE steps. Log: 02_geometry_optimization_fire_log.csv"
+)
 
 # %%
 # Final energies per system
@@ -203,7 +205,7 @@ print(f"\nCompleted {fire_opt.step_count} FIRE steps. Log: fire_opt.csv")
 
 final_energies = batch_opt.energies.squeeze(-1).cpu().tolist()
 force_norms = batch_opt.forces.norm(dim=-1)
-fmax_final = torch.zeros(batch_opt.num_graphs)
+fmax_final = torch.zeros(batch_opt.num_graphs, device=batch_opt.device)
 fmax_final.scatter_reduce_(
     0, batch_opt.batch, force_norms, reduce="amax", include_self=True
 )


### PR DESCRIPTION
## Summary
- **Log filename**: `print()` on line 194 referenced `fire_opt.csv` but the `LoggingHook` writes to `02_geometry_optimization_fire_log.csv`
- **Device mismatch**: `torch.zeros(batch_opt.num_graphs)` always allocates on CPU; when the batch is on CUDA the subsequent `scatter_reduce_` crashes with `RuntimeError: Expected all tensors to be on the same device`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan
- [x] Verified on GPU: `scatter_reduce_` crashed **before** fix, succeeds **after**
- [x] Full example runs successfully on both CPU and CUDA
- [x] `ruff check` and `ruff format` clean