### PR TITLE
Prevent CI coverage from failing prematurely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
         run: |
           if [ -f .coverage.baseline ]; then
             echo "Baseline coverage found, will combine with PR delta"
-            cp .coverage.baseline .coverage.main
+            cp .coverage.baseline coverage_main.dat
           else
             echo "No baseline coverage found, PR will generate full coverage"
           fi
@@ -273,12 +273,12 @@ jobs:
           # This selects tests based on cached db but doesn't update it
           # Keep fail-under disabled here; threshold is enforced in shared
           # coverage reporting after canonicalization.
+          export COVERAGE_FILE=coverage_pr.dat
           uv run pytest --cov=nvalchemi --cov-report= --cov-fail-under=0 --testmon --testmon-nocollect test/
-          if [ ! -f .coverage ]; then
+          if [ ! -f coverage_pr.dat ]; then
             echo "No PR coverage produced from selective run; falling back to full test suite"
             uv run pytest --cov=nvalchemi --cov-report= --cov-fail-under=0 test/
           fi
-          mv .coverage .coverage.pr
 
       # ========================================================================
       # COVERAGE REPORTING (shared for full runs and PR runs)
@@ -296,15 +296,15 @@ jobs:
             fi
           else
             # Combine baseline (if exists) with PR coverage, then canonicalize to .coverage
-            if [ -f .coverage.main ] && [ -f .coverage.pr ]; then
+            if [ -f coverage_main.dat ] && [ -f coverage_pr.dat ]; then
               echo "Combining baseline and PR coverage"
-              uv run coverage combine .coverage.main .coverage.pr
-            elif [ -f .coverage.pr ]; then
+              uv run coverage combine --data-file=.coverage coverage_main.dat coverage_pr.dat
+            elif [ -f coverage_pr.dat ]; then
               echo "Using PR coverage only (no baseline)"
-              mv .coverage.pr .coverage
-            elif [ -f .coverage.main ]; then
+              mv coverage_pr.dat .coverage
+            elif [ -f coverage_main.dat ]; then
               echo "Using baseline coverage only"
-              mv .coverage.main .coverage
+              mv coverage_main.dat .coverage
             else
               echo "Warning: No coverage data available"
               exit 1


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR changes the "Run selective tests (PR)" stage of the CI workflow to not fail on coverage when running the reduced set of unit tests.

This stage instead produces a more compact set of coverage information, which is then in the later reporting step combined with the baseline coverage information. Failing due to insufficient coverage should then only happen (as originally intended) at the "Check coverage threshold (PR only)" stage.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

PR #46 was failing due to this issue

## Changes Made

<!-- List the key changes made in this PR -->

- Made reduced coverage test run not fail on lack of coverage

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
