### PR TITLE
refactor(examples): rename attributes in all example scripts

### DIFF
--- a/examples/advanced/01_biased_potential.py
+++ b/examples/advanced/01_biased_potential.py
@@ -32,7 +32,7 @@ windowed histograms with WHAM or MBAR.
 
 Key concepts demonstrated
 -------------------------
-* Implementing a ``bias_fn(batch) -> (energies, forces)`` closure.
+* Implementing a ``bias_fn(batch) -> (energy, forces)`` closure.
 * Registering :class:`~nvalchemi.dynamics.hooks.BiasedPotentialHook` on
   :class:`~nvalchemi.dynamics.NVTLangevin`.
 * Comparing COM drift in biased vs. unbiased runs.
@@ -109,7 +109,7 @@ def _make_argon_cluster(
         positions=positions,
         atomic_numbers=torch.full((n,), 18, dtype=torch.long),  # Argon Z=18
         forces=torch.zeros(n, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=velocities,
     )
 
@@ -118,7 +118,7 @@ def _make_argon_cluster(
 # Defining a harmonic COM restraint
 # ----------------------------------
 # The bias function receives a :class:`~nvalchemi.data.Batch` and must return
-# ``(bias_energies, bias_forces)`` with shapes ``[B, 1]`` and ``[N, 3]``
+# ``(bias_energy, bias_forces)`` with shapes ``[B, 1]`` and ``[N, 3]``
 # respectively.
 #
 # For a single-system batch (B=1) the center-of-mass restraint is:
@@ -155,7 +155,7 @@ def harmonic_com_bias(
 
     Returns
     -------
-    bias_energies : torch.Tensor
+    bias_energy : torch.Tensor
         Shape ``[B, 1]``.
     bias_forces : torch.Tensor
         Shape ``[N, 3]``.
@@ -163,7 +163,7 @@ def harmonic_com_bias(
     B = batch.num_graphs
     device = batch.positions.device
     positions = batch.positions  # [N, 3]
-    batch_idx = batch.batch  # [N] — graph index for each atom
+    batch_idx = batch.batch_idx  # [N] — graph index for each atom
 
     # Compute atoms per graph for normalisation.
     atoms_per_graph = batch.num_nodes_per_graph.float()  # [B]
@@ -178,7 +178,7 @@ def harmonic_com_bias(
     delta = com - tgt.unsqueeze(0)  # [B, 3]
 
     # Potential energy per graph: 0.5 * k * ||delta||^2
-    bias_energies = 0.5 * k_spring * (delta**2).sum(dim=-1, keepdim=True)  # [B, 1]
+    bias_energy = 0.5 * k_spring * (delta**2).sum(dim=-1, keepdim=True)  # [B, 1]
 
     # Force on atom i = -k * delta[graph_of_i] / N_graph
     # (uniform distribution of COM force to all atoms in the graph)
@@ -186,7 +186,7 @@ def harmonic_com_bias(
     n_per_atom = atoms_per_graph[batch_idx].unsqueeze(-1)  # [N, 1]
     bias_forces = -k_spring * delta_per_atom / n_per_atom  # [N, 3]
 
-    return bias_energies, bias_forces
+    return bias_energy, bias_forces
 
 
 # %%
@@ -210,6 +210,7 @@ k_spring = 5.0  # eV/Å²
 
 # Build the bias function as a closure over target_com and k_spring.
 def my_bias_fn(batch: Batch) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply harmonic COM bias with captured target and spring constant."""
     return harmonic_com_bias(batch, target_com=target_com, k_spring=k_spring)
 
 

--- a/examples/advanced/02_custom_hook.py
+++ b/examples/advanced/02_custom_hook.py
@@ -166,7 +166,7 @@ class RadialDistributionHook:
         """Accumulate pair distances into the histogram."""
         batch = ctx.batch
         # Process each graph (system) in the batch independently.
-        ptr = batch.ptr  # [B+1] — atom start/end indices per graph
+        ptr = batch.batch_ptr  # [B+1] — atom start/end indices per graph
         # NOTE: .cpu() forces a GPU→CPU synchronization here.  For a
         # production RDF hook on large systems, keep the histogram on GPU
         # (torch.histc works on CUDA) and only transfer the final g(r) result
@@ -300,7 +300,7 @@ def _make_cluster(n_per_side: int = 2, seed: int = 0) -> AtomicData:
         positions=positions,
         atomic_numbers=torch.full((n,), 18, dtype=torch.long),
         forces=torch.zeros(n, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=0.1 * torch.randn(n, 3),
     )
 

--- a/examples/advanced/03_custom_convergence.py
+++ b/examples/advanced/03_custom_convergence.py
@@ -82,7 +82,7 @@ def _make_cluster(
         positions=positions,
         atomic_numbers=torch.full((n,), 18, dtype=torch.long),
         forces=torch.zeros(n, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=torch.zeros(n, 3),
     )
 
@@ -124,7 +124,7 @@ dual_hook = ConvergenceHook(
         # Energy criterion: per-system energy ≤ -0.1 eV (cluster is bound).
         # This guards against spurious convergence at high energy.
         {
-            "key": "energies",
+            "key": "energy",
             "threshold": -0.1,
         },
     ]
@@ -141,44 +141,44 @@ print("Dual hook:", dual_hook)
 #
 # Here we implement a **relative energy-change** criterion: a system is
 # converged when :math:`|\Delta E / E| < \varepsilon` between consecutive steps.  This requires
-# state — we track the previous energies in a closure.
+# state — we track the previous energy in a closure.
 #
-# The ``custom_op`` callable is called with the full ``batch.energies``
+# The ``custom_op`` callable is called with the full ``batch.energy``
 # tensor of shape ``[B, 1]``.
 
-prev_energies: dict[str, torch.Tensor] = {}  # mutable state accessible via closure
+prev_energy: dict[str, torch.Tensor] = {}  # mutable state accessible via closure
 
 
-def energy_change_criterion(energies: torch.Tensor) -> torch.Tensor:
+def energy_change_criterion(energy: torch.Tensor) -> torch.Tensor:
     """Return True for systems whose relative energy change is < 1e-4.
 
     Parameters
     ----------
-    energies : torch.Tensor
-        Shape ``[B, 1]`` — per-system total energies in eV.
+    energy : torch.Tensor
+        Shape ``[B, 1]`` — per-system total energy in eV.
 
     Returns
     -------
     torch.Tensor
         Shape ``[B]`` boolean — True where |ΔE/E| < 1e-4.
     """
-    e = energies.squeeze(-1)  # [B]
-    if "last" not in prev_energies:
+    e = energy.squeeze(-1)  # [B]
+    if "last" not in prev_energy:
         # First call: cannot compute delta, treat all as unconverged.
-        prev_energies["last"] = e.detach().clone()
+        prev_energy["last"] = e.detach().clone()
         return torch.zeros(e.shape[0], dtype=torch.bool, device=e.device)
 
-    delta = (e - prev_energies["last"]).abs()
-    denom = prev_energies["last"].abs().clamp(min=1e-12)
+    delta = (e - prev_energy["last"]).abs()
+    denom = prev_energy["last"].abs().clamp(min=1e-12)
     rel_change = delta / denom
-    prev_energies["last"] = e.detach().clone()
+    prev_energy["last"] = e.detach().clone()
     return rel_change < 1e-4
 
 
 custom_hook = ConvergenceHook(
     criteria=[
         {
-            "key": "energies",
+            "key": "energy",
             "threshold": 0.0,  # threshold is ignored when custom_op is set
             "custom_op": energy_change_criterion,
         }
@@ -199,7 +199,7 @@ print("Custom hook:", custom_hook)
 print("\n=== FIRE with dual force+energy-change convergence ===")
 
 # Reset the shared closure state for a clean run.
-prev_energies.clear()
+prev_energy.clear()
 
 data_list = [
     _make_cluster(2, spacing_factor=1.05, seed=0),
@@ -217,7 +217,7 @@ dual_custom_hook = ConvergenceHook(
             "reduce_dims": -1,
         },
         {
-            "key": "energies",
+            "key": "energy",
             "threshold": 0.0,
             "custom_op": energy_change_criterion,
         },
@@ -242,13 +242,17 @@ class _LogHook:
     def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
         batch = ctx.batch
         step = ctx.step_count + 1
-        energies = batch.energies.squeeze(-1)
+        energy = batch.energy.squeeze(-1)
         fmax_per_sys = torch.zeros(batch.num_graphs, device=batch.device)
         fmax_per_sys.scatter_reduce_(
-            0, batch.batch, batch.forces.norm(dim=-1), reduce="amax", include_self=True
+            0,
+            batch.batch_idx,
+            batch.forces.norm(dim=-1),
+            reduce="amax",
+            include_self=True,
         )
         rows = [
-            f"  sys{i}: E={energies[i].item():+.5f} eV  fmax={fmax_per_sys[i].item():.5f} eV/Å"
+            f"  sys{i}: E={energy[i].item():+.5f} eV  fmax={fmax_per_sys[i].item():.5f} eV/Å"
             for i in range(batch.num_graphs)
         ]
         print(f"[step {step:4d}]\n" + "\n".join(rows))
@@ -258,6 +262,6 @@ fire.register_hook(_LogHook())
 batch = fire.run(batch)
 print(f"\nCompleted {fire.step_count} FIRE steps (dual convergence).")
 
-final_energies = batch.energies.squeeze(-1)
+final_energy = batch.energy.squeeze(-1)
 for i in range(batch.num_graphs):
-    print(f"  sys{i}: final E = {final_energies[i].item():+.6f} eV")
+    print(f"  sys{i}: final E = {final_energy[i].item():+.6f} eV")

--- a/examples/advanced/04_mace_nvt.py
+++ b/examples/advanced/04_mace_nvt.py
@@ -155,7 +155,7 @@ def _make_argon_cluster(n_per_side: int = 2, seed: int = 0) -> AtomicData:
         positions=positions,
         atomic_numbers=torch.full((n,), 18, dtype=torch.long),  # Ar Z=18
         forces=torch.zeros(n, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=_v_std * torch.randn(n, 3),
     )
 
@@ -196,7 +196,7 @@ def _make_water_cluster(n_molecules: int = 3, seed: int = 0) -> AtomicData:
         positions=positions.float(),
         atomic_numbers=torch.tensor(atomic_numbers_list, dtype=torch.long),
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=(_v_stds * torch.randn(n_atoms, 3)).float(),
     )
 
@@ -245,14 +245,14 @@ print(f"Run complete: {nvt.step_count} steps")
 ke_per_graph = kinetic_energy_per_graph(
     velocities=batch.velocities,
     masses=batch.atomic_masses,
-    batch_idx=batch.batch,
+    batch_idx=batch.batch_idx,
     num_graphs=batch.num_graphs,
 )  # [B, 1]
 
 n_atoms_per_graph = batch.num_nodes_per_graph.float()  # [B]
 T_inst = (2.0 * ke_per_graph.squeeze(-1)) / (3.0 * n_atoms_per_graph * KB_EV)
 
-mean_E = batch.energies.squeeze(-1).mean().item()
+mean_E = batch.energy.squeeze(-1).mean().item()
 mean_T = T_inst.mean().item()
 
 print("\nFinal observables (model-agnostic):")

--- a/examples/advanced/05_custom_integrator.py
+++ b/examples/advanced/05_custom_integrator.py
@@ -196,7 +196,7 @@ class VelocityRescalingThermostat(BaseDynamics):
         ke = kinetic_energy_per_graph(
             velocities=batch.velocities,
             masses=batch.atomic_masses,
-            batch_idx=batch.batch,
+            batch_idx=batch.batch_idx,
             num_graphs=batch.num_graphs,
         ).squeeze(-1)  # [B]
 
@@ -206,7 +206,7 @@ class VelocityRescalingThermostat(BaseDynamics):
 
         # Rescaling factor λ[B] broadcast to per-atom [N,1].
         lam = (self.temperature / T_inst).sqrt()  # [B]
-        lam_per_atom = lam[batch.batch].unsqueeze(-1)  # [N, 1]
+        lam_per_atom = lam[batch.batch_idx].unsqueeze(-1)  # [N, 1]
         batch.velocities.mul_(lam_per_atom)
 
 
@@ -241,7 +241,7 @@ def _make_cluster(n_per_side: int = 2, seed: int = 0) -> AtomicData:
         positions=positions,
         atomic_numbers=torch.full((n,), 18, dtype=torch.long),
         forces=torch.zeros(n, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=_v_std * torch.randn(n, 3),
     )
 
@@ -262,7 +262,7 @@ class _TempLogger:
     def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
         batch = ctx.batch
         ke = kinetic_energy_per_graph(
-            batch.velocities, batch.atomic_masses, batch.batch, batch.num_graphs
+            batch.velocities, batch.atomic_masses, batch.batch_idx, batch.num_graphs
         ).squeeze(-1)
         n_atoms = batch.num_nodes_per_graph.float()
         T_inst = (2.0 * ke) / (3.0 * n_atoms * KB_EV)

--- a/examples/advanced/06_ewald_electrostatics.py
+++ b/examples/advanced/06_ewald_electrostatics.py
@@ -49,7 +49,7 @@ This example:
 
 Key concepts demonstrated
 --------------------------
-* Constructing an :class:`~nvalchemi.data.AtomicData` with ``node_charges``
+* Constructing an :class:`~nvalchemi.data.AtomicData` with ``charges``
   (shape ``[N, 1]``, elementary charge units).
 * Instantiating :class:`~nvalchemi.models.ewald.EwaldModelWrapper` with a
   real-space cutoff and auto-estimated Ewald parameters.
@@ -89,7 +89,7 @@ model.model_config.compute_forces = True
 # We build a 2×2×2 conventional cubic supercell (64 atoms).
 #
 # **Important**: Na and Cl positions are collected separately, then
-# concatenated, so that ``atomic_numbers`` and ``node_charges`` align
+# concatenated, so that ``atomic_numbers`` and ``charges`` align
 # correctly with ``positions``.  Interleaving the two species within the
 # same image ordering would silently mis-assign charges.
 #
@@ -154,9 +154,9 @@ cell = torch.eye(3).unsqueeze(0) * cell_size  # (1, 3, 3)
 data = AtomicData(
     positions=positions,
     atomic_numbers=atomic_numbers,
-    node_charges=charges,  # (N, 1) — required shape for AtomicData
+    charges=charges,  # (N, 1) — required shape for AtomicData
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=cell,
     pbc=torch.tensor([[True, True, True]]),
 )
@@ -188,7 +188,7 @@ nl_hook(
 
 result = model(batch)
 
-energy_eV = result["energies"].item()
+energy_eV = result["energy"].item()
 forces = result["forces"]  # (N, 3) eV/Å
 
 print(f"\nEwald energy: {energy_eV:.4f} eV")
@@ -246,9 +246,9 @@ perturbed_positions = positions + 0.05 * torch.randn_like(positions)
 data_pert = AtomicData(
     positions=perturbed_positions,
     atomic_numbers=atomic_numbers,
-    node_charges=charges,
+    charges=charges,
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=cell,
     pbc=torch.tensor([[True, True, True]]),
 )
@@ -266,7 +266,7 @@ nl_hook(ctx_pert, DynamicsStage.BEFORE_COMPUTE)
 result_pert = model(batch_pert)
 
 print("\nPerturbed geometry:")
-print(f"  Ewald energy:         {result_pert['energies'].item():.4f} eV")
+print(f"  Ewald energy:         {result_pert['energy'].item():.4f} eV")
 print(
     f"  Max force magnitude:  {result_pert['forces'].norm(dim=-1).max().item():.4f} eV/Å"
 )

--- a/examples/advanced/07_composable_model_composition.py
+++ b/examples/advanced/07_composable_model_composition.py
@@ -31,17 +31,17 @@ nvalchemi lets you combine any two
     combined = lj_model + ewald_model
 
 The result is an :class:`~nvalchemi.models.composable.ComposableModelWrapper` that
-calls each sub-model in sequence and **sums** their energies, forces, and
-stresses element-wise.  A single shared
+calls each sub-model in sequence and **sums** their energy, forces, and
+stress element-wise.  A single shared
 :class:`~nvalchemi.models.base.ModelConfig` instance propagates flags like
-``compute_stresses`` to every sub-model automatically.
+``compute_stress`` to every sub-model automatically.
 
 This example:
 
 * Builds a simple charge-neutral ionic fluid (alternating +1/−1 particles
   on a cubic lattice, inspired by a primitive model electrolyte).
 * Combines a Lennard-Jones short-range model with an Ewald long-range model.
-* Shows that setting ``combined.model_config.compute_stresses = True``
+* Shows that setting ``combined.model_config.compute_stress = True``
   automatically activates stress computation in **both** sub-models.
 * Demonstrates :meth:`~nvalchemi.models.composable.ComposableModelWrapper.make_neighbor_hooks`
   which returns the single hook needed for the composite model (using the
@@ -110,7 +110,7 @@ ewald_model = EwaldModelWrapper(
 )
 
 # Combine with the + operator.  The result is an ComposableModelWrapper that
-# runs both sub-models and sums their energies/forces/stresses.
+# runs both sub-models and sums their energy/forces/stress.
 combined = lj_model + ewald_model
 
 print(f"Combined model type: {type(combined).__name__}")
@@ -129,9 +129,9 @@ print(f"Sub-models: {[type(m).__name__ for m in combined.models]}")
 # Or to enable stress computation for NPT (requires the batch to have stress
 # storage pre-allocated — standard NPT dynamics handles this automatically):
 #
-#     combined.model_config.compute_stresses = True
-#     assert lj_model.model_config.compute_stresses is True   # propagated
-#     assert ewald_model.model_config.compute_stresses is True
+#     combined.model_config.compute_stress = True
+#     assert lj_model.model_config.compute_stress is True   # propagated
+#     assert ewald_model.model_config.compute_stress is True
 
 # Demonstrate propagation using compute_forces (safe to toggle without a
 # pre-allocated stress buffer).
@@ -192,9 +192,9 @@ cell = torch.eye(3).unsqueeze(0) * box_size
 data = AtomicData(
     positions=positions,
     atomic_numbers=atomic_numbers,
-    node_charges=charges,  # (N, 1)
+    charges=charges,  # (N, 1)
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=cell,
     pbc=torch.tensor([[True, True, True]]),
 )
@@ -295,11 +295,11 @@ if os.getenv("NVALCHEMI_PLOT", "0") == "1" and rows:
         import matplotlib.pyplot as plt
 
         steps = [int(float(r["step"])) for r in rows]
-        energies = [float(r["energy"]) for r in rows]
+        energy = [float(r["energy"]) for r in rows]
         temps = [float(r["temperature"]) for r in rows]
 
         fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(7, 6), sharex=True)
-        ax1.plot(steps, energies, lw=2)
+        ax1.plot(steps, energy, lw=2)
         ax1.set_ylabel("LJ + Coulomb energy (eV)")
         ax1.set_title(
             f"Primitive electrolyte ({n_atoms} ions) — LJ + Ewald NVT at {T_INIT:.0f} K"

--- a/examples/basic/01_data_structures.py
+++ b/examples/basic/01_data_structures.py
@@ -35,12 +35,12 @@ positions = torch.randn(4, 3)
 atomic_numbers = torch.tensor([1, 6, 6, 1], dtype=torch.long)
 data = AtomicData(positions=positions, atomic_numbers=atomic_numbers)
 
-# With edges (e.g. bonds or neighbor list): provide ``edge_index`` shape ``[n_edges, 2]``.
-edge_index = torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]], dtype=torch.long)
+# With edges (e.g. bonds or neighbor list): provide ``neighbor_list`` shape ``[n_edges, 2]``.
+neighbor_list = torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]], dtype=torch.long)
 data_with_edges = AtomicData(
     positions=positions,
     atomic_numbers=atomic_numbers,
-    edge_index=edge_index,
+    neighbor_list=neighbor_list,
 )
 print(f"With edges: num_edges={data_with_edges.num_edges}")
 
@@ -48,11 +48,11 @@ print(f"With edges: num_edges={data_with_edges.num_edges}")
 data_with_system = AtomicData(
     positions=positions,
     atomic_numbers=atomic_numbers,
-    energies=torch.tensor([[0.5]]),
+    energy=torch.tensor([[0.5]]),
     cell=torch.eye(3).unsqueeze(0),
     pbc=torch.tensor([[True, True, False]]),
 )
-print(f"System energies shape: {data_with_system.energies.shape}")
+print(f"System energy shape: {data_with_system.energy.shape}")
 
 # %%
 # AtomicData — Properties
@@ -141,17 +141,17 @@ data_list = [
     AtomicData(
         positions=torch.randn(2, 3),
         atomic_numbers=torch.ones(2, dtype=torch.long),
-        energies=torch.tensor([[0.0]]),
+        energy=torch.tensor([[0.0]]),
     ),
     AtomicData(
         positions=torch.randn(3, 3),
         atomic_numbers=torch.ones(3, dtype=torch.long),
-        energies=torch.tensor([[0.0]]),
+        energy=torch.tensor([[0.0]]),
     ),
     AtomicData(
         positions=torch.randn(1, 3),
         atomic_numbers=torch.ones(1, dtype=torch.long),
-        energies=torch.tensor([[0.0]]),
+        energy=torch.tensor([[0.0]]),
     ),
 ]
 batch = Batch.from_data_list(data_list)
@@ -172,7 +172,7 @@ print(f"Batch num_graphs={batch.num_graphs}, num_nodes={batch.num_nodes}")
 print(f"num_graphs={batch.num_graphs}, batch_size={batch.batch_size}")
 print(f"num_nodes_list={batch.num_nodes_list}, num_edges_list={batch.num_edges_list}")
 print(
-    f"batch (graph index per node) shape: {batch.batch.shape}, ptr: {batch.ptr.tolist()}"
+    f"batch_idx (graph index per node) shape: {batch.batch_idx.shape}, batch_ptr: {batch.batch_ptr.tolist()}"
 )
 print(f"max_num_nodes={batch.max_num_nodes}")
 
@@ -229,12 +229,12 @@ batch.add_key(
 data_a = AtomicData(
     positions=torch.randn(2, 3),
     atomic_numbers=torch.ones(2, dtype=torch.long),
-    edge_index=torch.tensor([[0, 1]], dtype=torch.long),
+    neighbor_list=torch.tensor([[0, 1]], dtype=torch.long),
 )
 data_b = AtomicData(
     positions=torch.randn(3, 3),
     atomic_numbers=torch.ones(3, dtype=torch.long),
-    edge_index=torch.tensor([[0, 1], [1, 0]], dtype=torch.long),
+    neighbor_list=torch.tensor([[0, 1], [1, 0]], dtype=torch.long),
 )
 batch_with_edges = Batch.from_data_list([data_a, data_b])
 batch_with_edges.add_key(
@@ -280,7 +280,7 @@ def _tiny_graph(energy: float):
     return AtomicData(
         positions=torch.randn(2, 3),
         atomic_numbers=torch.ones(2, dtype=torch.long),
-        energies=torch.tensor([[energy]]),
+        energy=torch.tensor([[energy]]),
     )
 
 
@@ -302,7 +302,7 @@ print(
 
 src_batch.defrag(copied_mask=copied_mask)
 print(f"After defrag: src_batch has {src_batch.num_graphs} graph(s)")
-print(f"Remaining graph energy: {src_batch['energies']}")
+print(f"Remaining graph energy: {src_batch['energy']}")
 
 # %%
 # Batch — Device, clone, contiguous, pin_memory

--- a/examples/basic/02_geometry_optimization.py
+++ b/examples/basic/02_geometry_optimization.py
@@ -125,7 +125,7 @@ def _make_system(n_per_side: int, spacing: float = _R_MIN * 1.05) -> AtomicData:
         positions=positions,
         atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),  # Argon
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         velocities=torch.zeros(n_atoms, 3),
     )
 
@@ -158,7 +158,7 @@ def _make_system(n_per_side: int, spacing: float = _R_MIN * 1.05) -> AtomicData:
 
 print("=== FIRE Geometry Optimization ===")
 
-# Two identical lattice sizes; different spacings give different starting energies.
+# Two identical lattice sizes; different spacings give different starting energy.
 data_list_opt = [
     _make_system(2, spacing=_R_MIN * 1.05),
     _make_system(2, spacing=_R_MIN * 1.20),
@@ -196,21 +196,21 @@ print(
 )
 
 # %%
-# Final energies per system
+# Final energy per system
 # --------------------------
-# After the run, ``batch_opt.energies`` holds the per-system potential energy
+# After the run, ``batch_opt.energy`` holds the per-system potential energy
 # as output by the last model forward pass.  For a well-relaxed small cluster
 # the total energy should be negative, with each atom contributing roughly
 # −½ z ε where z is its coordination number.
 
-final_energies = batch_opt.energies.squeeze(-1).cpu().tolist()
+final_energy = batch_opt.energy.squeeze(-1).cpu().tolist()
 force_norms = batch_opt.forces.norm(dim=-1)
 fmax_final = torch.zeros(batch_opt.num_graphs, device=batch_opt.device)
 fmax_final.scatter_reduce_(
-    0, batch_opt.batch, force_norms, reduce="amax", include_self=True
+    0, batch_opt.batch_idx, force_norms, reduce="amax", include_self=True
 )
 fmax_list = fmax_final.cpu().tolist()
 
 print("\nRelaxed system summary:")
 for i in range(batch_opt.num_graphs):
-    print(f"  sys{i}: E={final_energies[i]:+.6f} eV  fmax={fmax_list[i]:.6f} eV/Å")
+    print(f"  sys{i}: E={final_energy[i]:+.6f} eV  fmax={fmax_list[i]:.6f} eV/Å")

--- a/examples/basic/03_ase_integration.py
+++ b/examples/basic/03_ase_integration.py
@@ -31,7 +31,7 @@ file I/O, and visualization tools; nvalchemi-toolkit consumes the resulting
 .. note::
 
     :class:`~nvalchemi.models.demo.DemoModelWrapper` is used throughout.
-    It produces fictitious energies/forces, so the trajectories are *not*
+    It produces fictitious energy/forces, so the trajectories are *not*
     physically meaningful.  Replace it with a trained MLIP for real science.
 """
 
@@ -75,7 +75,7 @@ model.eval()
 # :class:`~nvalchemi.dynamics.hooks.FreezeAtomsHook` knows which atoms to
 # freeze.
 #
-# Integrators also need ``forces``, ``energies``, and ``velocities``
+# Integrators also need ``forces``, ``energy``, and ``velocities``
 # pre-allocated so ``compute()`` can write into them.
 
 
@@ -84,7 +84,7 @@ def atoms_to_data(atoms) -> AtomicData:
     data = AtomicData.from_atoms(atoms)
     n = data.num_nodes
     data.forces = torch.zeros(n, 3)
-    data.energies = torch.zeros(1, 1)
+    data.energy = torch.zeros(1, 1)
     data.add_node_property("velocities", torch.zeros(n, 3))
     return data
 

--- a/examples/basic/04_nve_energy_conservation.py
+++ b/examples/basic/04_nve_energy_conservation.py
@@ -127,7 +127,7 @@ data = AtomicData(
     positions=positions,
     atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),  # Argon Z=18
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=torch.eye(3).unsqueeze(0) * box_size,
     pbc=torch.tensor([[True, True, True]]),
 )

--- a/examples/basic/05_nvt_langevin.py
+++ b/examples/basic/05_nvt_langevin.py
@@ -119,7 +119,7 @@ data = AtomicData(
     positions=positions,
     atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
 )
 data.add_node_property("velocities", velocities)
 

--- a/examples/distributed/01_distributed_pipeline.py
+++ b/examples/distributed/01_distributed_pipeline.py
@@ -84,7 +84,7 @@ def atoms_to_data(atoms) -> AtomicData:
     data = AtomicData.from_atoms(atoms)
     n = data.num_nodes
     data.forces = torch.zeros(n, 3)
-    data.energies = torch.zeros(1, 1)
+    data.energy = torch.zeros(1, 1)
     data.add_node_property("velocities", torch.zeros(n, 3))
     return data
 

--- a/examples/distributed/02_distributed_monitoring.py
+++ b/examples/distributed/02_distributed_monitoring.py
@@ -80,7 +80,7 @@ def atoms_to_data(atoms) -> AtomicData:
     data = AtomicData.from_atoms(atoms)
     n = data.num_nodes
     data.forces = torch.zeros(n, 3)
-    data.energies = torch.zeros(1, 1)
+    data.energy = torch.zeros(1, 1)
     data.add_node_property("velocities", torch.zeros(n, 3))
     return data
 
@@ -445,9 +445,9 @@ def _print_post_run_summary(num_ranks: int) -> None:
             if not rows:
                 print(f"{r:<6} {role_map[r]:<12} {'0':<12} {'n/a':<16} {'n/a':<12}")
                 continue
-            energies = [float(row["energy"]) for row in rows if row.get("energy")]
+            energy = [float(row["energy"]) for row in rows if row.get("energy")]
             fmaxes = [float(row["fmax"]) for row in rows if row.get("fmax")]
-            mean_energy = sum(energies) / len(energies) if energies else float("nan")
+            mean_energy = sum(energy) / len(energy) if energy else float("nan")
             mean_fmax = sum(fmaxes) / len(fmaxes) if fmaxes else float("nan")
             print(
                 f"{r:<6} {role_map[r]:<12} {len(rows):<12} "

--- a/examples/intermediate/01_multistage_pipeline.py
+++ b/examples/intermediate/01_multistage_pipeline.py
@@ -101,7 +101,7 @@ def _make_system(n_atoms: int, seed: int) -> AtomicData:
         atomic_numbers=torch.randint(1, 10, (n_atoms,), dtype=torch.long, generator=g),
         atomic_masses=torch.ones(n_atoms),
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
     )
     data.add_node_property("velocities", torch.zeros(n_atoms, 3))
     return data
@@ -286,7 +286,7 @@ class SimpleDataset:
             ),
             atomic_masses=torch.ones(self.atoms_per_sample),
             forces=torch.zeros(self.atoms_per_sample, 3),
-            energies=torch.zeros(1, 1),
+            energy=torch.zeros(1, 1),
         )
         data.add_node_property("velocities", torch.zeros(self.atoms_per_sample, 3))
         return data, {}
@@ -382,8 +382,8 @@ class StatusSnapshotHook:
         else:
             dist_str = "no status"
         e_str = ""
-        if batch.energies is not None:
-            e_mean = batch.energies.squeeze(-1).mean().cpu().item()
+        if batch.energy is not None:
+            e_mean = batch.energy.squeeze(-1).mean().cpu().item()
             e_str = f"  E_mean={e_mean:.4f}"
         logging.info("step=%3d  [%s]%s", ctx.step_count, dist_str, e_str)
         self._print_count += 1

--- a/examples/intermediate/02_trajectory_zarr_io.py
+++ b/examples/intermediate/02_trajectory_zarr_io.py
@@ -112,7 +112,7 @@ data = AtomicData(
     atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),  # Ar = 18
     atomic_masses=torch.full((n_atoms,), mass_ar),
     forces=torch.zeros(n_atoms, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=cell,
     pbc=torch.tensor([[True, True, True]]),
 )

--- a/examples/intermediate/03_npt_barostat_validation.py
+++ b/examples/intermediate/03_npt_barostat_validation.py
@@ -117,14 +117,14 @@ def make_fcc_batch(lattice_constant: float, seed_vel: int) -> Batch:
         atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),
         atomic_masses=torch.full((n_atoms,), MASS_AR),
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         cell=cell,
         pbc=torch.tensor([[True, True, True]]),
     )
     data.add_node_property("velocities", velocities)
 
     batch = Batch.from_data_list([data])
-    batch["stresses"] = torch.zeros(batch.num_graphs, 3, 3)
+    batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)
     return batch
 
 

--- a/examples/intermediate/04_inflight_batching.py
+++ b/examples/intermediate/04_inflight_batching.py
@@ -99,7 +99,7 @@ class HostMemoryWithSystemId(HostMemory):
                 return
             if num_selected < num_total:
                 indices = torch.nonzero(mask, as_tuple=True)[0]
-                _ = batch.ptr  # trigger lazy init for SegmentedLevelStorage
+                _ = batch.batch_ptr  # trigger lazy init for SegmentedLevelStorage
                 batch = batch.index_select(indices)
 
         # Extract system_id before unbatching; the AtomicData reconstruction loses
@@ -216,7 +216,7 @@ class MixedSizeDataset:
             atomic_numbers=torch.randint(1, 10, (n,), dtype=torch.long, generator=g),
             atomic_masses=torch.ones(n),
             forces=torch.zeros(n, 3),
-            energies=torch.zeros(1, 1),
+            energy=torch.zeros(1, 1),
         )
         data.add_node_property("velocities", torch.zeros(n, 3))
         return data, {}

--- a/examples/intermediate/05_safety_and_monitoring.py
+++ b/examples/intermediate/05_safety_and_monitoring.py
@@ -24,7 +24,7 @@ gradients, or energy drift that silently corrupts a long trajectory.
 This example demonstrates four hooks that make simulations more robust:
 
 * :class:`~nvalchemi.dynamics.hooks.NaNDetectorHook` — raises
-  :class:`RuntimeError` immediately when ``forces`` or ``energies`` contain
+  :class:`RuntimeError` immediately when ``forces`` or ``energy`` contain
   non-finite values (NaN or Inf).  Prevents corrupted state from propagating.
 * :class:`~nvalchemi.dynamics.hooks.MaxForceClampHook` — rescales atom force
   vectors whose L2 norm exceeds a threshold, preventing integration blow-ups
@@ -82,7 +82,7 @@ def _demo_system(n_atoms: int, seed: int) -> AtomicData:
         atomic_numbers=torch.randint(1, 10, (n_atoms,), dtype=torch.long, generator=g),
         atomic_masses=torch.ones(n_atoms),
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
     )
     data.add_node_property("velocities", torch.zeros(n_atoms, 3))
     return data
@@ -116,7 +116,7 @@ def _lj_system_bad(n_atoms: int, seed: int, box: float = 10.0) -> AtomicData:
         atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),
         atomic_masses=torch.full((n_atoms,), mass_ar),
         forces=torch.zeros(n_atoms, 3),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
         cell=cell,
         pbc=torch.tensor([[True, True, True]]),
     )
@@ -147,7 +147,7 @@ bad_data = AtomicData(
     atomic_numbers=torch.tensor([18, 18], dtype=torch.long),
     atomic_masses=torch.full((2,), 39.948),
     forces=torch.zeros(2, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=torch.eye(3).unsqueeze(0) * 20.0,
     pbc=torch.tensor([[True, True, True]]),
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Renames plural/legacy attribute names to their new singular forms across all 19 example scripts in `examples/`. This is the second phase of the attribute rename effort (issue #23), following the source + tests rename in PR #56.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Relates to #23

## Changes Made

- `energies` -> `energy` (~73 occurrences across all examples)
- `edge_index` -> `neighbor_list` (6 occurrences, basic data structures)
- `.batch` -> `.batch_idx` (8 occurrences, attribute access on AtomicData/Batch only)
- `.ptr` -> `.batch_ptr` (3 occurrences, attribute access on AtomicData/Batch only)
- `stresses` -> `stress` (3 occurrences, NPT/composition examples)
- `node_charges` -> `charges` (5 occurrences, electrostatics examples)
- Added missing docstring to `my_bias_fn` in `advanced/01_biased_potential.py` (required by interrogate)

### Not renamed (correctly preserved)

- `ctx.batch` — `HookContext.batch` property returning the `Batch` object (not the index tensor)
- `batch=` kwargs (e.g. `fused.run(batch=None)`)
- `batch` as local variables, `Batch` class references, `batch_size`, `num_batches`
- `atomic_numbers`, `atomic_masses`, `shifts`, `unit_shifts`

### Not found in examples (confirmed absent)

- `virials`, `dipoles`, `graph_charges`, `graph_spins`

## Testing

- All 19 example scripts verified with `py_compile` (syntax check)
- All 19 example scripts executed end-to-end with `uv run python` — all pass
- Distributed examples gracefully skip when not under `torchrun`
- `rg` scan confirms zero remaining instances of old attribute names

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

This PR is structured as 4 commits, one per example category (basic, intermediate, advanced, distributed) for easier review. The documentation rename (`rename-docs`) will follow as the third and final phase.