### PR TITLE
feat(data): default atomic_numbers to int32 in factory methods

### DIFF
--- a/nvalchemi/data/atomic_data.py
+++ b/nvalchemi/data/atomic_data.py
@@ -760,7 +760,7 @@ class AtomicData(BaseModel, DataMixin):
 
         # Get base components from ase.Atoms object
         atomic_numbers = torch.as_tensor(
-            atoms.arrays["numbers"], device=device, dtype=torch.long
+            atoms.arrays["numbers"], device=device, dtype=torch.int32
         )
         positions = torch.as_tensor(
             atoms.arrays["positions"], device=device, dtype=dtype
@@ -967,7 +967,7 @@ class AtomicData(BaseModel, DataMixin):
             device = torch.device(device)
 
         atomic_numbers = torch.as_tensor(
-            structure.atomic_numbers, device=device, dtype=torch.long
+            structure.atomic_numbers, device=device, dtype=torch.int32
         )
         positions = torch.as_tensor(structure.cart_coords, device=device, dtype=dtype)
 

--- a/test/data/test_atomic_data.py
+++ b/test/data/test_atomic_data.py
@@ -25,6 +25,7 @@ import numpy as np
 import pytest
 import torch
 from ase import Atoms
+from pydantic import ValidationError
 
 from nvalchemi import _typing as t
 from nvalchemi.data.atomic_data import (
@@ -92,6 +93,14 @@ class TestAtomicDataConstruction:
         )
         assert data.atomic_numbers.dtype == int_dtype
         assert data.neighbor_list.dtype == int_dtype
+
+    def test_float_atomic_numbers_rejected(self):
+        """Pydantic validates atomic_numbers against the Integer type alias."""
+        with pytest.raises(ValidationError):
+            AtomicData(
+                positions=torch.randn(2, 3),
+                atomic_numbers=torch.tensor([1.0, 6.0], dtype=torch.float32),
+            )
 
     def test_optional_node_fields(self):
         data = AtomicData(
@@ -607,6 +616,12 @@ class TestFromAtoms:
         assert data.dipole.shape == (1, 3)
         assert data.charges.shape == (3, 1)
 
+    def test_atomic_numbers_default_int32(self):
+        """from_atoms produces int32 atomic_numbers by default."""
+        atoms = Atoms(numbers=[8, 1, 1], positions=[[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+        data = AtomicData.from_atoms(atoms)
+        assert data.atomic_numbers.dtype == torch.int32
+
 
 # -----------------------------------------------------------------------------
 # dtype cast warning
@@ -900,3 +915,11 @@ class TestFromStructure:
         assert torch.allclose(
             data_struct.atomic_masses, data_atoms.atomic_masses, atol=1e-2
         )
+
+    def test_atomic_numbers_default_int32(self):
+        """from_structure produces int32 atomic_numbers by default."""
+        from pymatgen.core import Lattice, Structure
+
+        struct = Structure(Lattice.cubic(3.6), 4 * ["Cu"], self._cu_fcc_coords)
+        data = AtomicData.from_structure(struct)
+        assert data.atomic_numbers.dtype == torch.int32


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Change the default integer dtype for `atomic_numbers` from `torch.long` (int64) to `torch.int32` in `AtomicData.from_atoms()` and `AtomicData.from_structure()`. The `AtomicNumbers` type alias already uses generic `jaxtyping.Integer` — this change makes the factory methods consistent by not forcing int64. Users who need a different dtype can recast afterwards.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Changed `dtype=torch.long` to `dtype=torch.int32` in `from_atoms` for the `atomic_numbers` tensor
- Changed `dtype=torch.long` to `dtype=torch.int32` in `from_structure` for the `atomic_numbers` tensor
- Added `test_atomic_numbers_default_int32` tests for both `from_atoms` and `from_structure`
- Added `test_float_atomic_numbers_rejected` to verify Pydantic + jaxtyping rejects float dtypes

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

80 tests pass, 0 failures.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

- Downstream model wrappers (MACE calls `.long()`, DFTD3 calls `.to(torch.int32)`) already cast `atomic_numbers` to their needed dtype, so this is safe.
- Direct construction `AtomicData(atomic_numbers=tensor)` already accepted any integer dtype via the `Integer[torch.Tensor, "V"]` type alias — this just aligns the factory methods.
- int32 covers element numbers 1-118 with ample headroom.