### PR TITLE
docs(rename): update attribute names across documentation and skills

### DIFF
--- a/.claude/skills/nvalchemi-data-storage/SKILL.md
+++ b/.claude/skills/nvalchemi-data-storage/SKILL.md
@@ -46,7 +46,7 @@ writer = AtomicDataZarrWriter("dataset.zarr")
 data = AtomicData(
     positions=torch.randn(10, 3),
     atomic_numbers=torch.ones(10, dtype=torch.long),
-    energies=torch.tensor([[0.5]]),
+    energy=torch.tensor([[0.5]]),
 )
 writer.write(data)
 
@@ -263,7 +263,7 @@ data_list = [
     AtomicData(
         positions=torch.randn(n, 3),
         atomic_numbers=torch.ones(n, dtype=torch.long),
-        energies=torch.tensor([[float(i)]]),
+        energy=torch.tensor([[float(i)]]),
     )
     for i, n in enumerate([5, 8, 3, 12])
 ]
@@ -285,7 +285,7 @@ loader = DataLoader(ds, batch_size=2, shuffle=True, prefetch_factor=2)
 for epoch in range(10):
     loader.set_epoch(epoch)
     for batch in loader:
-        energies = batch["energies"]      # [batch_size, 1]
+        energy = batch["energy"]          # [batch_size, 1]
         positions = batch["positions"]    # [total_nodes, 3]
         # ... model forward pass ...
 ```

--- a/.claude/skills/nvalchemi-data-structures/SKILL.md
+++ b/.claude/skills/nvalchemi-data-structures/SKILL.md
@@ -80,10 +80,13 @@ Fields are organized by level. All are optional except `positions` and `atomic_n
 | Node   | `charges`          | `[V, 1]`          |                                     |
 | Node   | `node_embeddings`  | `[V, H]`          |                                     |
 | Node   | `kinetic_energies` | `[V, 1]`          |                                     |
-| Edge   | `neighbor_list`    | `[2, E]`          | COO format, int64                   |
-| Edge   | `shifts`           | `[E, 3]`          | Periodic shifts                     |
-| Edge   | `unit_shifts`      | `[E, 3]`          | Unit cell shifts                    |
+| Edge   | `neighbor_list`    | `[E, 2]`          | COO format, int64                   |
+| Edge   | `shifts`           | `[E, 3]`          | Cartesian displacements (`neighbor_list_shifts @ cell`) |
+| Edge   | `neighbor_list_shifts` | `[E, 3]`       | Integer lattice image indices       |
 | Edge   | `edge_embeddings`  | `[E, H]`          |                                     |
+| Dense  | `neighbor_matrix`  | `[V, K]`          | Dense neighbor matrix (int64)       |
+| Dense  | `neighbor_matrix_shifts` | `[V, K, 3]` | Periodic shifts for dense neighbors |
+| Dense  | `num_neighbors`    | `[V]`             | Valid neighbor count per atom        |
 | System | `cell`             | `[1, 3, 3]`       | Lattice vectors                     |
 | System | `pbc`              | `[1, 3]`          | Periodic boundary conditions (bool) |
 | System | `energy`           | `[1]`             | eV                                  |

--- a/.claude/skills/nvalchemi-data-structures/SKILL.md
+++ b/.claude/skills/nvalchemi-data-structures/SKILL.md
@@ -39,14 +39,14 @@ data = AtomicData(
 data = AtomicData(
     positions=torch.randn(4, 3),
     atomic_numbers=torch.tensor([1, 6, 6, 1], dtype=torch.long),
-    edge_index=torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long),
+    neighbor_list=torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long),
 )
 
 # With system-level fields (energy, cell, pbc)
 data = AtomicData(
     positions=torch.randn(4, 3),
     atomic_numbers=torch.tensor([1, 6, 6, 1], dtype=torch.long),
-    energies=torch.tensor([[0.5]]),
+    energy=torch.tensor([[0.5]]),
     cell=torch.eye(3).unsqueeze(0),       # [1, 3, 3]
     pbc=torch.tensor([[True, True, False]]),  # [1, 3]
 )
@@ -77,20 +77,20 @@ Fields are organized by level. All are optional except `positions` and `atomic_n
 | Node   | `forces`           | `[V, 3]`          | eV/Angstrom                         |
 | Node   | `velocities`       | `[V, 3]`          | Auto-initialized to zeros           |
 | Node   | `momenta`          | `[V, 3]`          |                                     |
-| Node   | `node_charges`     | `[V, 1]`          |                                     |
+| Node   | `charges`          | `[V, 1]`          |                                     |
 | Node   | `node_embeddings`  | `[V, H]`          |                                     |
 | Node   | `kinetic_energies` | `[V, 1]`          |                                     |
-| Edge   | `edge_index`       | `[2, E]`          | COO format, int64                   |
+| Edge   | `neighbor_list`    | `[2, E]`          | COO format, int64                   |
 | Edge   | `shifts`           | `[E, 3]`          | Periodic shifts                     |
 | Edge   | `unit_shifts`      | `[E, 3]`          | Unit cell shifts                    |
 | Edge   | `edge_embeddings`  | `[E, H]`          |                                     |
 | System | `cell`             | `[1, 3, 3]`       | Lattice vectors                     |
 | System | `pbc`              | `[1, 3]`          | Periodic boundary conditions (bool) |
-| System | `energies`         | `[1]`             | eV                                  |
-| System | `stresses`         | `[1, 3, 3]`       | eV/Angstrom^3                       |
-| System | `virials`          | `[1, 3, 3]`       |                                     |
-| System | `dipoles`          | `[1, 3]`          |                                     |
-| System | `graph_charges`    | `[1]`             |                                     |
+| System | `energy`           | `[1]`             | eV                                  |
+| System | `stress`           | `[1, 3, 3]`       | eV/Angstrom^3                       |
+| System | `virial`           | `[1, 3, 3]`       |                                     |
+| System | `dipole`           | `[1, 3]`          |                                     |
+| System | `charge`           | `[1]`             |                                     |
 | System | `graph_embeddings` | `[1, H]`          |                                     |
 
 Custom data can be stored in the `info: dict[str, torch.Tensor]` field.
@@ -173,8 +173,8 @@ batch.num_graphs            # number of graphs
 batch.batch_size            # alias for num_graphs
 batch.num_nodes             # total nodes across all graphs
 batch.num_edges             # total edges across all graphs
-batch.batch                 # Tensor [num_nodes] — per-node graph index
-batch.ptr                   # Tensor [num_graphs+1] — cumulative node counts
+batch.batch_idx             # Tensor [num_nodes] — per-node graph index
+batch.batch_ptr             # Tensor [num_graphs+1] — cumulative node counts
 batch.num_nodes_list        # list[int] — per-graph node counts
 batch.num_edges_list        # list[int] — per-graph edge counts
 batch.num_nodes_per_graph   # Tensor — per-graph node counts

--- a/.claude/skills/nvalchemi-data-structures/SKILL.md
+++ b/.claude/skills/nvalchemi-data-structures/SKILL.md
@@ -39,7 +39,7 @@ data = AtomicData(
 data = AtomicData(
     positions=torch.randn(4, 3),
     atomic_numbers=torch.tensor([1, 6, 6, 1], dtype=torch.long),
-    neighbor_list=torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long),
+    neighbor_list=torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]], dtype=torch.long),
 )
 
 # With system-level fields (energy, cell, pbc)

--- a/.claude/skills/nvalchemi-dynamics-api/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-api/SKILL.md
@@ -62,7 +62,7 @@ data = AtomicData(
 )
 batch = Batch.from_data_list([data])
 batch.forces = torch.zeros(3, 3)
-batch.energies = torch.zeros(1, 1)
+batch.energy = torch.zeros(1, 1)
 
 result = dynamics.run(batch)
 ```

--- a/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
@@ -80,7 +80,7 @@ ON_CONVERGE (8)   ← only if convergence detected
 
 | Goal | Stage |
 |------|-------|
-| Modify forces/energies after model | `DynamicsStage.AFTER_COMPUTE` |
+| Modify forces/energy after model | `DynamicsStage.AFTER_COMPUTE` |
 | Observe final state (logging, snapshots) | `DynamicsStage.AFTER_STEP` |
 | Wrap positions after velocity update | `DynamicsStage.AFTER_POST_UPDATE` |
 | Instrument timing / profiling | `DynamicsStage.BEFORE_STEP` |
@@ -120,12 +120,12 @@ which enum types are accepted. For example, `BaseDynamics` sets
 
 ### Safety hooks (stage: AFTER_COMPUTE)
 
-**NaNDetectorHook** — detect NaN/Inf in forces and energies.
+**NaNDetectorHook** — detect NaN/Inf in forces and energy.
 
 ```python
 NaNDetectorHook(
     frequency=1,              # check every N steps
-    extra_keys=["stresses"],  # additional batch keys to check (optional)
+    extra_keys=["stress"],    # additional batch keys to check (optional)
 )
 ```
 
@@ -323,7 +323,7 @@ Register hooks in this order for correct behavior:
 
 ```python
 hooks = [
-    # 1. Bias (modifies forces/energies)
+    # 1. Bias (modifies forces/energy)
     BiasedPotentialHook(bias_fn=my_bias),
     # 2. Safety (clamp after all force modifications)
     MaxForceClampHook(max_force=10.0),
@@ -383,7 +383,7 @@ data = AtomicData(
 )
 batch = Batch.from_data_list([data])
 batch.forces = torch.zeros(3, 3)
-batch.energies = torch.zeros(1, 1)
+batch.energy = torch.zeros(1, 1)
 
 dynamics.run(batch)
 ```

--- a/.claude/skills/nvalchemi-dynamics-implementation/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-implementation/SKILL.md
@@ -33,7 +33,7 @@ Each call to `step(batch)` executes:
 ```
 
 - `pre_update()` and `post_update()` run inside `torch.no_grad()`
-- `compute()` calls the model forward pass and writes forces/energies to the batch in-place
+- `compute()` calls the model forward pass and writes forces/energy to the batch in-place
 - You implement `pre_update()` and `post_update()`; everything else is inherited
 
 ---
@@ -131,7 +131,7 @@ def post_update(self, batch: Batch) -> None:
 
 | Method | Description |
 |--------|-------------|
-| `compute(batch)` | Model forward pass → validates outputs → writes forces/energies to batch |
+| `compute(batch)` | Model forward pass → validates outputs → writes forces/energy to batch |
 | `step(batch)` | Full step with hook dispatch (see flow above) |
 | `run(batch, n_steps=None)` | Loop calling `step()` for `n_steps` iterations |
 | `register_hook(hook)` | Register a hook at its declared stage |
@@ -172,9 +172,9 @@ data = AtomicData(
 )
 batch = Batch.from_data_list([data])
 
-# Initialize required fields (forces/energies must exist for copy_())
+# Initialize required fields (forces/energy must exist for copy_())
 batch.forces = torch.zeros(3, 3)
-batch.energies = torch.zeros(1, 1)
+batch.energy = torch.zeros(1, 1)
 
 # Run
 result = dynamics.run(batch)

--- a/.claude/skills/nvalchemi-model-wrapping/SKILL.md
+++ b/.claude/skills/nvalchemi-model-wrapping/SKILL.md
@@ -63,10 +63,10 @@ def model_card(self) -> ModelCard:
         supports_edge_embeddings=False,
         supports_graph_embeddings=False,
         # Requirements
-        needs_neighborlist=False,       # expects edge_index in input
+        needs_neighborlist=False,       # expects neighbor_list in input
         needs_pbc=False,                # requires cell/pbc in input
-        needs_node_charges=False,       # requires node_charges
-        needs_system_charges=False,     # requires graph_charges
+        needs_node_charges=False,       # requires charges
+        needs_system_charges=False,     # requires charge
     )
 ```
 
@@ -98,7 +98,7 @@ def adapt_input(self, data: AtomicData | Batch, **kwargs: Any) -> dict[str, Any]
 
     # Handle batched vs single input
     if isinstance(data, Batch):
-        model_inputs["batch_indices"] = data.batch
+        model_inputs["batch_indices"] = data.batch_idx
     else:
         model_inputs["batch_indices"] = None
 
@@ -119,10 +119,10 @@ def adapt_output(self, model_output: Any, data: AtomicData | Batch) -> ModelOutp
     output = super().adapt_output(model_output, data)
 
     # Map model outputs to standardized keys
-    energies = model_output["energies"]
-    if isinstance(data, AtomicData) and energies.ndim == 1:
-        energies = energies.unsqueeze(-1)   # must be [B, 1]
-    output["energies"] = energies
+    energy = model_output["energy"]
+    if isinstance(data, AtomicData) and energy.ndim == 1:
+        energy = energy.unsqueeze(-1)   # must be [B, 1]
+    output["energy"] = energy
 
     if self.model_config.compute_forces:
         output["forces"] = model_output["forces"]
@@ -134,11 +134,11 @@ def adapt_output(self, model_output: Any, data: AtomicData | Batch) -> ModelOutp
 
 | Key          | Shape        | Notes                    |
 |--------------|-------------|--------------------------|
-| `energies`   | `[B, 1]`   | Per-graph energy (eV)    |
+| `energy`     | `[B, 1]`   | Per-graph energy (eV)    |
 | `forces`     | `[V, 3]`   | Per-node forces          |
-| `stresses`   | `[B, 3, 3]`| Per-graph stress tensor  |
+| `stress`     | `[B, 3, 3]`| Per-graph stress tensor  |
 | `hessians`   | `[V, 3, 3]`| Energy Hessian           |
-| `dipoles`    | `[B, 3]`   | Dipole moment            |
+| `dipole`     | `[B, 3]`   | Dipole moment            |
 | `charges`    | `[V, 1]`   | Partial charges          |
 
 ### 5. Implement compute_embeddings
@@ -157,7 +157,7 @@ def compute_embeddings(self, data: AtomicData | Batch, **kwargs: Any) -> AtomicD
 
     # Aggregate to graph level
     if isinstance(data, Batch):
-        batch_indices = data.batch
+        batch_indices = data.batch_idx
         num_graphs = data.batch_size
     else:
         batch_indices = torch.zeros_like(model_inputs["atomic_numbers"])
@@ -229,7 +229,7 @@ Use `_verify_request()` to check if a computation is both requested and supporte
 
 ```python
 if self._verify_request(self.model_config, self.model_card, "stresses"):
-    output["stresses"] = compute_stress(...)
+    output["stress"] = compute_stress(...)
 ```
 
 ---
@@ -273,11 +273,11 @@ class MyPotential(nn.Module):
         node_energy = self.energy_head(h)
         if batch_indices is not None:
             num_graphs = batch_indices.max() + 1
-            energies = torch.zeros(num_graphs, 1, device=h.device, dtype=h.dtype)
-            energies.scatter_add_(0, batch_indices.unsqueeze(-1), node_energy)
+            energy = torch.zeros(num_graphs, 1, device=h.device, dtype=h.dtype)
+            energy.scatter_add_(0, batch_indices.unsqueeze(-1), node_energy)
         else:
-            energies = node_energy.sum(dim=0, keepdim=True)
-        return {"energies": energies}
+            energy = node_energy.sum(dim=0, keepdim=True)
+        return {"energy": energy}
 
 
 class MyPotentialWrapper(MyPotential, BaseModelMixin):
@@ -302,19 +302,19 @@ class MyPotentialWrapper(MyPotential, BaseModelMixin):
         model_inputs = super().adapt_input(data, **kwargs)
         model_inputs["positions"] = data.positions
         if isinstance(data, Batch):
-            model_inputs["batch_indices"] = data.batch
+            model_inputs["batch_indices"] = data.batch_idx
         else:
             model_inputs["batch_indices"] = None
         return model_inputs
 
     def adapt_output(self, model_output: Any, data: AtomicData | Batch) -> ModelOutputs:
         output = super().adapt_output(model_output, data)
-        output["energies"] = model_output["energies"]
+        output["energy"] = model_output["energy"]
         if self.model_config.compute_forces:
             output["forces"] = -torch.autograd.grad(
-                model_output["energies"],
+                model_output["energy"],
                 data.positions,
-                grad_outputs=torch.ones_like(model_output["energies"]),
+                grad_outputs=torch.ones_like(model_output["energy"]),
                 create_graph=self.training,
             )[0]
         return output
@@ -340,6 +340,6 @@ data = AtomicData(
 )
 batch = Batch.from_data_list([data])
 outputs = model(batch)
-# outputs["energies"] shape: [1, 1]
+# outputs["energy"] shape: [1, 1]
 # outputs["forces"] shape: [5, 3]
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ batch = Batch.from_data_list([mol_a, mol_b])
 # Wrap a model and run
 model = DemoModelWrapper()
 outputs = model(batch)
-print(outputs["energies"].shape)  # [2, 1] &mdash; one energy per system
+print(outputs["energy"].shape)    # [2, 1] &mdash; one energy per system
 print(outputs["forces"].shape)    # [7, 3] &mdash; one force vector per atom
 ```
 

--- a/docs/modules/dynamics/hooks.rst
+++ b/docs/modules/dynamics/hooks.rst
@@ -31,7 +31,7 @@ be registered with an engine:
        frequency: int = 1
 
        def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
-           print(f"Step {ctx.step_count}: energy = {ctx.batch.energies.mean():.4f}")
+           print(f"Step {ctx.step_count}: energy = {ctx.batch.energy.mean():.4f}")
 
 Because ``Hook`` is a ``runtime_checkable`` ``Protocol``, you can also
 use it as a type hint and check membership with ``isinstance``:
@@ -120,7 +120,7 @@ Each engine declares which stage types it accepts via ``_stage_type``.
      - Before the model forward pass.
    * - ``AFTER_COMPUTE``
      - 4
-     - After forces/energies are written to the batch.
+     - After forces/energy are written to the batch.
    * - ``BEFORE_POST_UPDATE``
      - 5
      - Before the second integrator half-step (velocities).
@@ -240,13 +240,13 @@ These hooks modify the batch **after** the model forward pass and
    * - Hook
      - Purpose
    * - :class:`~nvalchemi.dynamics.hooks.NaNDetectorHook`
-     - Detect NaN/Inf in forces and energies; raise with
+     - Detect NaN/Inf in forces and energy; raise with
        diagnostic info (affected graph indices, step count).
    * - :class:`~nvalchemi.dynamics.hooks.MaxForceClampHook`
      - Clamp per-atom force magnitudes to a safe maximum,
        preserving force direction. Prevents numerical explosions.
    * - :class:`~nvalchemi.dynamics.hooks.BiasedPotentialHook`
-     - Add an external bias potential (energies + forces) for
+     - Add an external bias potential (energy + forces) for
        enhanced sampling: umbrella sampling, metadynamics,
        steered MD, harmonic restraints, wall potentials.
    * - :class:`~nvalchemi.dynamics.hooks.WrapPeriodicHook`
@@ -313,7 +313,7 @@ Safety: NaN detection + force clamping
            # Clamp first, then check — both fire at AFTER_COMPUTE
            # in registration order.
            MaxForceClampHook(max_force=50.0, log_clamps=True),
-           NaNDetectorHook(extra_keys=["stresses"]),
+           NaNDetectorHook(extra_keys=["stress"]),
        ],
    )
 
@@ -372,7 +372,7 @@ Custom scalars via LoggingHook
 
    def pressure(ctx, stage):
        """Compute instantaneous pressure from the virial."""
-       return compute_pressure(ctx.batch.stresses, ctx.batch.cell)
+       return compute_pressure(ctx.batch.stress, ctx.batch.cell)
 
    hook = LoggingHook(
        backend="csv",

--- a/docs/modules/dynamics/implementing_dynamics.rst
+++ b/docs/modules/dynamics/implementing_dynamics.rst
@@ -56,7 +56,7 @@ These class-level sets drive **automatic validation**:
   checks that every key in ``__needs_keys__`` is present and non-``None``
   in the model outputs. A clear ``RuntimeError`` is raised otherwise.
 * ``__provides_keys__`` documents which additional batch fields the
-  integrator writes (beyond model outputs like forces and energies).
+  integrator writes (beyond model outputs like forces and energy).
   The diagnostic helper ``_validate_batch_keys`` can verify them.
 
 When dynamics are composed into a :class:`~nvalchemi.dynamics.FusedStage`,
@@ -217,7 +217,7 @@ every call:
 
 ``compute()`` handles the full model pipeline: forward pass →
 ``adapt_output()`` → ``_validate_model_outputs()`` → write
-forces/energies to batch via ``copy_()``.
+forces/energy to batch via ``copy_()``.
 
 
 ``masked_update`` for ``FusedStage`` compatibility
@@ -231,8 +231,8 @@ directly. The default implementation in ``BaseDynamics`` is:
 .. code-block:: python
 
    def masked_update(self, batch, mask):
-       # Expand graph-level mask → node-level via batch.batch
-       node_mask = mask[batch.batch]
+       # Expand graph-level mask → node-level via batch.batch_idx
+       node_mask = mask[batch.batch_idx]
 
        # Snapshot unmasked state
        original_positions = batch.positions.clone()

--- a/docs/userguide/about/intro.md
+++ b/docs/userguide/about/intro.md
@@ -112,7 +112,7 @@ inflight batching.
 {py:class}`~nvalchemi.models.base.BaseModelMixin` provides a standardized
 wrapper around any PyTorch MLIP. A
 {py:class}`~nvalchemi.models.base.ModelCard` declares capabilities (e.g.,
-forces, stresses, periodic boundaries) and a
+forces, stress, periodic boundaries) and a
 {py:class}`~nvalchemi.models.base.ModelConfig` controls runtime behavior.
 The wrapper's `adapt_input` / `adapt_output` methods handle format conversion
 so the model sees its native tensors and the toolkit sees

--- a/docs/userguide/data.md
+++ b/docs/userguide/data.md
@@ -17,7 +17,7 @@ structure for efficient GPU-friendly training and inference.
 - **Required**: `positions` (shape `[n_nodes, 3]`) and `atomic_numbers` (shape `[n_nodes]`).
 - **Optional node-level**: e.g. `atomic_masses`, `forces`, `velocities`, `node_attrs`.
 - **Optional edge-level**: `neighbor_list` (shape `[n_edges, 2]`) and edge attributes such
-as `shifts` for periodicity.
+as `shifts` (Cartesian displacements) and `neighbor_list_shifts` (integer lattice indices) for periodicity.
 - **Optional system-level**: `energy`, `cell`, `pbc`, `stress`, `virial`, etc.
 
 All tensor fields use PyTorch tensors, so you can move them to GPU with `.to(device)` or
@@ -150,7 +150,7 @@ Every tensor attribute belongs to one of three **levels**:
 |-----------|----------------------------|--------------------------------------|---------------------------------------------|
 | **system** | {py:class}`~nvalchemi.data.level_storage.UniformLevelStorage` | First dim = number of graphs | `cell`, `pbc`, `energy`, `stress` |
 | **atoms** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `positions`, `atomic_numbers`, `forces` |
-| **edges** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `neighbor_list`, `shifts`, `edge_embeddings` |
+| **edges** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `neighbor_list`, `shifts`, `neighbor_list_shifts`, `edge_embeddings` |
 
 **Uniform storage** is straightforward: every graph contributes exactly one row, so
 the i-th graph's data is always at index `i`. System-level properties like the

--- a/docs/userguide/data.md
+++ b/docs/userguide/data.md
@@ -16,9 +16,9 @@ structure for efficient GPU-friendly training and inference.
 
 - **Required**: `positions` (shape `[n_nodes, 3]`) and `atomic_numbers` (shape `[n_nodes]`).
 - **Optional node-level**: e.g. `atomic_masses`, `forces`, `velocities`, `node_attrs`.
-- **Optional edge-level**: `edge_index` (shape `[n_edges, 2]`) and edge attributes such
+- **Optional edge-level**: `neighbor_list` (shape `[n_edges, 2]`) and edge attributes such
 as `shifts` for periodicity.
-- **Optional system-level**: `energies`, `cell`, `pbc`, `stresses`, `virials`, etc.
+- **Optional system-level**: `energy`, `cell`, `pbc`, `stress`, `virial`, etc.
 
 All tensor fields use PyTorch tensors, so you can move them to GPU with `.to(device)` or
 use the mixin method {py:meth}`nvalchemi.data.data.DataMixin.to` for device/dtype changes.
@@ -37,7 +37,7 @@ data = AtomicData(positions=positions, atomic_numbers=atomic_numbers)
 data = AtomicData(
     positions=positions,
     atomic_numbers=atomic_numbers,
-    energies=torch.tensor([[0.0]]),
+    energy=torch.tensor([[0.0]]),
 )
 ```
 
@@ -66,12 +66,12 @@ data_list = [
     AtomicData(
         positions=torch.randn(2, 3),
         atomic_numbers=torch.ones(2, dtype=torch.long),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
     ),
     AtomicData(
         positions=torch.randn(3, 3),
         atomic_numbers=torch.ones(3, dtype=torch.long),
-        energies=torch.zeros(1, 1),
+        energy=torch.zeros(1, 1),
     ),
 ]
 batch = Batch.from_data_list(data_list)
@@ -95,7 +95,7 @@ conventions. The type of index determines what you get back:
 
 When selecting multiple graphs (slice, tensor, or list), the underlying
 {py:meth}`~nvalchemi.data.batch.Batch.index_select` method operates directly on the
-concatenated storage --- it slices segments and adjusts `edge_index` offsets without
+concatenated storage --- it slices segments and adjusts `neighbor_list` offsets without
 reconstructing individual `AtomicData` objects, so it is efficient even for large
 batches.
 
@@ -119,13 +119,13 @@ gets the correct slice.
 ```python
 batch.add_key("node_feat", [torch.randn(2, 4), torch.randn(3, 4)], level="node")
 batch.add_key(
-    "energies",
+    "energy",
     [torch.tensor([[0.1]]), torch.tensor([[0.2]])],
     level="system",
     overwrite=True,
 )
 list_of_data = batch.to_data_list()
-# list_of_data[i] now has "node_feat" and "energies" with the right shapes.
+# list_of_data[i] now has "node_feat" and "energy" with the right shapes.
 ```
 
 ## Device and serialization
@@ -148,9 +148,9 @@ Every tensor attribute belongs to one of three **levels**:
 
 | Level | Storage class | Shape convention | Examples |
 |-----------|----------------------------|--------------------------------------|---------------------------------------------|
-| **system** | {py:class}`~nvalchemi.data.level_storage.UniformLevelStorage` | First dim = number of graphs | `cell`, `pbc`, `energies`, `stresses` |
+| **system** | {py:class}`~nvalchemi.data.level_storage.UniformLevelStorage` | First dim = number of graphs | `cell`, `pbc`, `energy`, `stress` |
 | **atoms** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `positions`, `atomic_numbers`, `forces` |
-| **edges** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `edge_index`, `shifts`, `edge_embeddings` |
+| **edges** | {py:class}`~nvalchemi.data.level_storage.SegmentedLevelStorage` | Concatenated across graphs | `neighbor_list`, `shifts`, `edge_embeddings` |
 
 **Uniform storage** is straightforward: every graph contributes exactly one row, so
 the i-th graph's data is always at index `i`. System-level properties like the
@@ -161,7 +161,7 @@ are concatenated into a single tensor of shape `(total_nodes, 3)`. To know where
 graph's atoms start and end, the storage tracks `segment_lengths` and a pointer array
 `batch_ptr`. The i-th graph's nodes live at `positions[batch_ptr[i]:batch_ptr[i+1]]`.
 Edge data works the same way, with node-index offsets automatically applied to
-`edge_index` so that each graph's edges still point to the correct atoms in the
+`neighbor_list` so that each graph's edges still point to the correct atoms in the
 flattened array.
 
 The mapping from attribute name to level is determined by a
@@ -191,7 +191,7 @@ template = AtomicData(
     positions=torch.zeros(1, 3),
     atomic_numbers=torch.zeros(1, dtype=torch.long),
     forces=torch.zeros(1, 3),
-    energies=torch.zeros(1, 1),
+    energy=torch.zeros(1, 1),
     cell=torch.zeros(1, 3, 3),
     pbc=torch.zeros(1, 3, dtype=torch.bool),
 )
@@ -271,18 +271,18 @@ The conversion maps ASE fields to ALCHEMI fields:
 | `atoms.positions` | `positions` | Always populated |
 | `atoms.get_pbc()` | `pbc` | Reshaped to `(1, 3)` |
 | `atoms.get_cell()` | `cell` | Reshaped to `(1, 3, 3)` |
-| `atoms.info[energy_key]` | `energies` | `None` if absent; `(1, 1)` |
+| `atoms.info[energy_key]` | `energy` | `None` if absent; `(1, 1)` |
 | `atoms.arrays[forces_key]` | `forces` | `None` if absent |
-| `atoms.info[stress_key]` | `stresses` | `None` if absent; Voigt → `(1, 3, 3)` |
-| `atoms.info[virials_key]` | `virials` | `None` if absent; Voigt → `(1, 3, 3)` |
-| `atoms.info[dipole_key]` | `dipoles` | `None` if absent; `(1, 3)` |
-| `atoms.arrays[charges_key]` | `node_charges` | `None` if absent; `(N, 1)` |
-| `atoms.info["charge"]` | `graph_charges` | `None` if absent; from per-atom sum |
+| `atoms.info[stress_key]` | `stress` | `None` if absent; Voigt → `(1, 3, 3)` |
+| `atoms.info[virials_key]` | `virial` | `None` if absent; Voigt → `(1, 3, 3)` |
+| `atoms.info[dipole_key]` | `dipole` | `None` if absent; `(1, 3)` |
+| `atoms.arrays[charges_key]` | `charges` | `None` if absent; `(N, 1)` |
+| `atoms.info["charge"]` | `charge` | `None` if absent; from per-atom sum |
 | `atoms.get_masses()` | `atomic_masses` | Always populated |
 | `atoms.info` (remaining) | `info` | Arrays, lists, ints, floats kept; bools/strings dropped |
 
-Optional label fields (`energies`, `forces`, `stresses`, `virials`, `dipoles`,
-`node_charges`, `graph_charges`) are populated **only** when present in the ASE
+Optional label fields (`energy`, `forces`, `stress`, `virial`, `dipole`,
+`charges`, `charge`) are populated **only** when present in the ASE
 object; otherwise they remain `None`. The input `atoms` object is **not** mutated.
 
 Keyword arguments (`energy_key`, `forces_key`, etc.) let you adapt to different

--- a/docs/userguide/dynamics.md
+++ b/docs/userguide/dynamics.md
@@ -39,7 +39,7 @@ A single call to `step()` proceeds through these stages in order:
 1. **BEFORE_STEP** hooks fire.
 2. `pre_update(batch)` --- the integrator's first half-step (e.g. update velocities
    by half a timestep), bracketed by BEFORE/AFTER_PRE_UPDATE hooks.
-3. `compute(batch)` --- the wrapped ML model evaluates forces (and stresses, if
+3. `compute(batch)` --- the wrapped ML model evaluates forces (and stress, if
    needed), bracketed by BEFORE/AFTER_COMPUTE hooks.
 4. `post_update(batch)` --- the integrator's second half-step (e.g. complete the
    velocity update with the new forces), bracketed by BEFORE/AFTER_POST_UPDATE hooks.

--- a/docs/userguide/dynamics_hooks.md
+++ b/docs/userguide/dynamics_hooks.md
@@ -35,7 +35,7 @@ class MyHook:
     frequency = 1
 
     def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
-        print(f"Step {ctx.step_count}: energy = {ctx.batch.energies.mean():.4f}")
+        print(f"Step {ctx.step_count}: energy = {ctx.batch.energy.mean():.4f}")
 
 assert isinstance(MyHook(), Hook)  # True — structural subtyping
 ```
@@ -349,7 +349,7 @@ class FileWriterHook:
         return self
 
     def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
-        energy = ctx.batch.energies.mean().item()
+        energy = ctx.batch.energy.mean().item()
         self._file.write(f"{ctx.step_count},{energy}\n")
 
     def __exit__(self, *exc):

--- a/docs/userguide/dynamics_simulations.md
+++ b/docs/userguide/dynamics_simulations.md
@@ -58,7 +58,7 @@ with FIREVariableCell(
 ```
 
 The cell degrees of freedom are propagated using an NPH-like scheme at zero target
-pressure. The model must return `stresses` (or `virials`) in addition to `forces`.
+pressure. The model must return `stress` (or `virial`) in addition to `forces`.
 
 ### Choosing between fixed and variable cell
 
@@ -135,7 +135,7 @@ with NPT(
     trajectory = md.run(batch)
 ```
 
-The model must return `stresses` for NPT to propagate the cell degrees of freedom.
+The model must return `stress` for NPT to propagate the cell degrees of freedom.
 
 ## Writing your own dynamics
 
@@ -149,7 +149,7 @@ define how the batch state evolves within a single step.
 Your subclass must provide:
 
 1. **`__needs_keys__`** --- a set of strings naming the model outputs your dynamics
-   reads (e.g. `{"forces"}`, or `{"forces", "stresses"}` for cell-aware schemes).
+   reads (e.g. `{"forces"}`, or `{"forces", "stress"}` for cell-aware schemes).
 2. **`__provides_keys__`** --- a set of strings naming the batch keys your dynamics
    writes (e.g. `{"positions", "velocities"}`).
 3. **`pre_update(batch)`** --- called *before* the model forward pass. Typically
@@ -227,7 +227,7 @@ updates:
 |---------------|--------------------|-------------------------|
 | `pre_update` entry | Hooks ran | Positions and velocities from the *previous* step; forces may be from the previous `compute` (or absent on step 0) |
 | `pre_update` exit | You updated positions | New positions; velocities partially updated (or unchanged) |
-| After `compute` | Model ran | Fresh `forces` (and `energies`, `stresses`, etc.) for the new positions |
+| After `compute` | Model ran | Fresh `forces` (and `energy`, `stress`, etc.) for the new positions |
 | `post_update` entry | Forces are fresh | Complete the velocity update with new forces |
 | `post_update` exit | Step is done | Consistent positions, velocities, and forces for the current timestep |
 
@@ -247,7 +247,7 @@ updates:
   `_prev_accelerations` pattern above is typical.
 - **`__needs_keys__` matters**: `BaseDynamics` uses this set to verify the model
   produces the required outputs before the simulation starts. If your dynamics needs
-  stresses, declare `{"forces", "stresses"}`.
+  stress, declare `{"forces", "stress"}`.
 - **FusedStage compatibility**: When your dynamics runs inside a
   {py:class}`~nvalchemi.dynamics.base.FusedStage`, a save-and-restore mask is
   applied around `pre_update` and `post_update` so that only systems belonging to

--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -107,7 +107,7 @@ Every wrapper must return a `ModelCard` from its
 | Field | Default | Meaning |
 |---|---|---|
 | `needs_pbc` | *(required)* | Model expects `pbc` and `cell` in its input |
-| `needs_neighborlist` | `False` | Model expects `edge_index` in its input |
+| `needs_neighborlist` | `False` | Model expects `neighbor_list` in its input |
 | `needs_node_charges` | `False` | Model expects partial charges per atom |
 | `needs_system_charges` | `False` | Model expects total system charge |
 
@@ -228,7 +228,7 @@ def adapt_input(self, data: AtomicData | Batch, **kwargs) -> dict[str, Any]:
 
     # Handle batched vs. single input
     if isinstance(data, Batch):
-        model_inputs["batch_indices"] = data.batch
+        model_inputs["batch_indices"] = data.batch_idx
     else:
         model_inputs["batch_indices"] = None
 
@@ -249,10 +249,10 @@ auto-maps any keys whose names already match:
 def adapt_output(self, model_output, data: AtomicData | Batch) -> ModelOutputs:
     output = super().adapt_output(model_output, data)
 
-    energies = model_output["energies"]
-    if isinstance(data, AtomicData) and energies.ndim == 1:
-        energies = energies.unsqueeze(-1)  # must be [B, 1]
-    output["energies"] = energies
+    energy = model_output["energy"]
+    if isinstance(data, AtomicData) and energy.ndim == 1:
+        energy = energy.unsqueeze(-1)  # must be [B, 1]
+    output["energy"] = energy
 
     if self.model_config.compute_forces:
         output["forces"] = model_output["forces"]
@@ -271,11 +271,11 @@ The standard output shapes are:
 
 | Key | Shape | Description |
 |---|---|---|
-| `energies` | `[B, 1]` | Per-graph total energy |
+| `energy` | `[B, 1]` | Per-graph total energy |
 | `forces` | `[V, 3]` | Per-atom forces |
-| `stresses` | `[B, 3, 3]` | Per-graph stress tensor |
+| `stress` | `[B, 3, 3]` | Per-graph stress tensor |
 | `hessians` | `[V, 3, 3]` | Per-atom Hessian |
-| `dipoles` | `[B, 3]` | Per-graph dipole moment |
+| `dipole` | `[B, 3]` | Per-graph dipole moment |
 | `charges` | `[V, 1]` | Per-atom partial charges |
 
 ### Step 6 (optional) --- Implement `compute_embeddings`
@@ -295,7 +295,7 @@ def compute_embeddings(self, data: AtomicData | Batch, **kwargs) -> AtomicData |
 
     # Aggregate to graph level via scatter
     if isinstance(data, Batch):
-        batch_indices = data.batch
+        batch_indices = data.batch_idx
         num_graphs = data.batch_size
     else:
         batch_indices = torch.zeros_like(model_inputs["atomic_numbers"])
@@ -378,11 +378,11 @@ class MyPotential(nn.Module):
         node_energy = self.energy_head(h)
         if batch_indices is not None:
             num_graphs = batch_indices.max() + 1
-            energies = torch.zeros(num_graphs, 1, device=h.device, dtype=h.dtype)
-            energies.scatter_add_(0, batch_indices.unsqueeze(-1), node_energy)
+            energy = torch.zeros(num_graphs, 1, device=h.device, dtype=h.dtype)
+            energy.scatter_add_(0, batch_indices.unsqueeze(-1), node_energy)
         else:
-            energies = node_energy.sum(dim=0, keepdim=True)
-        return {"energies": energies}
+            energy = node_energy.sum(dim=0, keepdim=True)
+        return {"energy": energy}
 
 
 class MyPotentialWrapper(MyPotential, BaseModelMixin):
@@ -406,17 +406,17 @@ class MyPotentialWrapper(MyPotential, BaseModelMixin):
     def adapt_input(self, data: AtomicData | Batch, **kwargs: Any) -> dict[str, Any]:
         model_inputs = super().adapt_input(data, **kwargs)
         model_inputs["positions"] = data.positions
-        model_inputs["batch_indices"] = data.batch if isinstance(data, Batch) else None
+        model_inputs["batch_indices"] = data.batch_idx if isinstance(data, Batch) else None
         return model_inputs
 
     def adapt_output(self, model_output: Any, data: AtomicData | Batch) -> ModelOutputs:
         output = super().adapt_output(model_output, data)
-        output["energies"] = model_output["energies"]
+        output["energy"] = model_output["energy"]
         if self.model_config.compute_forces:
             output["forces"] = -torch.autograd.grad(
-                model_output["energies"],
+                model_output["energy"],
                 data.positions,
-                grad_outputs=torch.ones_like(model_output["energies"]),
+                grad_outputs=torch.ones_like(model_output["energy"]),
                 create_graph=self.training,
             )[0]
         return output
@@ -444,7 +444,7 @@ data = AtomicData(
 )
 batch = Batch.from_data_list([data])
 outputs = model(batch)
-# outputs["energies"] shape: [1, 1]
+# outputs["energy"] shape: [1, 1]
 # outputs["forces"] shape: [5, 3]
 ```
 
@@ -452,7 +452,7 @@ outputs = model(batch)
 
 Once wrapped, a model plugs directly into the dynamics framework. The
 dynamics integrator calls the wrapper's `forward` method internally via
-`BaseDynamics.compute()`, and the resulting forces and energies are written
+`BaseDynamics.compute()`, and the resulting forces and energy are written
 back to the batch:
 
 ```python

--- a/docs/userguide/zarr_compression.md
+++ b/docs/userguide/zarr_compression.md
@@ -52,7 +52,7 @@ The toolkit organises Zarr arrays into three logical groups:
 | Group | Contents | Default compression |
 |-------|----------|---------------------|
 | `meta` | Pointer arrays (`atoms_ptr`, `edges_ptr`), validity mask | None |
-| `core` | Positions, forces, energies, atomic numbers, cell, pbc | None |
+| `core` | Positions, forces, energy, atomic numbers, cell, pbc | None |
 | `custom` | User-added arrays via `AtomicData.custom` | None |
 
 {py:class}`~nvalchemi.data.datapipes.ZarrWriteConfig` lets you set different
@@ -167,9 +167,9 @@ The following table gives concrete values for common arrays:
 | positions `[V, 3]` | 3 | float32 | 12 | 83,333 | 333,333 |
 | forces `[V, 3]` | 3 | float32 | 12 | 83,333 | 333,333 |
 | atomic_numbers `[V]` | 1 | int64 | 8 | 125,000 | 500,000 |
-| energies `[B]` | 1 | float64 | 8 | 125,000 | 500,000 |
+| energy `[B]` | 1 | float64 | 8 | 125,000 | 500,000 |
 | cell `[B, 3, 3]` | 9 | float32 | 36 | 27,778 | 111,111 |
-| edge_index `[2, E]` | 2 | int64 | 16 | 62,500 | 250,000 |
+| neighbor_list `[2, E]` | 2 | int64 | 16 | 62,500 | 250,000 |
 | shifts `[E, 3]` | 3 | float32 | 12 | 83,333 | 333,333 |
 
 **Example: positions (float32, shape [V, 3]), 1 MB target**
@@ -181,7 +181,7 @@ $$
 \text{chunk\_size} = \left\lfloor \frac{1{,}000{,}000}{12} \right\rfloor = 83{,}333
 $$
 
-**Example: energies (float64, shape [B]), 1 MB target**
+**Example: energy (float64, shape [B]), 1 MB target**
 
 $$
 \text{bytes\_per\_row} = 1 \times 8 = 8 \text{ bytes}
@@ -211,7 +211,7 @@ Atom-level fields (positions, forces, atomic_numbers) are stored as
 **concatenated** arrays of shape `[V_total, ...]` where `V_total` is the sum of
 atoms across all structures. The `chunk_size` parameter controls the number of
 **rows** in each chunk, not the number of structures. System-level fields
-(energies, cell, pbc) have one row per structure, so `chunk_size` directly equals
+(energy, cell, pbc) have one row per structure, so `chunk_size` directly equals
 the number of structures per chunk.
 ```
 
@@ -229,13 +229,13 @@ the store.
 | positions | [5M, 3] | float32 | 60 MB |
 | forces | [5M, 3] | float32 | 60 MB |
 | atomic_numbers | [5M] | int64 | 40 MB |
-| energies | [100k] | float64 | 0.8 MB |
+| energy | [100k] | float64 | 0.8 MB |
 | cell | [100k, 3, 3] | float32 | 3.6 MB |
 | pbc | [100k, 3] | bool | 0.3 MB |
-| stresses | [100k, 3, 3] | float32 | 3.6 MB |
-| virials | [100k, 3, 3] | float32 | 3.6 MB |
-| dipoles | [100k, 3] | float32 | 1.2 MB |
-| edge_index | [2, 20M] | int64 | 320 MB |
+| stress | [100k, 3, 3] | float32 | 3.6 MB |
+| virial | [100k, 3, 3] | float32 | 3.6 MB |
+| dipole | [100k, 3] | float32 | 1.2 MB |
+| neighbor_list | [2, 20M] | int64 | 320 MB |
 | shifts | [20M, 3] | float32 | 240 MB |
 | metadata (ptrs, masks) | — | mixed | 27 MB |
 | **Total (with edges)** | | | **760 MB** |
@@ -459,7 +459,7 @@ Key options:
 | `--level` | 3 | Compression level |
 | `--chunk-size` | — | Chunk size for node/system arrays |
 | `--shard-size` | — | Shard size for node/system arrays |
-| `--edge-chunk-size` | — | Chunk size for edge arrays (edge_index, shifts) |
+| `--edge-chunk-size` | — | Chunk size for edge arrays (neighbor_list, shifts) |
 | `--edge-shard-size` | — | Shard size for edge arrays |
 
 ### Example output

--- a/docs/userguide/zarr_compression.md
+++ b/docs/userguide/zarr_compression.md
@@ -169,7 +169,7 @@ The following table gives concrete values for common arrays:
 | atomic_numbers `[V]` | 1 | int64 | 8 | 125,000 | 500,000 |
 | energy `[B]` | 1 | float64 | 8 | 125,000 | 500,000 |
 | cell `[B, 3, 3]` | 9 | float32 | 36 | 27,778 | 111,111 |
-| neighbor_list `[2, E]` | 2 | int64 | 16 | 62,500 | 250,000 |
+| neighbor_list `[E, 2]` | 2 | int64 | 16 | 62,500 | 250,000 |
 | shifts `[E, 3]` | 3 | float32 | 12 | 83,333 | 333,333 |
 
 **Example: positions (float32, shape [V, 3]), 1 MB target**
@@ -235,7 +235,7 @@ the store.
 | stress | [100k, 3, 3] | float32 | 3.6 MB |
 | virial | [100k, 3, 3] | float32 | 3.6 MB |
 | dipole | [100k, 3] | float32 | 1.2 MB |
-| neighbor_list | [2, 20M] | int64 | 320 MB |
+| neighbor_list | [20M, 2] | int64 | 320 MB |
 | shifts | [20M, 3] | float32 | 240 MB |
 | metadata (ptrs, masks) | — | mixed | 27 MB |
 | **Total (with edges)** | | | **760 MB** |

--- a/nvalchemi/data/data.py
+++ b/nvalchemi/data/data.py
@@ -309,7 +309,7 @@ class DataMixin:
         if self.neighbor_list is not None:
             if self.neighbor_list.dtype not in [torch.int32, torch.int64]:
                 raise RuntimeError(
-                    ("Expected edge indices of dtype {}, but found dtype  {}").format(
+                    ("Expected neighbor_list of dtype {}, but found dtype  {}").format(
                         torch.int32, self.neighbor_list.dtype
                     )
                 )
@@ -326,7 +326,7 @@ class DataMixin:
             if self.neighbor_list.dim() != 2 or self.neighbor_list.size(1) != 2:
                 raise RuntimeError(
                     (
-                        "Edge indices should have shape [num_edges, 2] but found"
+                        "Neighbor list should have shape [num_edges, 2] but found"
                         " shape {}"
                     ).format(self.neighbor_list.size())
                 )
@@ -340,7 +340,7 @@ class DataMixin:
             if min_index < 0 or max_index > self.num_nodes - 1:
                 raise RuntimeError(
                     (
-                        "Edge indices must lay in the interval [0, {}]"
+                        "Neighbor list indices must lay in the interval [0, {}]"
                         " but found them in the interval [{}, {}]"
                     ).format(self.num_nodes - 1, min_index, max_index)
                 )
@@ -372,7 +372,7 @@ class DataMixin:
             if self.neighbor_list.size(0) != self.edge_attr.size(0):
                 raise RuntimeError(
                     (
-                        "Edge indices and edge attributes hold a differing "
+                        "Neighbor list and edge attributes hold a differing "
                         "number of edges, found {} and {}"
                     ).format(self.neighbor_list.size(), self.edge_attr.size())
                 )

--- a/nvalchemi/data/datapipes/backends/zarr.py
+++ b/nvalchemi/data/datapipes/backends/zarr.py
@@ -389,7 +389,7 @@ class AtomicDataZarrWriter:
             The data to be written (used to determine chunk shape).
         cat_dim : int, optional
             The concatenation axis (variable-length dimension) for chunking.
-            Defaults to 0. For ``neighbor_list`` (stored as ``[2, E]``), use 1.
+            Defaults to 0. For ``neighbor_list`` (stored as ``[E, 2]``), use 0.
 
         Returns
         -------

--- a/nvalchemi/models/base.py
+++ b/nvalchemi/models/base.py
@@ -144,7 +144,7 @@ class ModelConfig(BaseModel):
     gradient_keys: Annotated[
         set[str],
         Field(
-            description="Set of keys to compute gradients for in the `Batch` of `AtomicData` structure..",
+            description="Set of keys to compute gradients for in the `Batch` of `AtomicData` structure.",
             default_factory=set,
         ),
     ]
@@ -257,6 +257,9 @@ class ModelCard(BaseModel):
 # Mapping from output property names (written to AtomicData) to the suffix
 # used for ModelConfig.compute_{suffix} and ModelCard.supports_{suffix}.
 # Used by output_data() to avoid per-call model_dump() serialization.
+# To support a custom output key, add a new entry here AND add the
+# corresponding ``compute_<suffix>`` / ``supports_<suffix>`` fields to
+# ModelConfig / ModelCard.
 _OUTPUT_KEY_TO_CONFIG_SUFFIX: dict[str, str] = {
     "forces": "forces",
     "stress": "stresses",

--- a/nvalchemi/models/base.py
+++ b/nvalchemi/models/base.py
@@ -254,12 +254,8 @@ class ModelCard(BaseModel):
         return self.neighbor_config is not None
 
 
-# Mapping from output property names (written to AtomicData) to the suffix
-# used for ModelConfig.compute_{suffix} and ModelCard.supports_{suffix}.
-# Used by output_data() to avoid per-call model_dump() serialization.
-# To support a custom output key, add a new entry here AND add the
-# corresponding ``compute_<suffix>`` / ``supports_<suffix>`` fields to
-# ModelConfig / ModelCard.
+# To support a new output key, add an entry here AND the corresponding
+# ``compute_<suffix>`` / ``supports_<suffix>`` fields to ModelConfig / ModelCard.
 _OUTPUT_KEY_TO_CONFIG_SUFFIX: dict[str, str] = {
     "forces": "forces",
     "stress": "stresses",

--- a/test/data/test_data_mixin.py
+++ b/test/data/test_data_mixin.py
@@ -543,7 +543,7 @@ class TestDataMixin:
         """Test debug method with invalid neighbor_list dtype."""
         self.data.neighbor_list = torch.tensor([[0, 1], [1, 2]], dtype=torch.float32)
 
-        with pytest.raises(RuntimeError, match="Expected edge indices of dtype"):
+        with pytest.raises(RuntimeError, match="Expected neighbor_list of dtype"):
             self.data.debug()
 
     def test_debug_method_invalid_edge_index_shape(self):
@@ -553,7 +553,7 @@ class TestDataMixin:
         )  # Wrong shape
 
         with pytest.raises(
-            RuntimeError, match="Edge indices should have shape \\[num_edges, 2\\]"
+            RuntimeError, match="Neighbor list should have shape \\[num_edges, 2\\]"
         ):
             self.data.debug()
 
@@ -564,7 +564,9 @@ class TestDataMixin:
             [[0, 1], [1, 3]], dtype=torch.long
         )  # Index 3 is out of range
 
-        with pytest.raises(RuntimeError, match="Edge indices must lay in the interval"):
+        with pytest.raises(
+            RuntimeError, match="Neighbor list indices must lay in the interval"
+        ):
             self.data.debug()
 
     def test_debug_method_face_invalid(self):
@@ -585,7 +587,7 @@ class TestDataMixin:
 
         with pytest.raises(
             RuntimeError,
-            match="Edge indices and edge attributes hold a differing number of edges",
+            match="Neighbor list and edge attributes hold a differing number of edges",
         ):
             self.data.debug()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Final PR in the attribute-rename epic (#23). Applies the 10 attribute renames
consistently across all documentation, skills files, and README.md. Also includes
three minor source code fixes identified during the epic review.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #23

## Changes Made

### Documentation renames (16 files)

Applied 10 attribute renames across all docs, skills, and README:

| Old | New |
|-----|-----|
| `energies` | `energy` |
| `stresses` | `stress` |
| `virials` | `virial` |
| `dipoles` | `dipole` |
| `node_charges` | `charges` |
| `graph_charges` | `charge` |
| `edge_index` | `neighbor_list` |
| `.batch` (attribute) | `.batch_idx` |
| `.ptr` (attribute) | `.batch_ptr` |

`graph_spins` -> `spin` had 0 matches.

**Files**: 6 skills SKILL.md, README.md, 7 docs/userguide .md files, 2 docs/modules/dynamics .rst files.

**Intentionally NOT changed**:
- `docs/model_card_ext.py` — all 8 matches are ModelCard/ModelConfig API field names (`supports_energies`, `compute_stresses`, etc.) which correctly match the source code
- `kinetic_energies` — separate attribute
- `virials_key` — keyword argument name

### Source code fixes (3 files)

- `nvalchemi/models/base.py`: Added developer comment to `_OUTPUT_KEY_TO_CONFIG_SUFFIX` explaining how to extend it for custom output keys; fixed double period typo in `gradient_keys` field description
- `nvalchemi/data/data.py`: Updated 4 `debug()` error messages from "Edge indices" to "Neighbor list"/"neighbor_list"
- `test/data/test_data_mixin.py`: Updated 4 `pytest.raises(match=...)` strings to match new error messages

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

52 data tests pass. No new tests needed — updated existing test match strings.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

This is the third and final PR in the attribute-rename epic:
- **PR #56** (merged): Source code + tests
- **PR #59** (open): Examples
- **This PR**: Documentation, skills, README + minor source fixes

ModelCard/ModelConfig field names (`supports_energies`, `compute_stresses`, `compute_dipoles`, etc.) are intentionally preserved throughout. The `_OUTPUT_KEY_TO_CONFIG_SUFFIX` mapping in `models/base.py` maps new output keys (e.g. `"energy"`) to config suffixes (e.g. `"energies"`), so `_verify_request()` requires these config fields to keep their current names.