### PR TITLE
fix(dynamics): FusedStage single-stage convergence causes duplicate writes and sink overflow

### DIFF
--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -2586,9 +2586,16 @@ class FusedStage(BaseDynamics):
 
         self.fused_hooks: list[Hook] = []
 
-        for i in range(len(self.sub_stages) - 1):
+        for i in range(len(self.sub_stages)):
             source_code, source_dynamics = self.sub_stages[i]
-            target_code, _ = self.sub_stages[i + 1]
+            if i + 1 < len(self.sub_stages):
+                target_code, _ = self.sub_stages[i + 1]
+            else:
+                # The last stage graduates directly to exit_status when it
+                # declares a convergence criterion.
+                if source_dynamics.convergence_hook is None:
+                    continue
+                target_code = self.exit_status
 
             # Remove duplicate migration hooks with the same (source_status, target_status)
             # to prevent double-fire after __add__ reconstruction.
@@ -2849,8 +2856,10 @@ class FusedStage(BaseDynamics):
         if status.dim() == 2:
             status = status.squeeze(-1)
 
+        stage_active_masks: list[torch.Tensor] = []
         for status_code, dynamics in self.sub_stages:
             mask = status == status_code
+            stage_active_masks.append(mask)
             dynamics._call_hooks(DynamicsStage.BEFORE_PRE_UPDATE, batch)
             if mask.any():
                 dynamics._masked_pre_update(batch, mask)
@@ -2916,10 +2925,26 @@ class FusedStage(BaseDynamics):
         if pre_converge_status.dim() == 2:
             pre_converge_status = pre_converge_status.squeeze(-1)
 
-        for _, dynamics in self.sub_stages:
+        for active_mask, (_, dynamics) in zip(
+            stage_active_masks, self.sub_stages, strict=True
+        ):
             converged = dynamics._check_convergence(batch)
-            dynamics._last_converged = converged
-            if converged is not None:
+            if converged is None:
+                dynamics._last_converged = None
+                continue
+
+            stage_converged = torch.zeros(
+                batch.num_graphs, dtype=torch.bool, device=batch.device
+            )
+            stage_converged[converged] = True
+            stage_converged &= active_mask
+
+            if not stage_converged.any():
+                dynamics._last_converged = None
+                continue
+
+            dynamics._last_converged = torch.where(stage_converged)[0]
+            if dynamics._last_converged is not None:
                 dynamics._call_hooks(DynamicsStage.ON_CONVERGE, batch)
 
         self.step_count += 1

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -2944,8 +2944,7 @@ class FusedStage(BaseDynamics):
                 continue
 
             dynamics._last_converged = torch.where(stage_converged)[0]
-            if dynamics._last_converged is not None:
-                dynamics._call_hooks(DynamicsStage.ON_CONVERGE, batch)
+            dynamics._call_hooks(DynamicsStage.ON_CONVERGE, batch)
 
         self.step_count += 1
         for _, dynamics in self.sub_stages:

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -421,8 +421,7 @@ class TestFusedStage:
         conv_hooks_before = [
             h
             for h in dynamics0.hooks
-            if isinstance(h, ConvergenceHook)
-            and h.source_status is not None
+            if isinstance(h, ConvergenceHook) and h.source_status is not None
         ]
 
         FusedStage(sub_stages=[(0, dynamics0)])
@@ -430,8 +429,7 @@ class TestFusedStage:
         conv_hooks_after = [
             h
             for h in dynamics0.hooks
-            if isinstance(h, ConvergenceHook)
-            and h.source_status is not None
+            if isinstance(h, ConvergenceHook) and h.source_status is not None
         ]
         assert len(conv_hooks_after) == len(conv_hooks_before)
 

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -38,6 +38,8 @@ from nvalchemi.dynamics.base import (
     Hook,
     _CommunicationMixin,
 )
+from nvalchemi.dynamics.hooks import ConvergedSnapshotHook
+from nvalchemi.dynamics.sinks import HostMemory
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.models.base import BaseModelMixin, ModelCard
 from nvalchemi.models.demo import DemoModelWrapper
@@ -395,6 +397,63 @@ class TestFusedStage:
 
         # All should have migrated to status=1 via auto-registered ConvergenceHook
         assert (batch.status == 1).all()
+
+    def test_single_stage_auto_registers_migration_hook(self) -> None:
+        """Single-stage FusedStage with convergence_hook auto-registers 0 -> exit_status."""
+        dynamics0 = BaseDynamics(
+            model=self.model,
+            convergence_hook=ConvergenceHook.from_fmax(1e6),
+        )
+
+        fused = FusedStage(sub_stages=[(0, dynamics0)])
+
+        batch = create_batch_with_status(n_graphs=3)
+        batch.status = torch.tensor([0, 0, 0])
+
+        fused.step(batch)
+
+        assert (batch.status == fused.exit_status).all()
+
+    def test_single_stage_no_convergence_hook_skips_auto_registration(self) -> None:
+        """Single-stage FusedStage without convergence_hook skips migration hook."""
+        dynamics0 = BaseDynamics(model=self.model)
+
+        conv_hooks_before = [
+            h
+            for h in dynamics0.hooks
+            if isinstance(h, ConvergenceHook)
+            and h.source_status is not None
+        ]
+
+        FusedStage(sub_stages=[(0, dynamics0)])
+
+        conv_hooks_after = [
+            h
+            for h in dynamics0.hooks
+            if isinstance(h, ConvergenceHook)
+            and h.source_status is not None
+        ]
+        assert len(conv_hooks_after) == len(conv_hooks_before)
+
+    def test_single_stage_converged_snapshot_no_overflow(self) -> None:
+        """ConvergedSnapshotHook must not overflow when converged samples graduate."""
+        n_graphs = 3
+        sink = HostMemory(capacity=n_graphs)
+        dynamics0 = BaseDynamics(
+            model=self.model,
+            convergence_hook=ConvergenceHook.from_fmax(1e6),
+            hooks=[ConvergedSnapshotHook(sink=sink)],
+        )
+
+        fused = FusedStage(sub_stages=[(0, dynamics0)])
+
+        batch = create_batch_with_status(n_graphs=n_graphs)
+        batch.status = torch.tensor([0, 0, 0])
+
+        for _ in range(3):
+            fused.step(batch)
+
+        assert len(sink) == n_graphs
 
     def test_all_complete_true(self) -> None:
         """all_complete should return True when all samples at exit status."""
@@ -1472,6 +1531,51 @@ class TestFusedStageSubstageHooks:
         fused.step(batch)
 
         assert hook.call_count == 0
+
+    def test_on_converge_only_fires_for_active_samples(self) -> None:
+        """ON_CONVERGE converged_mask should only include samples active in that stage.
+
+        Two-stage FusedStage where both stages use high-threshold convergence.
+        Samples [0,1] are at status 0, sample [2] at status 1.
+        Stage-0's ON_CONVERGE mask must be [True, True, False],
+        stage-1's ON_CONVERGE mask must be [False, False, True].
+        """
+
+        class _MaskCapture:
+            stage = DynamicsStage.ON_CONVERGE
+            frequency = 1
+
+            def __init__(self) -> None:
+                self.masks: list[torch.Tensor] = []
+
+            def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+                self.masks.append(ctx.converged_mask.clone())
+
+        dynamics0 = BaseDynamics(
+            model=self.model,
+            convergence_hook=ConvergenceHook.from_fmax(1e6),
+        )
+        dynamics1 = BaseDynamics(
+            model=self.model,
+            convergence_hook=ConvergenceHook.from_fmax(1e6),
+        )
+
+        cap0 = _MaskCapture()
+        cap1 = _MaskCapture()
+        dynamics0.register_hook(cap0)
+        dynamics1.register_hook(cap1)
+
+        fused = FusedStage(sub_stages=[(0, dynamics0), (1, dynamics1)])
+
+        batch = create_batch_with_status(n_graphs=3)
+        batch.status = torch.tensor([0, 0, 1])
+
+        fused.step(batch)
+
+        assert len(cap0.masks) == 1
+        assert cap0.masks[0].tolist() == [True, True, False]
+        assert len(cap1.masks) == 1
+        assert cap1.masks[0].tolist() == [False, False, True]
 
     def test_non_applicable_stages_not_fired(self) -> None:
         """BEFORE_COMPUTE, AFTER_PRE_UPDATE, and BEFORE_POST_UPDATE should NOT fire on substages.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

When a `FusedStage` has a single sub-stage (or when the last sub-stage declares a `convergence_hook`), no migration hook was auto-registered to graduate converged samples to `exit_status`. This caused `ConvergedSnapshotHook` to write the same converged samples on every subsequent step, eventually overflowing bounded sinks like `HostMemory`. Additionally, `ON_CONVERGE` hooks could fire for samples that were not active in the corresponding sub-stage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes https://github.com/NVIDIA/nvalchemi-toolkit/issues/62

## Changes Made

- Extended `FusedStage.__init__` auto-registration loop from `range(len(sub_stages) - 1)` to `range(len(sub_stages))` so the last sub-stage gets a migration hook to `exit_status` when it declares a `convergence_hook`
- Captured `stage_active_masks` during the pre-update phase and intersected them with convergence results in `_step_impl`, ensuring `ON_CONVERGE` hooks only fire for samples that belong to the corresponding sub-stage
- Added four new tests: single-stage auto-registration, skip when no convergence hook, end-to-end snapshot no-overflow, and active-sample-only ON_CONVERGE mask verification

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

All 84 tests in `test/dynamics/test_single_loop.py` pass (including 4 new), plus 132 tests in `test_inflight.py`, `test_observer_hooks.py`, and `test_demo_dynamics.py` with zero regressions.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The reproduction script `repro_fusedstage_duplicate_converged_writes.py` (untracked) confirms the fix: the "bad" scenario no longer overflows.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.