### PR TITLE
fix(dynamics): mask stale neighbor matrix entries before COO conversion

### DIFF
--- a/nvalchemi/dynamics/hooks/neighbor_list.py
+++ b/nvalchemi/dynamics/hooks/neighbor_list.py
@@ -446,8 +446,8 @@ class NeighborListHook:
         fill_value = batch.num_nodes
         stale = self._col_range.unsqueeze(0) >= self._num_neighbors.unsqueeze(1)
         self._neighbor_matrix[stale] = fill_value
-        if self._neighbor_shifts is not None:
-            self._neighbor_shifts[stale] = 0
+        if self._neighbor_matrix_shifts is not None:
+            self._neighbor_matrix_shifts[stale] = 0
 
         neighbor_list_coo = get_neighbor_list_from_neighbor_matrix(
             neighbor_matrix=self._neighbor_matrix,

--- a/nvalchemi/dynamics/hooks/neighbor_list.py
+++ b/nvalchemi/dynamics/hooks/neighbor_list.py
@@ -163,6 +163,7 @@ class NeighborListHook:
 
         # Neighbor Matrix state: populated after the first build.
         self._neighbor_matrix: torch.Tensor | None = None
+        self._col_range: torch.Tensor | None = None
         self._num_neighbors: torch.Tensor | None = None
         self._neighbor_shifts: torch.Tensor | None = None
 

--- a/nvalchemi/dynamics/hooks/neighbor_list.py
+++ b/nvalchemi/dynamics/hooks/neighbor_list.py
@@ -359,6 +359,9 @@ class NeighborListHook:
         self._neighbor_matrix = torch.full(
             (N, self.config.max_neighbors), N, dtype=torch.int32, device=device
         )
+        self._col_range = torch.arange(
+            self.config.max_neighbors, device=device, dtype=torch.int32
+        )
         self._num_neighbors = torch.zeros(N, dtype=torch.int32, device=device)
         if pbc is not None:
             self._neighbor_shifts = torch.zeros(
@@ -433,13 +436,25 @@ class NeighborListHook:
         break.  Called only when ``format=COO``.
         """
 
+        # Mask stale entries in the neighbor matrix before COO conversion.
+        # The upstream kernel only writes slots 0..num_neighbors[i]-1 on
+        # rebuild; when neighbor counts shrink, slots num_neighbors[i]..old
+        # retain stale indices from the previous build.  Overwriting them
+        # with fill_value in-place is safe because the next rebuild will
+        # rewrite valid slots.
+        fill_value = batch.num_nodes
+        stale = self._col_range.unsqueeze(0) >= self._num_neighbors.unsqueeze(1)
+        self._neighbor_matrix[stale] = fill_value
+        if self._neighbor_shifts is not None:
+            self._neighbor_shifts[stale] = 0
+
         neighbor_list_coo = get_neighbor_list_from_neighbor_matrix(
             neighbor_matrix=self._neighbor_matrix,
             num_neighbors=self._num_neighbors,
             neighbor_shift_matrix=self._neighbor_shifts
             if self._neighbor_shifts is not None
             else None,
-            fill_value=batch.num_nodes,
+            fill_value=fill_value,
         )
         edge_index = neighbor_list_coo[0].T.contiguous()  # (E, 2) int32
         if len(neighbor_list_coo) > 2:

--- a/test/dynamics/test_neighbor_list_hook.py
+++ b/test/dynamics/test_neighbor_list_hook.py
@@ -897,3 +897,68 @@ class TestCompilerDisable:
             N, B, batch.positions.dtype, batch.device, None, None
         )
         assert hook._buf_positions is not None
+
+
+# ===========================================================================
+# TestStaleCOOEntries — regression test for stale neighbor matrix entries
+# ===========================================================================
+
+
+class TestStaleCOOEntries:
+    """Regression tests: shrinking neighbor counts must not leave stale COO edges.
+
+    When a Verlet skin rebuild finds fewer neighbors for an atom than the
+    previous build, slots beyond ``num_neighbors[i]`` in the neighbor matrix
+    retain stale indices.  The fix in ``_update_edges_group`` masks these
+    before the COO conversion.
+    """
+
+    @staticmethod
+    def _edges_as_set(batch: Batch) -> set[tuple[int, int]]:
+        """Return the COO edge_index as a set of (src, dst) pairs."""
+        return {tuple(row) for row in batch.edge_index.cpu().tolist()}
+
+    @staticmethod
+    def _edge_counts(batch: Batch) -> torch.Tensor:
+        """Per-atom edge count derived from the COO edge_index."""
+        ei = batch.edge_index.cpu()
+        src = ei[:, 0]
+        return torch.bincount(src, minlength=batch.num_nodes)
+
+    def _run_shrink_scenario(self, device: str) -> None:
+        """Build hook+batch, run initial rebuild, move atom out of range, rebuild."""
+        self.hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None), skin=1.0
+        )
+        self.batch = _line_batch(device)
+        # Step 1: full rebuild — atoms 0 and 1 are neighbors (dist 1.5)
+        self.hook(_ctx(self.batch), _STAGE)
+        self.pairs_before = self._edges_as_set(self.batch)
+
+        # Move atom 1 far away from atom 0 (dist 4.0 > cutoff+skin=3.5),
+        # close to atom 2 (dist 1.0 < cutoff).
+        # Displacement of 2.5 A > skin/2 = 0.5 triggers a rebuild.
+        self.batch.positions[1, 0] = 4.0
+        self.hook(_ctx(self.batch), _STAGE)
+        self.pairs_after = self._edges_as_set(self.batch)
+
+    def test_shrinking_neighbors_no_stale_edges(self, device: str):
+        """Moving an atom out of cutoff+skin must remove its stale edges."""
+        self._run_shrink_scenario(device)
+        assert (0, 1) in self.pairs_before or (1, 0) in self.pairs_before
+        # Atom 0 should have NO neighbors now (nearest is 4.0 A away)
+        assert (0, 1) not in self.pairs_after, "stale edge 0->1 not removed"
+        assert (1, 0) not in self.pairs_after, "stale edge 1->0 not removed"
+        # Atoms 1 and 2 should be neighbors (dist 1.0)
+        assert (1, 2) in self.pairs_after or (2, 1) in self.pairs_after
+
+    def test_shrinking_neighbors_edge_count_matches_num_neighbors(self, device: str):
+        """After rebuild, per-atom COO edge counts must equal num_neighbors."""
+        self._run_shrink_scenario(device)
+        coo_counts = self._edge_counts(self.batch)
+        # In COO mode num_neighbors lives on the hook's internal buffer,
+        # not on the batch object.
+        nn = self.hook._num_neighbors.cpu()
+        assert torch.equal(coo_counts, nn.to(coo_counts.dtype)), (
+            f"COO edge counts {coo_counts.tolist()} != num_neighbors {nn.tolist()}"
+        )

--- a/test/dynamics/test_neighbor_list_hook.py
+++ b/test/dynamics/test_neighbor_list_hook.py
@@ -917,13 +917,13 @@ class TestStaleCOOEntries:
 
     @staticmethod
     def _edges_as_set(batch: Batch) -> set[tuple[int, int]]:
-        """Return the COO edge_index as a set of (src, dst) pairs."""
-        return {tuple(row) for row in batch.edge_index.cpu().tolist()}
+        """Return the COO neighbor_list as a set of (src, dst) pairs."""
+        return {tuple(row) for row in batch.neighbor_list.cpu().tolist()}
 
     @staticmethod
     def _edge_counts(batch: Batch) -> torch.Tensor:
-        """Per-atom edge count derived from the COO edge_index."""
-        ei = batch.edge_index.cpu()
+        """Per-atom edge count derived from the COO neighbor_list."""
+        ei = batch.neighbor_list.cpu()
         src = ei[:, 0]
         return torch.bincount(src, minlength=batch.num_nodes)
 


### PR DESCRIPTION
## Summary

- Fix stale edges in COO neighbor list output when neighbor counts shrink between Verlet skin rebuilds
- Cache `_col_range` tensor to avoid per-step allocation in `_update_edges_group`
- Add `TestStaleCOOEntries` regression test covering the shrinking-neighbors scenario

## Problem

When `NeighborListHook` uses a Verlet skin for selective rebuilds, the upstream warp kernel (`_update_neighbor_matrix`) only writes slots `0..num_neighbors[i]-1` in the neighbor matrix. If an atom's neighbor count **decreases** between rebuilds, the old entries in `neighbor_matrix[i, new_count:old_count]` are never overwritten with `fill_value` — they retain stale atom indices from the previous build.

`get_neighbor_list_from_neighbor_matrix` uses `neighbor_matrix != fill_value` to identify valid entries, so these stale indices pass the mask and appear as phantom edges in the COO output. This causes energy/force mismatches during MD compared to ASE + model.

## Fix

In `_update_edges_group`, before calling `get_neighbor_list_from_neighbor_matrix`, create a boolean mask `col_range >= num_neighbors[i]` and overwrite stale slots with `fill_value` in-place. The `col_range` tensor is cached in `_alloc_output_tensors` alongside the neighbor matrix buffers.

The in-place overwrite is safe because the next rebuild will rewrite all valid slots via `atomic_add`.

## Test

`TestStaleCOOEntries` sets up a 3-atom line system, runs an initial rebuild, then moves an atom far enough to trigger a Verlet skin rebuild with fewer neighbors. It verifies:
1. No stale edges remain in the COO `edge_index`
2. Per-atom COO edge counts match the internal `num_neighbors` buffer