### PR TITLE
feat(hooks): lift general hooks out of dynamics namespace

### DIFF
--- a/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
@@ -13,17 +13,22 @@ The hook system is framework-wide: the same `Hook` protocol works for
 dynamics and custom pipelines — only the stage enum changes.
 
 ```python
-from nvalchemi.hooks import Hook, HookContext, HookRegistryMixin
+from nvalchemi.hooks import (
+    BiasedPotentialHook,
+    Hook,
+    HookContext,
+    HookRegistryMixin,
+    NeighborListHook,
+    WrapPeriodicHook,
+)
 from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.dynamics.hooks import (
-    BiasedPotentialHook,
     EnergyDriftMonitorHook,
     LoggingHook,
     MaxForceClampHook,
     NaNDetectorHook,
     ProfilerHook,
     SnapshotHook,
-    WrapPeriodicHook,
 )
 ```
 
@@ -35,8 +40,8 @@ Any object with these attributes satisfies the `Hook` protocol (runtime-checkabl
 
 ```python
 class Hook(Protocol):
-    frequency: int   # execute every N steps (1 = every step)
-    stage: Enum      # stage enum value at which this hook runs
+    frequency: int        # execute every N steps (1 = every step)
+    stage: Enum | None    # stage enum value (None for stage-agnostic hooks)
 
     def __call__(self, ctx: HookContext, stage: Enum) -> None:
         """Called with a context snapshot and the current stage."""
@@ -55,6 +60,7 @@ class HookContext:
     model: BaseModelMixin | None = None
     converged_mask: Tensor | None = None      # dynamics only
     global_rank: int = 0                      # distributed rank
+    workflow: Any = None                      # back-reference to the engine
 ```
 
 Access batch data via `ctx.batch`, step info via `ctx.step_count`, etc.
@@ -67,7 +73,7 @@ Access batch data via `ctx.batch`, step info via `ctx.step_count`, etc.
 
 Each `step()` call fires hooks at 9 stages in this order:
 
-```
+```text
 BEFORE_STEP (0)
   BEFORE_PRE_UPDATE (1)  →  pre_update()  →  AFTER_PRE_UPDATE (2)
   BEFORE_COMPUTE (3)     →  compute()      →  AFTER_COMPUTE (4)
@@ -153,6 +159,7 @@ def my_bias(batch: Batch) -> tuple[torch.Tensor, torch.Tensor]:
 
 BiasedPotentialHook(
     bias_fn=my_bias,
+    stage=DynamicsStage.AFTER_COMPUTE,
     frequency=1,
 )
 ```
@@ -201,7 +208,7 @@ EnergyDriftMonitorHook(
 **WrapPeriodicHook** — wrap positions back into the unit cell.
 
 ```python
-WrapPeriodicHook(frequency=10)  # wrap every 10 steps
+WrapPeriodicHook(frequency=10, stage=DynamicsStage.AFTER_POST_UPDATE)
 ```
 
 ### Profiling hook (multi-stage, uses plum dispatch)
@@ -324,13 +331,13 @@ Register hooks in this order for correct behavior:
 ```python
 hooks = [
     # 1. Bias (modifies forces/energy)
-    BiasedPotentialHook(bias_fn=my_bias),
+    BiasedPotentialHook(bias_fn=my_bias, stage=DynamicsStage.AFTER_COMPUTE),
     # 2. Safety (clamp after all force modifications)
     MaxForceClampHook(max_force=10.0),
     # 3. NaN detection (check final forces)
     NaNDetectorHook(),
     # 4. Periodic wrapping
-    WrapPeriodicHook(frequency=10),
+    WrapPeriodicHook(frequency=10, stage=DynamicsStage.AFTER_POST_UPDATE),
     # 5. Observers (read final state)
     LoggingHook(frequency=100),
     SnapshotHook(sink=my_sink, frequency=50),

--- a/docs/modules/dynamics/hooks.rst
+++ b/docs/modules/dynamics/hooks.rst
@@ -189,7 +189,7 @@ These hooks prepare the batch **before** the model forward pass.
 
    * - Hook
      - Purpose
-   * - :class:`~nvalchemi.dynamics.hooks.NeighborListHook`
+   * - :class:`~nvalchemi.hooks.NeighborListHook`
      - Compute or refresh the neighbor list (``MATRIX`` or ``COO``
        format) with optional Verlet-skin buffering to skip redundant
        rebuilds.
@@ -245,11 +245,11 @@ These hooks modify the batch **after** the model forward pass and
    * - :class:`~nvalchemi.dynamics.hooks.MaxForceClampHook`
      - Clamp per-atom force magnitudes to a safe maximum,
        preserving force direction. Prevents numerical explosions.
-   * - :class:`~nvalchemi.dynamics.hooks.BiasedPotentialHook`
+   * - :class:`~nvalchemi.hooks.BiasedPotentialHook`
      - Add an external bias potential (energy + forces) for
        enhanced sampling: umbrella sampling, metadynamics,
        steered MD, harmonic restraints, wall potentials.
-   * - :class:`~nvalchemi.dynamics.hooks.WrapPeriodicHook`
+   * - :class:`~nvalchemi.hooks.WrapPeriodicHook`
      - Wrap atomic positions back into the unit cell under PBC.
        Fires at ``AFTER_POST_UPDATE``, respects per-system
        ``batch.pbc`` flags.
@@ -322,7 +322,8 @@ Enhanced sampling with a bias potential
 
 .. code-block:: python
 
-   from nvalchemi.dynamics.hooks import BiasedPotentialHook
+   from nvalchemi.hooks import BiasedPotentialHook
+   from nvalchemi.dynamics.base import DynamicsStage
 
    def harmonic_restraint(batch):
        """Restrain center of mass to the origin."""
@@ -332,7 +333,7 @@ Enhanced sampling with a bias potential
        bias_forces = -k * com.expand_as(batch.positions) / batch.num_nodes
        return bias_energy, bias_forces
 
-   hook = BiasedPotentialHook(bias_fn=harmonic_restraint)
+   hook = BiasedPotentialHook(bias_fn=harmonic_restraint, stage=DynamicsStage.AFTER_COMPUTE)
    dynamics = DemoDynamics(model=model, dt=0.5, hooks=[hook])
 
 Profiling with Nsight Systems

--- a/docs/userguide/about/faq.md
+++ b/docs/userguide/about/faq.md
@@ -26,7 +26,7 @@ See the [installation guide](install) for full prerequisites.
 
 ### How do I compute neighbor lists during a simulation?
 
-Register a {class}`~nvalchemi.dynamics.hooks.NeighborListHook` on your dynamics
+Register a {class}`~nvalchemi.hooks.NeighborListHook` on your dynamics
 engine. The hook recomputes neighbors at the `BEFORE_COMPUTE` stage of every
 step (with optional Verlet-skin buffering to skip redundant rebuilds). See the
 [dynamics hooks user guide](../dynamics_hooks) and the

--- a/docs/userguide/about/intro.md
+++ b/docs/userguide/about/intro.md
@@ -149,7 +149,7 @@ ALCHEMI Toolkit is organized into a small set of tightly integrated modules:
 | [Data loading](datapipes_guide) | Zarr-backed I/O with CUDA-stream prefetching | {py:class}`~nvalchemi.data.datapipes.AtomicDataZarrWriter`, {py:class}`~nvalchemi.data.datapipes.Reader`, {py:class}`~nvalchemi.data.datapipes.Dataset`, {py:class}`~nvalchemi.data.datapipes.DataLoader` |
 | [Models](models_guide) | Unified MLIP interface and model composition | {py:class}`~nvalchemi.models.base.BaseModelMixin`, {py:class}`~nvalchemi.models.base.ModelCard`, {py:class}`~nvalchemi.models.composable.ComposableModelWrapper` |
 | [Dynamics](dynamics_guide) | Integrators, hooks, and simulation orchestration | {py:class}`~nvalchemi.dynamics.base.BaseDynamics`, {py:class}`~nvalchemi.dynamics.base.FusedStage`, {py:class}`~nvalchemi.dynamics.base.DistributedPipeline` |
-| [Hooks](dynamics_hooks_guide) | Pluggable callbacks at nine points per step | {py:class}`~nvalchemi.dynamics.base.Hook`, {py:class}`~nvalchemi.dynamics.hooks.NeighborListHook`, {py:class}`~nvalchemi.dynamics.hooks.SnapshotHook` |
+| [Hooks](dynamics_hooks_guide) | Pluggable callbacks at nine points per step | {py:class}`~nvalchemi.hooks.Hook`, {py:class}`~nvalchemi.hooks.NeighborListHook`, {py:class}`~nvalchemi.dynamics.hooks.SnapshotHook` |
 | [Data sinks](dynamics_sinks_guide) | Trajectory capture to GPU buffer, host memory, or disk | {py:class}`~nvalchemi.dynamics.sinks.GPUBuffer`, {py:class}`~nvalchemi.dynamics.sinks.HostMemory`, {py:class}`~nvalchemi.dynamics.sinks.ZarrData` |
 
 ## What's Next?

--- a/examples/advanced/01_biased_potential.py
+++ b/examples/advanced/01_biased_potential.py
@@ -23,7 +23,7 @@ a barrier — are rare events on MD timescales.  **Biased sampling** adds an
 external potential that encourages the system to explore regions it would not
 visit spontaneously.
 
-This example demonstrates the :class:`~nvalchemi.dynamics.hooks.BiasedPotentialHook`
+This example demonstrates the :class:`~nvalchemi.hooks.BiasedPotentialHook`
 by adding a **harmonic center-of-mass (COM) restraint** to a Lennard-Jones
 argon cluster during NVT dynamics.  The restraint keeps the cluster anchored
 near a target position.  In a production umbrella-sampling workflow you would
@@ -33,7 +33,7 @@ windowed histograms with WHAM or MBAR.
 Key concepts demonstrated
 -------------------------
 * Implementing a ``bias_fn(batch) -> (energies, forces)`` closure.
-* Registering :class:`~nvalchemi.dynamics.hooks.BiasedPotentialHook` on
+* Registering :class:`~nvalchemi.hooks.BiasedPotentialHook` on
   :class:`~nvalchemi.dynamics.NVTLangevin`.
 * Comparing COM drift in biased vs. unbiased runs.
 
@@ -55,8 +55,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.dynamics.hooks import BiasedPotentialHook, NeighborListHook
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import BiasedPotentialHook, HookContext, NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -213,8 +212,10 @@ def my_bias_fn(batch: Batch) -> tuple[torch.Tensor, torch.Tensor]:
     return harmonic_com_bias(batch, target_com=target_com, k_spring=k_spring)
 
 
-bias_hook = BiasedPotentialHook(bias_fn=my_bias_fn)
-neighbor_hook = NeighborListHook(model.model_card.neighbor_config)
+bias_hook = BiasedPotentialHook(bias_fn=my_bias_fn, stage=DynamicsStage.AFTER_COMPUTE)
+neighbor_hook = NeighborListHook(
+    model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
 
 nvt_biased = NVTLangevin(
     model=model,
@@ -269,7 +270,11 @@ nvt_unbiased = NVTLangevin(
     n_steps=200,
     random_seed=7,
 )
-nvt_unbiased.register_hook(NeighborListHook(model.model_card.neighbor_config))
+nvt_unbiased.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
 nvt_unbiased.register_hook(_COMRecorder(com_unbiased))
 batch_unbiased = nvt_unbiased.run(batch_unbiased)
 print(f"Unbiased run complete: {nvt_unbiased.step_count} steps")

--- a/examples/advanced/02_custom_hook.py
+++ b/examples/advanced/02_custom_hook.py
@@ -306,9 +306,6 @@ def _make_cluster(n_per_side: int = 2, seed: int = 0) -> AtomicData:
 
 batch = Batch.from_data_list([_make_cluster(n_per_side=4, seed=13)])
 
-batch = nvt.run(batch)
-print(f"System: {batch.num_graphs} graph(s), {batch.num_nodes} atoms total")
-
 rdf_hook = RadialDistributionHook(
     r_min=2.5,
     r_max=10.0,
@@ -330,6 +327,9 @@ nvt = NVTLangevin(
 )
 nvt.register_hook(neighbor_hook)
 nvt.register_hook(rdf_hook)
+
+print(f"System: {batch.num_graphs} graph(s), {batch.num_nodes} atoms total")
+batch = nvt.run(batch)
 
 print(f"\nRun complete: {nvt.step_count} steps, {rdf_hook.n_samples} RDF snapshots")
 rdf_hook.save_rdf()

--- a/examples/advanced/02_custom_hook.py
+++ b/examples/advanced/02_custom_hook.py
@@ -58,8 +58,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.dynamics.hooks import NeighborListHook
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import HookContext, NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)

--- a/examples/advanced/03_custom_convergence.py
+++ b/examples/advanced/03_custom_convergence.py
@@ -45,8 +45,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import FIRE
 from nvalchemi.dynamics.base import ConvergenceHook, DynamicsStage
-from nvalchemi.dynamics.hooks import NeighborListHook
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import HookContext, NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -230,7 +229,11 @@ fire = FIRE(
     n_steps=500,
     convergence_hook=dual_custom_hook,
 )
-fire.register_hook(NeighborListHook(model.model_card.neighbor_config))
+fire.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
 
 
 class _LogHook:

--- a/examples/advanced/04_mace_nvt.py
+++ b/examples/advanced/04_mace_nvt.py
@@ -34,7 +34,7 @@ Key concepts demonstrated
 --------------------------
 * Loading a MACE model via ``MACEWrapper.from_checkpoint``.
 * Reading ``model.model_card.neighbor_config`` to wire a
-  :class:`~nvalchemi.dynamics.hooks.NeighborListHook` automatically —
+   :class:`~nvalchemi.hooks.NeighborListHook` automatically —
   the same code works for LJ (MATRIX format) and MACE (COO format).
 * Model-agnostic temperature and energy observation.
 
@@ -64,11 +64,12 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
-from nvalchemi.dynamics.hooks import NeighborListHook
+from nvalchemi.dynamics.base import DynamicsStage
 
 # KB_EV and kinetic_energy_per_graph are internal helpers used by the built-in
 # integrators.  A stable public re-export may be added in a future release.
 from nvalchemi.dynamics.hooks._utils import KB_EV, kinetic_energy_per_graph
+from nvalchemi.hooks import NeighborListHook
 
 logging.basicConfig(level=logging.INFO)
 
@@ -115,14 +116,16 @@ if not USE_MACE:
 # ----------------------------------------------
 # :attr:`~nvalchemi.models.base.ModelCard.neighbor_config` encodes the cutoff,
 # list format (COO or MATRIX), and whether to use a half-list.
-# :class:`~nvalchemi.dynamics.hooks.NeighborListHook` reads this automatically.
+# :class:`~nvalchemi.hooks.NeighborListHook` reads this automatically.
 #
 # If ``neighbor_config`` is ``None`` (e.g. a demo model that does its own
 # neighbour search), no hook is needed.
 
 neighbor_hook = None
 if model.model_card.neighbor_config is not None:
-    neighbor_hook = NeighborListHook(model.model_card.neighbor_config)
+    neighbor_hook = NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
     print(
         f"Wired NeighborListHook: format={model.model_card.neighbor_config.format.name}, "
         f"cutoff={model.model_card.neighbor_config.cutoff:.2f} Å"

--- a/examples/advanced/04_mace_nvt.py
+++ b/examples/advanced/04_mace_nvt.py
@@ -213,7 +213,6 @@ else:
 
 sim_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 batch = Batch.from_data_list([data], device=sim_device)
-batch = nvt.run(batch)
 print(f"\nSystem: {system_label}  →  {batch.num_nodes} atoms on {sim_device}")
 
 # %%
@@ -235,6 +234,7 @@ if neighbor_hook is not None:
     nvt.register_hook(neighbor_hook)
 
 print("\nRunning 100 NVT steps …")
+batch = nvt.run(batch)
 print(f"Run complete: {nvt.step_count} steps")
 
 # %%

--- a/examples/advanced/05_custom_integrator.py
+++ b/examples/advanced/05_custom_integrator.py
@@ -60,12 +60,11 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.dynamics.hooks import NeighborListHook
 
 # KB_EV and kinetic_energy_per_graph are internal helpers used by the built-in
 # integrators.  A stable public re-export may be added in a future release.
 from nvalchemi.dynamics.hooks._utils import KB_EV, kinetic_energy_per_graph
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import HookContext, NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -284,7 +283,11 @@ integrator = VelocityRescalingThermostat(
     temperature=T_RESCALE,
     n_steps=n_steps,
 )
-integrator.register_hook(NeighborListHook(model.model_card.neighbor_config))
+integrator.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
 integrator.register_hook(_TempLogger("VR", temps_rescaling, frequency=20))
 
 batch_vr = integrator.run(batch_vr)
@@ -314,7 +317,11 @@ langevin = NVTLangevin(
     n_steps=n_steps,
     random_seed=42,
 )
-langevin.register_hook(NeighborListHook(model.model_card.neighbor_config))
+langevin.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
 langevin.register_hook(_TempLogger("NVT", temps_langevin, frequency=20))
 
 batch_nvt = langevin.run(batch_nvt)

--- a/examples/advanced/06_ewald_electrostatics.py
+++ b/examples/advanced/06_ewald_electrostatics.py
@@ -65,7 +65,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.dynamics.hooks import NeighborListHook
+from nvalchemi.hooks import NeighborListHook
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.models.ewald import EwaldModelWrapper
 
@@ -171,9 +171,11 @@ print(
 # Building the neighbor list and evaluating energy + forces
 # ----------------------------------------------------------
 # For a one-shot energy evaluation, build the neighbor list manually using
-# :class:`~nvalchemi.dynamics.hooks.NeighborListHook` outside the dynamics loop.
+# :class:`~nvalchemi.hooks.NeighborListHook` outside the dynamics loop.
 
-nl_hook = NeighborListHook(model.model_card.neighbor_config)
+nl_hook = NeighborListHook(
+    model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
 # Create a minimal HookContext for one-time neighbor list build
 ctx = HookContext(
     batch=batch,

--- a/examples/advanced/07_composable_model_composition.py
+++ b/examples/advanced/07_composable_model_composition.py
@@ -57,7 +57,7 @@ Key concepts demonstrated
   sub-model with a single assignment.
 * :meth:`~nvalchemi.models.base.BaseModelMixin.make_neighbor_hooks` —
   returns a list with one correctly-configured
-  :class:`~nvalchemi.dynamics.hooks.NeighborListHook`.
+   :class:`~nvalchemi.hooks.NeighborListHook`.
 * Chaining three or more models — ``a + b + c`` flattens into one wrapper.
 """
 
@@ -70,7 +70,9 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
-from nvalchemi.dynamics.hooks import LoggingHook, WrapPeriodicHook
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.dynamics.hooks import LoggingHook
+from nvalchemi.hooks import WrapPeriodicHook
 from nvalchemi.models.ewald import EwaldModelWrapper
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
@@ -211,7 +213,7 @@ print(
 # -----------------------------------------
 # :meth:`~nvalchemi.models.composable.ComposableModelWrapper.make_neighbor_hooks`
 # returns a list containing exactly one
-# :class:`~nvalchemi.dynamics.hooks.NeighborListHook` configured for the
+# :class:`~nvalchemi.hooks.NeighborListHook` configured for the
 # combined model's effective cutoff (max of all sub-model cutoffs).
 # Registering this single hook is all that is needed — the neighbor data
 # is shared between both sub-models via
@@ -228,7 +230,7 @@ nvt = NVTLangevin(
 
 for hook in combined.make_neighbor_hooks():
     nvt.register_hook(hook)
-nvt.register_hook(WrapPeriodicHook())
+nvt.register_hook(WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE))
 
 # %%
 # Running and logging

--- a/examples/basic/02_geometry_optimization.py
+++ b/examples/basic/02_geometry_optimization.py
@@ -27,7 +27,7 @@ toward the net force direction.  FIRE often converges faster than steepest desce
 robust far from equilibrium, making it practical for batched relaxation
 campaigns where many systems must be processed in an ML-potential workflow.
 
-A :class:`~nvalchemi.dynamics.hooks.NeighborListHook` is registered on the
+A :class:`~nvalchemi.hooks.NeighborListHook` is registered on the
 optimizer so that the dense neighbor matrix is recomputed (or read from a
 Verlet skin cache) before every model forward pass.  Without this hook the
 model would always see a stale neighbor list.
@@ -49,8 +49,9 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import FIRE
-from nvalchemi.dynamics.base import ConvergenceHook
-from nvalchemi.dynamics.hooks import LoggingHook, NeighborListHook
+from nvalchemi.dynamics.base import ConvergenceHook, DynamicsStage
+from nvalchemi.dynamics.hooks import LoggingHook
+from nvalchemi.hooks import NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 # %%
@@ -83,7 +84,9 @@ model = LennardJonesModelWrapper(
     max_neighbors=MAX_NEIGHBORS,
 )
 
-neighbor_hook = NeighborListHook(model.model_card.neighbor_config)
+neighbor_hook = NeighborListHook(
+    model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
 
 
 # %%

--- a/examples/basic/04_nve_energy_conservation.py
+++ b/examples/basic/04_nve_energy_conservation.py
@@ -29,7 +29,7 @@ This example:
   intervals to demonstrate energy conservation.
 * Optionally plots E(t) vs step (set ``NVALCHEMI_PLOT=1`` to enable).
 
-A :class:`~nvalchemi.dynamics.hooks.WrapPeriodicHook` folds atom positions
+A :class:`~nvalchemi.hooks.WrapPeriodicHook` folds atom positions
 back into the unit cell at every step, preventing coordinates from drifting
 far from the origin.  An
 :class:`~nvalchemi.dynamics.hooks.EnergyDriftMonitorHook` warns if the
@@ -46,12 +46,12 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVE
+from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.dynamics.hooks import (
     EnergyDriftMonitorHook,
     LoggingHook,
-    NeighborListHook,
-    WrapPeriodicHook,
 )
+from nvalchemi.hooks import NeighborListHook, WrapPeriodicHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -148,21 +148,25 @@ print(
 #
 # Three hooks are registered:
 #
-# * :class:`~nvalchemi.dynamics.hooks.NeighborListHook` — rebuilds the dense
+# * :class:`~nvalchemi.hooks.NeighborListHook` — rebuilds the dense
 #   neighbor matrix when any atom has moved more than ``skin/2`` since the
 #   last build (Verlet skin = 0.5 Å by default, so rebuild triggers at >0.25 Å
 #   displacement).  A larger skin reduces rebuild frequency (faster) at the
 #   cost of a larger memory footprint; smaller skin is more memory-efficient
 #   but rebuilds more often.
-# * :class:`~nvalchemi.dynamics.hooks.WrapPeriodicHook` — folds positions back
+# * :class:`~nvalchemi.hooks.WrapPeriodicHook` — folds positions back
 #   into the simulation cell after each position update.
 # * :class:`~nvalchemi.dynamics.hooks.EnergyDriftMonitorHook` — checks
 #   per-atom-per-step drift every step and emits a warning if it exceeds 1e-4 eV.
 
 nve = NVE(model=model, dt=1.0, n_steps=200)
 
-nve.register_hook(NeighborListHook(model.model_card.neighbor_config))
-nve.register_hook(WrapPeriodicHook())
+nve.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
+nve.register_hook(WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE))
 nve.register_hook(
     EnergyDriftMonitorHook(
         threshold=1e-4,

--- a/examples/basic/05_nvt_langevin.py
+++ b/examples/basic/05_nvt_langevin.py
@@ -50,7 +50,7 @@ This example:
 
     Periodic-boundary NVE energy conservation is demonstrated in
     ``04_nve_energy_conservation.py``.  This example intentionally omits
-    ``pbc`` and :class:`~nvalchemi.dynamics.hooks.WrapPeriodicHook` to keep
+    ``pbc`` and :class:`~nvalchemi.hooks.WrapPeriodicHook` to keep
     the focus on Langevin thermalization rather than periodic geometry.
 """
 
@@ -63,7 +63,9 @@ from loguru import logger
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
-from nvalchemi.dynamics.hooks import LoggingHook, NeighborListHook
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.dynamics.hooks import LoggingHook
+from nvalchemi.hooks import NeighborListHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 # %%
@@ -184,7 +186,11 @@ nvt = NVTLangevin(
     n_steps=500,
 )
 
-nvt.register_hook(NeighborListHook(model.model_card.neighbor_config))
+nvt.register_hook(
+    NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+)
 
 with LoggingHook(backend="custom", writer_fn=_loguru_writer, frequency=20) as log_hook:
     nvt.register_hook(log_hook)

--- a/examples/intermediate/02_trajectory_zarr_io.py
+++ b/examples/intermediate/02_trajectory_zarr_io.py
@@ -55,7 +55,9 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.data.datapipes import AtomicDataZarrReader, DataLoader, Dataset
 from nvalchemi.dynamics import NVTLangevin, ZarrData
-from nvalchemi.dynamics.hooks import NeighborListHook, SnapshotHook, WrapPeriodicHook
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.dynamics.hooks import SnapshotHook
+from nvalchemi.hooks import NeighborListHook, WrapPeriodicHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -69,7 +71,7 @@ logging.basicConfig(level=logging.INFO)
 # is safely inside the 8.5 Å cutoff.
 #
 # The :class:`~nvalchemi.models.lj.LennardJonesModelWrapper` requires
-# a :class:`~nvalchemi.dynamics.hooks.NeighborListHook` to be registered
+# a :class:`~nvalchemi.hooks.NeighborListHook` to be registered
 # on the dynamics engine so that ``batch.neighbor_matrix`` is populated
 # before each model forward pass.
 
@@ -144,8 +146,10 @@ snapshot_hook = SnapshotHook(sink=zarr_sink, frequency=10)
 #    each position update to prevent atoms drifting outside the box.
 # 3. ``SnapshotHook`` — writes to the Zarr sink every 10 steps.
 
-nl_hook = NeighborListHook(model.model_card.neighbor_config)
-wrap_hook = WrapPeriodicHook()
+nl_hook = NeighborListHook(
+    model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
+wrap_hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
 
 nvt = NVTLangevin(
     model=model,

--- a/examples/intermediate/03_npt_barostat_validation.py
+++ b/examples/intermediate/03_npt_barostat_validation.py
@@ -53,8 +53,10 @@ import os
 import torch
 
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.dynamics.hooks import LoggingHook, NeighborListHook, WrapPeriodicHook
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.dynamics.hooks import LoggingHook
 from nvalchemi.dynamics.integrators.npt import NPT
+from nvalchemi.hooks import NeighborListHook, WrapPeriodicHook
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -186,8 +188,10 @@ shared_npt_kwargs = dict(
 
 def run_npt(batch: Batch, label: str, log_path: str) -> tuple[Batch, list[float]]:
     """Run NPT and return (final_batch, list_of_volumes_logged_every_PRINT_EVERY steps)."""
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
-    wrap_hook = WrapPeriodicHook()
+    nl_hook = NeighborListHook(
+        model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+    )
+    wrap_hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
     logger = LoggingHook(backend="csv", log_path=log_path, frequency=PRINT_EVERY)
 
     npt = NPT(**shared_npt_kwargs, n_steps=N_STEPS, hooks=[nl_hook, wrap_hook, logger])

--- a/examples/intermediate/04_inflight_batching.py
+++ b/examples/intermediate/04_inflight_batching.py
@@ -63,7 +63,7 @@ round-trip through the sink.
 
 This example uses :class:`~nvalchemi.models.demo.DemoModelWrapper` (a small
 neural network) so no neighbor list is needed.  For a real LJ or MACE model,
-add :class:`~nvalchemi.dynamics.hooks.NeighborListHook` to each sub-stage.
+add :class:`~nvalchemi.hooks.NeighborListHook` to each sub-stage.
 """
 
 import logging

--- a/examples/intermediate/05_safety_and_monitoring.py
+++ b/examples/intermediate/05_safety_and_monitoring.py
@@ -53,14 +53,14 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVE, NVTLangevin
+from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.dynamics.hooks import (
     EnergyDriftMonitorHook,
     MaxForceClampHook,
     NaNDetectorHook,
-    NeighborListHook,
     ProfilerHook,
-    WrapPeriodicHook,
 )
+from nvalchemi.hooks import NeighborListHook, WrapPeriodicHook
 from nvalchemi.models.demo import DemoModelWrapper
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
@@ -155,7 +155,9 @@ bad_data.add_node_property("velocities", torch.zeros(2, 3))
 bad_batch = Batch.from_data_list([bad_data])
 
 nan_hook = NaNDetectorHook()
-nl_hook_nan = NeighborListHook(lj_model_nan.model_card.neighbor_config)
+nl_hook_nan = NeighborListHook(
+    lj_model_nan.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
 
 nvt_nan = NVTLangevin(
     model=lj_model_nan,
@@ -193,8 +195,10 @@ clamp_data = _lj_system_bad(n_atoms=8, seed=77, box=5.0)
 clamp_batch = Batch.from_data_list([clamp_data])
 
 clamp_hook = MaxForceClampHook(max_force=10.0)  # eV/Å
-nl_hook_clamp = NeighborListHook(lj_model_clamp.model_card.neighbor_config)
-wrap_hook_clamp = WrapPeriodicHook()
+nl_hook_clamp = NeighborListHook(
+    lj_model_clamp.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
+)
+wrap_hook_clamp = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
 
 nvt_clamp = NVTLangevin(
     model=lj_model_clamp,

--- a/nvalchemi/data/batch.py
+++ b/nvalchemi/data/batch.py
@@ -188,7 +188,7 @@ class Batch(DataMixin):
         Returns a tensor where ``edge_ptr[i] : edge_ptr[i+1]`` is the slice of
         edge rows in ``neighbor_list`` that belong to atom ``i`` (i.e. where atom
         ``i`` is the sender).  Valid only after a COO-format
-        :class:`~nvalchemi.dynamics.hooks.NeighborListHook` has populated the
+        :class:`~nvalchemi.hooks.NeighborListHook` has populated the
         edges group.
 
         An all-zeros pointer of length ``num_nodes + 1`` is returned when the

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -1438,6 +1438,7 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
             model=self.model,
             converged_mask=_mask,
             global_rank=self.global_rank,
+            workflow=self,
         )
 
     def _open_hooks(self) -> None:

--- a/nvalchemi/dynamics/hooks/__init__.py
+++ b/nvalchemi/dynamics/hooks/__init__.py
@@ -34,16 +34,10 @@ Hooks are organized into the following modules:
      - Numerical safety guards (NaN detection, force clamping).
    * - :mod:`monitors`
      - Long-running diagnostic monitors (energy drift).
-   * - :mod:`periodic`
-     - Periodic boundary condition utilities (coordinate wrapping).
    * - :mod:`freeze`
      - Freeze selected atoms by category during dynamics.
-   * - :mod:`bias`
-     - Biased potential hooks for enhanced sampling workflows.
    * - :mod:`profiling`
      - Performance profiling and step timing.
-   * - :mod:`neighbor_list`
-     - On-the-fly neighbor list construction (Verlet skin buffer, matrix format).
 
 All hooks implement the :class:`~nvalchemi.hooks.Hook` protocol and accept
 a :class:`~nvalchemi.hooks.HookContext` plus a stage enum in their
@@ -52,19 +46,14 @@ a :class:`~nvalchemi.hooks.HookContext` plus a stage enum in their
 
 from __future__ import annotations
 
-from nvalchemi.dynamics.hooks.bias import BiasedPotentialHook
 from nvalchemi.dynamics.hooks.freeze import FreezeAtomsHook
 from nvalchemi.dynamics.hooks.logging import LoggingHook
 from nvalchemi.dynamics.hooks.monitors import EnergyDriftMonitorHook
-from nvalchemi.dynamics.hooks.neighbor_list import NeighborListHook
-from nvalchemi.dynamics.hooks.periodic import WrapPeriodicHook
 from nvalchemi.dynamics.hooks.profiling import ProfilerHook
 from nvalchemi.dynamics.hooks.safety import MaxForceClampHook, NaNDetectorHook
 from nvalchemi.dynamics.hooks.snapshot import ConvergedSnapshotHook, SnapshotHook
 
 __all__ = [
-    "BiasedPotentialHook",
-    "NeighborListHook",
     "ConvergedSnapshotHook",
     "EnergyDriftMonitorHook",
     "FreezeAtomsHook",
@@ -73,5 +62,4 @@ __all__ = [
     "NaNDetectorHook",
     "ProfilerHook",
     "SnapshotHook",
-    "WrapPeriodicHook",
 ]

--- a/nvalchemi/dynamics/hooks/_utils.py
+++ b/nvalchemi/dynamics/hooks/_utils.py
@@ -33,11 +33,7 @@ from typing import Literal
 import torch
 import warp as wp
 from jaxtyping import Float
-from nvalchemiops.dynamics.utils import (
-    compute_cell_inverse,
-    compute_kinetic_energy,
-    wrap_positions_to_cell,
-)
+from nvalchemiops.dynamics.utils import compute_kinetic_energy
 from nvalchemiops.segment_ops import (
     segmented_max,
     segmented_mean,
@@ -168,40 +164,6 @@ def _(
     return torch.empty(num_graphs, device=velocities.device, dtype=velocities.dtype)
 
 
-@torch.library.custom_op("nvalchemi_hooks::wrap_positions", mutates_args=())
-def _wrap_positions(
-    positions: torch.Tensor,
-    cell: torch.Tensor,
-    batch_idx: torch.Tensor,
-) -> torch.Tensor:
-    vec_dtype = wp.vec3d if positions.dtype == torch.float64 else wp.vec3f
-    mat_dtype = wp.mat33d if positions.dtype == torch.float64 else wp.mat33f
-
-    # Transpose cell from row-convention (nvalchemi) to column-convention (nvalchemiops)
-    cell_T = cell.transpose(-2, -1).contiguous()
-
-    # Convert to warp arrays
-    num_systems = cell_T.shape[0]
-    wp_pos = wp.from_torch(positions.clone().contiguous(), dtype=vec_dtype)
-    wp_cell = wp.from_torch(cell_T, dtype=mat_dtype)
-    wp_cell_inv = wp.zeros(num_systems, dtype=mat_dtype, device=wp_pos.device)
-    wp_batch_idx = wp.from_torch(batch_idx.to(torch.int32))
-
-    compute_cell_inverse(wp_cell, wp_cell_inv)
-    wrap_positions_to_cell(wp_pos, wp_cell, wp_cell_inv, wp_batch_idx)
-
-    return wp.to_torch(wp_pos)
-
-
-@_wrap_positions.register_fake
-def _(
-    positions: torch.Tensor,
-    cell: torch.Tensor,
-    batch_idx: torch.Tensor,
-) -> torch.Tensor:
-    return torch.empty_like(positions)
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -326,44 +288,3 @@ def temperature_per_graph(
     )  # (B,)
     n_atoms = atoms_per_graph.float()  # (B,)
     return (2.0 * ke) / (3.0 * n_atoms * conversion_factor)
-
-
-def wrap_positions_into_cell(
-    positions: Float[torch.Tensor, "V 3"],
-    cell: Float[torch.Tensor, "B 3 3"],
-    pbc: torch.Tensor,
-    batch_idx: torch.Tensor,
-) -> Float[torch.Tensor, "V 3"]:
-    """Wrap positions into the unit cell using fractional coordinates.
-
-    Respects per-dimension periodicity: only periodic dimensions are
-    wrapped.  Non-periodic dimensions are left unchanged.
-
-    This function modifies ``positions`` **in-place** and returns the
-    same tensor.  Delegates to ``nvalchemiops.dynamics.utils.wrap_positions_to_cell``
-    for GPU-optimized wrapping, then applies per-dimension PBC masking
-    in pure PyTorch.
-
-    Parameters
-    ----------
-    positions : Float[Tensor, "V 3"]
-        Per-atom Cartesian positions. Modified in-place.
-    cell : Float[Tensor, "B 3 3"]
-        Lattice vectors as rows, one ``(3, 3)`` matrix per graph.
-    pbc : Tensor
-        Per-dimension periodicity flags, shape ``(B, 3)``, boolean.
-    batch_idx : Tensor
-        Per-atom graph membership indices of shape ``(V,)``.
-
-    Returns
-    -------
-    Float[Tensor, "V 3"]
-        The same ``positions`` tensor (modified in-place).
-    """
-    original = positions.clone()
-    wrapped = _wrap_positions(positions, cell, batch_idx)
-
-    # Restore non-periodic dimensions
-    per_atom_pbc = pbc[batch_idx]  # (V, 3)
-    positions.copy_(torch.where(per_atom_pbc, wrapped, original))
-    return positions

--- a/nvalchemi/dynamics/hooks/freeze.py
+++ b/nvalchemi/dynamics/hooks/freeze.py
@@ -176,7 +176,7 @@ class FreezeAtomsHook:
             if self.zero_forces:
                 batch.forces.copy_(torch.where(mask, zeros, batch.forces))
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: HookContext, stage: Enum) -> None:
         """Snapshot or restore frozen atom positions."""
         if stage == DynamicsStage.BEFORE_PRE_UPDATE:
             self._saved_positions = ctx.batch.positions.clone()

--- a/nvalchemi/hooks/__init__.py
+++ b/nvalchemi/hooks/__init__.py
@@ -19,9 +19,15 @@ from __future__ import annotations
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.hooks._protocol import Hook
 from nvalchemi.hooks._registry import HookRegistryMixin
+from nvalchemi.hooks.bias import BiasedPotentialHook
+from nvalchemi.hooks.neighbor_list import NeighborListHook
+from nvalchemi.hooks.periodic import WrapPeriodicHook
 
 __all__ = [
+    "BiasedPotentialHook",
     "Hook",
     "HookContext",
     "HookRegistryMixin",
+    "NeighborListHook",
+    "WrapPeriodicHook",
 ]

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -52,6 +52,10 @@ class HookContext:
         Current epoch number (training only).
     global_rank : int
         Distributed rank of this process.
+    workflow : Any
+        Back-reference to the engine running the hooks (e.g. a
+        ``BaseDynamics`` instance).  ``None`` when the workflow does
+        not inject itself.
     """
 
     batch: Batch
@@ -64,3 +68,4 @@ class HookContext:
     converged_mask: torch.Tensor | None = None
     epoch: int | None = None
     global_rank: int = 0
+    workflow: Any = None

--- a/nvalchemi/hooks/_protocol.py
+++ b/nvalchemi/hooks/_protocol.py
@@ -31,12 +31,14 @@ class Hook(Protocol):
     ----------
     frequency : int
         How often the hook runs (every N steps).
-    stage : Enum
-        The stage enum value at which this hook runs.
+    stage : Enum | None
+        The stage enum value at which this hook runs, or ``None`` for
+        hooks that are stage-agnostic until registered with a specific
+        engine.
     """
 
     frequency: int
-    stage: Enum
+    stage: Enum | None
 
     def __call__(self, ctx: HookContext, stage: Enum) -> None:
         """Execute the hook.

--- a/nvalchemi/hooks/_registry.py
+++ b/nvalchemi/hooks/_registry.py
@@ -86,12 +86,12 @@ class HookRegistryMixin:
             ``_runs_on_stage`` (cross-category hooks that manage their
             own stage dispatch bypass this check).
         """
-        if stage is not None:
-            hook.stage = stage
         if not isinstance(hook.frequency, int) or hook.frequency < 1:
             raise ValueError(
                 f"Hook frequency must be a positive integer, got {hook.frequency}"
             )
+        if stage is not None:
+            hook.stage = stage
         stage_type = self._stage_type
         # Hooks that define ``_runs_on_stage`` handle stage dispatch
         # themselves (e.g. cross-category hooks); skip the type check.

--- a/nvalchemi/hooks/_registry.py
+++ b/nvalchemi/hooks/_registry.py
@@ -61,24 +61,33 @@ class HookRegistryMixin:
             for hook in hooks:
                 self.register_hook(hook)
 
-    def register_hook(self, hook: Hook) -> None:
+    def register_hook(self, hook: Hook, stage: Enum | None = None) -> None:
         """Register a hook.
 
         Parameters
         ----------
         hook : Hook
             Hook to register.
+        stage : Enum | None
+            If provided, assigns ``hook.stage = stage`` before
+            validation. This allows stage-agnostic hooks (constructed
+            with ``stage=None``) to receive their stage at registration
+            time.
 
         Raises
         ------
         ValueError
             If ``hook.frequency`` is not a positive integer.
         TypeError
-            If ``hook.stage`` is not an instance of the accepted
-            ``_stage_type`` declared on the engine **and** the hook does
-            not define ``_runs_on_stage`` (cross-category hooks that
-            manage their own stage dispatch bypass this check).
+            If ``hook.stage`` is ``None`` after assignment and the hook
+            does not define ``_runs_on_stage``, or if ``hook.stage`` is
+            not an instance of the accepted ``_stage_type`` declared on
+            the engine **and** the hook does not define
+            ``_runs_on_stage`` (cross-category hooks that manage their
+            own stage dispatch bypass this check).
         """
+        if stage is not None:
+            hook.stage = stage
         if not isinstance(hook.frequency, int) or hook.frequency < 1:
             raise ValueError(
                 f"Hook frequency must be a positive integer, got {hook.frequency}"
@@ -87,9 +96,15 @@ class HookRegistryMixin:
         # Hooks that define ``_runs_on_stage`` handle stage dispatch
         # themselves (e.g. cross-category hooks); skip the type check.
         has_custom_dispatch = getattr(hook, "_runs_on_stage", None) is not None
+        if hook.stage is None and not has_custom_dispatch:
+            raise TypeError(
+                f"Hook {type(hook).__name__} has no stage assigned. "
+                f"Pass stage= to the hook constructor or to register_hook()."
+            )
         if (
             stage_type is not None
             and not has_custom_dispatch
+            and hook.stage is not None
             and not isinstance(hook.stage, stage_type)
         ):
             expected = (

--- a/nvalchemi/hooks/bias.py
+++ b/nvalchemi/hooks/bias.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 import torch
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.hooks._context import HookContext
 
 if TYPE_CHECKING:
@@ -83,9 +82,9 @@ class BiasedPotentialHook:
         current batch.  Must return a tuple of
         ``(bias_energy, bias_forces)`` with shapes ``(B, 1)`` and
         ``(V, 3)`` respectively, on the same device as the batch.
-    stage : Enum, optional
-        The stage at which to run this hook. Default is
-        ``DynamicsStage.AFTER_COMPUTE``.
+    stage : Enum | None, optional
+        The stage at which to run this hook. Default is ``None``
+        (stage-agnostic until registered with a specific engine).
     frequency : int, optional
         Apply the bias every ``frequency`` steps. Default ``1``
         (every step).
@@ -99,15 +98,15 @@ class BiasedPotentialHook:
         The bias potential function.
     frequency : int
         Bias application frequency in steps.
-    stage : Enum
-        The stage at which this hook fires (default ``AFTER_COMPUTE``).
+    stage : Enum | None
+        The stage at which this hook fires.
 
     Examples
     --------
     Harmonic restraint on center of mass:
 
     >>> import torch
-    >>> from nvalchemi.dynamics.hooks import BiasedPotentialHook
+    >>> from nvalchemi.hooks import BiasedPotentialHook
     >>> def harmonic_restraint(batch):
     ...     # Restrain center of mass to origin with k=10 eV/A^2
     ...     k = 10.0
@@ -137,7 +136,7 @@ class BiasedPotentialHook:
     def __init__(
         self,
         bias_fn: Callable[[Batch], tuple[Energy, Forces]],
-        stage: Enum = DynamicsStage.AFTER_COMPUTE,
+        stage: Enum | None = None,
         frequency: int = 1,
         inplace: bool = True,
     ) -> None:

--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -33,8 +33,8 @@ refreshed each step via ``Tensor.copy_()`` — to avoid per-step dynamic
 allocation inside the ``neighbor_list`` dispatcher.
 
 ``neighbor_list`` selects between ``batch_naive`` (avg < 2000 atoms/system)
-and ``batch_cell_list`` (avg ≥ 2000), see https://nvidia.github.io/nvalchemi-toolkit-ops/userguide/components/neighborlist.html.
-Both paths normally allocate auxiliary tensors on-demand with CPU–GPU syncs
+and ``batch_cell_list`` (avg >= 2000), see https://nvidia.github.io/nvalchemi-toolkit-ops/userguide/components/neighborlist.html.
+Both paths normally allocate auxiliary tensors on-demand with CPU-GPU syncs
 (e.g. ``.item()`` calls). :meth:`NeighborListHook._alloc_nl_kwargs`
 computes these **once** when the batch shape is first seen (or changes)
 and caches them in ``NeighborListHook._buf_nl_kwargs``:
@@ -90,7 +90,6 @@ except ImportError:
     _batch_nl_rebuild_inplace = None
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.models.base import NeighborConfig, NeighborListFormat
 
@@ -135,9 +134,9 @@ class NeighborListHook:
         moved more than ``skin / 2`` since the previous build (requires
         ``nvalchemiops >= 0.4``); set to ``0.0`` (default) to rebuild
         every step.
-    stage : Enum, optional
+    stage : Enum | None, optional
         The workflow stage at which this hook runs.  Defaults to
-        ``DynamicsStage.BEFORE_COMPUTE``.
+        ``None`` (stage-agnostic until registered with a specific engine).
 
     Raises
     ------
@@ -149,7 +148,7 @@ class NeighborListHook:
         self,
         config: NeighborConfig,
         skin: float = 0.0,
-        stage: Enum = DynamicsStage.BEFORE_COMPUTE,
+        stage: Enum | None = None,
     ) -> None:
         self.config = config
         self.skin = skin
@@ -484,7 +483,7 @@ class NeighborListHook:
         device: torch.device,
         dtype: torch.dtype,
     ) -> None:
-        """Pre-allocate algorithm-specific kwargs to remove CPU–GPU syncs.
+        """Pre-allocate algorithm-specific kwargs to remove CPU-GPU syncs.
 
         The ``neighbor_list`` dispatcher normally infers geometry-dependent
         values (shift ranges, cell-list sizes) at call time using ``.item()``
@@ -495,8 +494,8 @@ class NeighborListHook:
 
         Algorithm selection mirrors the dispatcher threshold:
 
-        * ``avg_atoms < 2000`` → ``batch_naive``
-        * ``avg_atoms ≥ 2000`` → ``batch_cell_list``
+        * ``avg_atoms < 2000`` -> ``batch_naive``
+        * ``avg_atoms >= 2000`` -> ``batch_cell_list``
 
         Parameters
         ----------
@@ -526,7 +525,7 @@ class NeighborListHook:
                 alloc_pbc = pbc
             else:
                 # Non-PBC: synthesise a bounding-box cell from current positions
-                # with a 1.5× pad so that position drift during the simulation
+                # with a 1.5x pad so that position drift during the simulation
                 # doesn't overflow the pre-allocated cell-list arrays.
                 expanded_idx = self._buf_batch_idx.unsqueeze(1).expand_as(positions)
                 pos_min = torch.full((B, 3), float("inf"), dtype=dtype, device=device)

--- a/nvalchemi/hooks/periodic.py
+++ b/nvalchemi/hooks/periodic.py
@@ -23,12 +23,95 @@ from __future__ import annotations
 
 from enum import Enum
 
+import torch
+import warp as wp
+from jaxtyping import Float
+from nvalchemiops.dynamics.utils import compute_cell_inverse, wrap_positions_to_cell
+
 from nvalchemi.data import Batch
-from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.dynamics.hooks._utils import wrap_positions_into_cell
 from nvalchemi.hooks._context import HookContext
 
 __all__ = ["WrapPeriodicHook"]
+
+
+# ---------------------------------------------------------------------------
+# Custom op + helper for position wrapping (moved from dynamics/hooks/_utils)
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("nvalchemi_hooks::wrap_positions", mutates_args=())
+def _wrap_positions(
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> torch.Tensor:
+    vec_dtype = wp.vec3d if positions.dtype == torch.float64 else wp.vec3f
+    mat_dtype = wp.mat33d if positions.dtype == torch.float64 else wp.mat33f
+
+    # Transpose cell from row-convention (nvalchemi) to column-convention (nvalchemiops)
+    cell_T = cell.transpose(-2, -1).contiguous()
+
+    # Convert to warp arrays
+    num_systems = cell_T.shape[0]
+    wp_pos = wp.from_torch(positions.clone().contiguous(), dtype=vec_dtype)
+    wp_cell = wp.from_torch(cell_T, dtype=mat_dtype)
+    wp_cell_inv = wp.zeros(num_systems, dtype=mat_dtype, device=wp_pos.device)
+    wp_batch_idx = wp.from_torch(batch_idx.to(torch.int32))
+
+    compute_cell_inverse(wp_cell, wp_cell_inv)
+    wrap_positions_to_cell(wp_pos, wp_cell, wp_cell_inv, wp_batch_idx)
+
+    return wp.to_torch(wp_pos)
+
+
+@_wrap_positions.register_fake
+def _(
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(positions)
+
+
+def wrap_positions_into_cell(
+    positions: Float[torch.Tensor, "V 3"],
+    cell: Float[torch.Tensor, "B 3 3"],
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> Float[torch.Tensor, "V 3"]:
+    """Wrap positions into the unit cell using fractional coordinates.
+
+    Respects per-dimension periodicity: only periodic dimensions are
+    wrapped.  Non-periodic dimensions are left unchanged.
+
+    This function modifies ``positions`` **in-place** and returns the
+    same tensor.  Delegates to ``nvalchemiops.dynamics.utils.wrap_positions_to_cell``
+    for GPU-optimized wrapping, then applies per-dimension PBC masking
+    in pure PyTorch.
+
+    Parameters
+    ----------
+    positions : Float[Tensor, "V 3"]
+        Per-atom Cartesian positions. Modified in-place.
+    cell : Float[Tensor, "B 3 3"]
+        Lattice vectors as rows, one ``(3, 3)`` matrix per graph.
+    pbc : Tensor
+        Per-dimension periodicity flags, shape ``(B, 3)``, boolean.
+    batch_idx : Tensor
+        Per-atom graph membership indices of shape ``(V,)``.
+
+    Returns
+    -------
+    Float[Tensor, "V 3"]
+        The same ``positions`` tensor (modified in-place).
+    """
+    original = positions.clone()
+    wrapped = _wrap_positions(positions, cell, batch_idx)
+
+    # Restore non-periodic dimensions
+    per_atom_pbc = pbc[batch_idx]  # (V, 3)
+    positions.copy_(torch.where(per_atom_pbc, wrapped, original))
+    return positions
 
 
 class WrapPeriodicHook:
@@ -78,17 +161,20 @@ class WrapPeriodicHook:
         Wrap positions every ``frequency`` steps. Default ``1``
         (every step). For simulations with moderate drift, wrapping
         every 10--100 steps is sufficient and reduces overhead.
+    stage : Enum | None, optional
+        The workflow stage at which this hook runs.  Defaults to
+        ``None`` (stage-agnostic until registered with a specific engine).
 
     Attributes
     ----------
     frequency : int
         Wrapping frequency in steps.
-    stage : DynamicsStage
-        Fixed to ``AFTER_POST_UPDATE``.
+    stage : Enum | None
+        The stage at which this hook fires.
 
     Examples
     --------
-    >>> from nvalchemi.dynamics.hooks import WrapPeriodicHook
+    >>> from nvalchemi.hooks import WrapPeriodicHook
     >>> hook = WrapPeriodicHook(frequency=10)
     >>> dynamics = DemoDynamics(model=model, n_steps=10_000, dt=0.5, hooks=[hook])
     >>> dynamics.run(batch)
@@ -110,7 +196,7 @@ class WrapPeriodicHook:
     def __init__(
         self,
         frequency: int = 1,
-        stage: Enum = DynamicsStage.AFTER_POST_UPDATE,
+        stage: Enum | None = None,
     ) -> None:
         self.frequency = frequency
         self.stage = stage

--- a/nvalchemi/hooks/periodic.py
+++ b/nvalchemi/hooks/periodic.py
@@ -175,7 +175,8 @@ class WrapPeriodicHook:
     Examples
     --------
     >>> from nvalchemi.hooks import WrapPeriodicHook
-    >>> hook = WrapPeriodicHook(frequency=10)
+    >>> from nvalchemi.dynamics.base import DynamicsStage
+    >>> hook = WrapPeriodicHook(frequency=10, stage=DynamicsStage.AFTER_POST_UPDATE)
     >>> dynamics = DemoDynamics(model=model, n_steps=10_000, dt=0.5, hooks=[hook])
     >>> dynamics.run(batch)
 

--- a/nvalchemi/models/base.py
+++ b/nvalchemi/models/base.py
@@ -57,7 +57,7 @@ class NeighborConfig(BaseModel):
 
     An instance of this class attached to a :class:`ModelCard` signals that
     the model requires a neighbor list and describes the format and parameters
-    it expects.  At runtime a :class:`~nvalchemi.dynamics.hooks.NeighborListHook`
+    it expects.  At runtime a :class:`~nvalchemi.hooks.NeighborListHook`
     reads this config to compute and cache the appropriate neighbor data.
 
     Attributes
@@ -601,15 +601,16 @@ class BaseModelMixin(abc.ABC):
         return ComposableModelWrapper(self, other)
 
     def make_neighbor_hooks(self) -> list:
-        """Return a list of :class:`~nvalchemi.dynamics.hooks.NeighborListHook` instances
+        """Return a list of :class:`~nvalchemi.hooks.NeighborListHook` instances
         for this model's neighbor configuration.
 
         Returns an empty list if the model does not require a neighbor list.
         Defers the import to avoid circular imports.
         """
-        from nvalchemi.dynamics.hooks import NeighborListHook  # noqa: PLC0415
+        from nvalchemi.dynamics.base import DynamicsStage  # noqa: PLC0415
+        from nvalchemi.hooks import NeighborListHook  # noqa: PLC0415
 
         nc = self.model_card.neighbor_config
         if nc is None:
             return []
-        return [NeighborListHook(nc)]
+        return [NeighborListHook(nc, stage=DynamicsStage.BEFORE_COMPUTE)]

--- a/nvalchemi/models/composable.py
+++ b/nvalchemi/models/composable.py
@@ -55,7 +55,7 @@ from nvalchemi.models.base import (
 )
 
 if TYPE_CHECKING:
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
 
 __all__ = ["ComposableModelWrapper"]
 
@@ -257,12 +257,13 @@ class ComposableModelWrapper(nn.Module, BaseModelMixin):
         The import is deferred to avoid circular imports between
         ``nvalchemi.models`` and ``nvalchemi.dynamics``.
         """
-        from nvalchemi.dynamics.hooks import NeighborListHook
+        from nvalchemi.dynamics.base import DynamicsStage
+        from nvalchemi.hooks import NeighborListHook
 
         nc = self.model_card.neighbor_config
         if nc is None:
             return []
-        return [NeighborListHook(nc)]
+        return [NeighborListHook(nc, stage=DynamicsStage.BEFORE_COMPUTE)]
 
     # ------------------------------------------------------------------
     # Forward pass
@@ -279,7 +280,7 @@ class ComposableModelWrapper(nn.Module, BaseModelMixin):
         ----------
         data : Batch
             Input batch.  Neighbor data must already be populated (e.g. by
-            a :class:`~nvalchemi.dynamics.hooks.NeighborListHook`).
+            a :class:`~nvalchemi.hooks.NeighborListHook`).
 
         Returns
         -------

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -23,7 +23,8 @@ Usage
 ::
 
     from nvalchemi.models.dftd3 import DFTD3ModelWrapper
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
 
     # PBE-D3(BJ) parameters (Grimme 2010)
     model = DFTD3ModelWrapper(
@@ -32,7 +33,7 @@ Usage
         s8=0.7875,
     )
 
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
+    nl_hook = NeighborListHook(model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
     dynamics.register_hook(nl_hook)
     dynamics.model = model
 
@@ -646,7 +647,7 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             Batch containing ``positions``, ``numbers``,
             ``neighbor_matrix``, ``num_neighbors``, and optionally
             ``cell`` / ``neighbor_matrix_shifts`` (populated by
-            :class:`~nvalchemi.dynamics.hooks.NeighborListHook`).
+            :class:`~nvalchemi.hooks.NeighborListHook`).
 
         Returns
         -------

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -24,11 +24,12 @@ Usage
 ::
 
     from nvalchemi.models.ewald import EwaldModelWrapper
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
 
     model = EwaldModelWrapper(cutoff=10.0)
 
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
+    nl_hook = NeighborListHook(model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
     dynamics.register_hook(nl_hook)
     dynamics.model = model
 
@@ -305,7 +306,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         data : Batch
             Batch containing ``positions``, ``charges``, ``cell``,
             ``neighbor_matrix``, and ``num_neighbors`` (populated by
-            :class:`~nvalchemi.dynamics.hooks.NeighborListHook`).
+            :class:`~nvalchemi.hooks.NeighborListHook`).
 
         Returns
         -------

--- a/nvalchemi/models/lj.py
+++ b/nvalchemi/models/lj.py
@@ -23,7 +23,8 @@ Usage
 ::
 
     from nvalchemi.models.lj import LennardJonesModelWrapper
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
 
     model = LennardJonesModelWrapper(
         epsilon=0.0104,   # eV (argon)
@@ -33,7 +34,7 @@ Usage
 
     # Register the neighbor-list hook so the batch gets neighbor_matrix
     # populated before each compute() call.
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
+    nl_hook = NeighborListHook(model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
     dynamics.register_hook(nl_hook)
     dynamics.model = model
 
@@ -96,11 +97,11 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
     half_list : bool, optional
         Pass ``True`` (default) if the neighbor matrix contains each pair
         once (half list).  Must match the ``half_fill`` argument given to
-        :class:`~nvalchemi.dynamics.hooks.NeighborListHook`.
+        :class:`~nvalchemi.hooks.NeighborListHook`.
     max_neighbors : int, optional
         Maximum neighbors per atom used when building the neighbor matrix.
         Passed through to :class:`~nvalchemi.models.base.NeighborConfig`
-        and read by :class:`~nvalchemi.dynamics.hooks.NeighborListHook`.
+        and read by :class:`~nvalchemi.hooks.NeighborListHook`.
         Defaults to 128.
 
     Attributes
@@ -300,7 +301,7 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
         data : Batch
             Batch containing ``positions``, ``neighbor_matrix``,
             ``num_neighbors``, and optionally ``cell`` / ``neighbor_matrix_shifts``
-            (populated by :class:`~nvalchemi.dynamics.hooks.NeighborListHook`).
+            (populated by :class:`~nvalchemi.hooks.NeighborListHook`).
 
         Returns
         -------

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -33,14 +33,14 @@ Or wrap an already-instantiated model::
     mace_model = torch.load("my_mace.pt", weights_only=False)
     model = MACEWrapper(mace_model)
 
-For dynamics, register :class:`~nvalchemi.dynamics.hooks.NeighborListHook`
+For dynamics, register :class:`~nvalchemi.hooks.NeighborListHook`
 with ``format=NeighborListFormat.COO`` so that ``neighbor_list`` and
 ``neighbor_list_shifts`` are populated before each model call::
 
-    from nvalchemi.models.base import NeighborConfig, NeighborListFormat
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
 
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
+    nl_hook = NeighborListHook(model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
     dynamics.register_hook(nl_hook)
     dynamics.model = model
 

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -23,11 +23,12 @@ Usage
 ::
 
     from nvalchemi.models.pme import PMEModelWrapper
-    from nvalchemi.dynamics.hooks import NeighborListHook
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
 
     model = PMEModelWrapper(cutoff=10.0)
 
-    nl_hook = NeighborListHook(model.model_card.neighbor_config)
+    nl_hook = NeighborListHook(model.model_card.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
     dynamics.register_hook(nl_hook)
     dynamics.model = model
 
@@ -351,7 +352,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         data : Batch
             Batch containing ``positions``, ``charges``, ``cell``,
             ``neighbor_matrix``, and ``num_neighbors`` (populated by
-            :class:`~nvalchemi.dynamics.hooks.NeighborListHook`).
+            :class:`~nvalchemi.hooks.NeighborListHook`).
 
         Returns
         -------

--- a/test/dynamics/test_bias_hook.py
+++ b/test/dynamics/test_bias_hook.py
@@ -24,8 +24,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.dynamics.hooks.bias import BiasedPotentialHook
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import BiasedPotentialHook, Hook, HookContext
 from nvalchemi.models.demo import DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -94,7 +93,9 @@ class TestBiasedPotentialHook:
         bias_e = torch.ones_like(batch.energy) * 0.5
         bias_f = torch.ones_like(batch.forces) * 0.1
 
-        hook = BiasedPotentialHook(bias_fn=lambda b: (bias_e, bias_f))
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (bias_e, bias_f), stage=DynamicsStage.AFTER_COMPUTE
+        )
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_COMPUTE)
 
@@ -112,7 +113,7 @@ class TestBiasedPotentialHook:
         def zero_bias(b):
             return torch.zeros_like(b.energy), torch.zeros_like(b.forces)
 
-        hook = BiasedPotentialHook(bias_fn=zero_bias)
+        hook = BiasedPotentialHook(bias_fn=zero_bias, stage=DynamicsStage.AFTER_COMPUTE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_COMPUTE)
 
@@ -132,7 +133,11 @@ class TestBiasedPotentialHook:
         bias_e = torch.ones_like(batch.energy) * 0.5
         bias_f = torch.ones_like(batch.forces) * 0.1
 
-        hook = BiasedPotentialHook(bias_fn=lambda b: (bias_e, bias_f), inplace=False)
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (bias_e, bias_f),
+            stage=DynamicsStage.AFTER_COMPUTE,
+            inplace=False,
+        )
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_COMPUTE)
 
@@ -150,7 +155,9 @@ class TestBiasedPotentialHook:
         def bad_energy(b):
             return torch.zeros(1, 1, device=device), torch.zeros_like(b.forces)
 
-        hook = BiasedPotentialHook(bias_fn=bad_energy)
+        hook = BiasedPotentialHook(
+            bias_fn=bad_energy, stage=DynamicsStage.AFTER_COMPUTE
+        )
         ctx = _make_ctx(batch, dynamics)
         with pytest.raises(RuntimeError, match="bias_energy shape"):
             hook(ctx, DynamicsStage.AFTER_COMPUTE)
@@ -163,7 +170,9 @@ class TestBiasedPotentialHook:
         def bad_forces(b):
             return torch.zeros_like(b.energy), torch.zeros(1, 3, device=device)
 
-        hook = BiasedPotentialHook(bias_fn=bad_forces)
+        hook = BiasedPotentialHook(
+            bias_fn=bad_forces, stage=DynamicsStage.AFTER_COMPUTE
+        )
         ctx = _make_ctx(batch, dynamics)
         with pytest.raises(RuntimeError, match="bias_forces shape"):
             hook(ctx, DynamicsStage.AFTER_COMPUTE)
@@ -179,7 +188,7 @@ class TestBiasedPotentialHook:
         def zero_bias(b):
             return torch.zeros_like(b.energy), torch.zeros_like(b.forces)
 
-        hook = BiasedPotentialHook(bias_fn=zero_bias)
+        hook = BiasedPotentialHook(bias_fn=zero_bias, stage=DynamicsStage.AFTER_COMPUTE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_COMPUTE)
 
@@ -187,19 +196,29 @@ class TestBiasedPotentialHook:
         assert torch.allclose(batch.energy, energies_before)
 
     def test_stage_is_after_compute(self) -> None:
-        hook = BiasedPotentialHook(bias_fn=lambda b: (b.energy, b.forces))
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (b.energy, b.forces), stage=DynamicsStage.AFTER_COMPUTE
+        )
         assert hook.stage == DynamicsStage.AFTER_COMPUTE
 
     def test_default_frequency_is_one(self) -> None:
-        hook = BiasedPotentialHook(bias_fn=lambda b: (b.energy, b.forces))
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (b.energy, b.forces), stage=DynamicsStage.AFTER_COMPUTE
+        )
         assert hook.frequency == 1
 
     def test_custom_frequency(self) -> None:
-        hook = BiasedPotentialHook(bias_fn=lambda b: (b.energy, b.forces), frequency=5)
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (b.energy, b.forces),
+            stage=DynamicsStage.AFTER_COMPUTE,
+            frequency=5,
+        )
         assert hook.frequency == 5
 
     def test_is_hook(self) -> None:
-        hook = BiasedPotentialHook(bias_fn=lambda b: (b.energy, b.forces))
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (b.energy, b.forces), stage=DynamicsStage.AFTER_COMPUTE
+        )
         assert isinstance(hook, Hook)
 
     def test_interaction_with_nan_detector(self, device: str) -> None:
@@ -212,7 +231,9 @@ class TestBiasedPotentialHook:
         def small_bias(b):
             return torch.ones_like(b.energy) * 0.01, torch.ones_like(b.forces) * 0.01
 
-        bias_hook = BiasedPotentialHook(bias_fn=small_bias)
+        bias_hook = BiasedPotentialHook(
+            bias_fn=small_bias, stage=DynamicsStage.AFTER_COMPUTE
+        )
         nan_hook = NaNDetectorHook()
         ctx = _make_ctx(batch, dynamics)
 
@@ -239,7 +260,9 @@ class TestBiasedPotentialHookCompile:
         bias_e = torch.ones(1, 1, device=device) * 0.5
         bias_f = torch.ones(3, 3, device=device) * 0.1
 
-        hook = BiasedPotentialHook(bias_fn=lambda b: (bias_e, bias_f))
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (bias_e, bias_f), stage=DynamicsStage.AFTER_COMPUTE
+        )
         compiled = torch.compile(hook._apply_bias, **self._compile_kwargs(device))
         compiled(batch)
 

--- a/test/dynamics/test_bias_hook.py
+++ b/test/dynamics/test_bias_hook.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for ``nvalchemi.dynamics.hooks.bias`` — Tier 1 bias hook.
+"""Unit tests for ``nvalchemi.hooks.bias`` — Tier 1 bias hook.
 
 Covers :class:`BiasedPotentialHook`.
 """

--- a/test/dynamics/test_hook_utils.py
+++ b/test/dynamics/test_hook_utils.py
@@ -23,8 +23,8 @@ from nvalchemi.dynamics.hooks._utils import (
     kinetic_energy_per_graph,
     scatter_reduce_per_graph,
     temperature_per_graph,
-    wrap_positions_into_cell,
 )
+from nvalchemi.hooks.periodic import wrap_positions_into_cell
 
 # ---------------------------------------------------------------------------
 # scatter_reduce_per_graph

--- a/test/dynamics/test_neighbor_list_hook.py
+++ b/test/dynamics/test_neighbor_list_hook.py
@@ -33,7 +33,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.dynamics.hooks.neighbor_list import NeighborListHook
+from nvalchemi.hooks import NeighborListHook
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.hooks._protocol import Hook
 from nvalchemi.models.base import NeighborConfig, NeighborListFormat
@@ -259,14 +259,18 @@ class TestNeighborListRebuildInplace:
 
 class TestNeighborListHookProtocol:
     def test_stage(self):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         assert hook.stage == DynamicsStage.BEFORE_COMPUTE
 
     def test_frequency(self):
-        assert NeighborListHook(_cfg()).frequency == 1
+        assert (
+            NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE).frequency == 1
+        )
 
     def test_hook_protocol(self):
-        assert isinstance(NeighborListHook(_cfg()), Hook)
+        assert isinstance(
+            NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE), Hook
+        )
 
 
 # ===========================================================================
@@ -278,13 +282,13 @@ class TestStagingBufferAllocation:
     """Verify staging buffers are allocated with correct shapes on first call."""
 
     def test_buffers_none_before_first_call(self):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         assert hook._buf_positions is None
         assert hook._buf_batch_ptr is None
         assert hook._buf_batch_idx is None
 
     def test_buffers_allocated_after_first_call(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -293,7 +297,7 @@ class TestStagingBufferAllocation:
         assert hook._buf_batch_idx is not None
 
     def test_buffer_shapes(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         N, B = batch.num_nodes, batch.num_graphs
         hook(_ctx(batch), _STAGE)
@@ -303,7 +307,7 @@ class TestStagingBufferAllocation:
         assert hook._buf_batch_idx.shape == (N,)
 
     def test_pbc_buffers_allocated_when_pbc_present(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
@@ -314,7 +318,7 @@ class TestStagingBufferAllocation:
         assert hook._buf_pbc.shape == (B, 3)
 
     def test_pbc_buffers_none_without_pbc(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=False)
         hook(_ctx(batch), _STAGE)
 
@@ -323,7 +327,7 @@ class TestStagingBufferAllocation:
 
     def test_rebuild_flags_all_true_after_alloc(self, device: str):
         """Initial rebuild_flags must be all-True to force first full build."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         # Access the flags AFTER staging allocation (first call triggers it)
         batch = _line_batch(device)
         # Peek at the flags before the NL call by reaching into _alloc_staging_buffers
@@ -338,7 +342,7 @@ class TestStagingBufferAllocation:
         assert hook._rebuild_flags.all(), "rebuild_flags must be all-True after alloc"
 
     def test_alloc_N_B_set_after_first_call(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -346,7 +350,7 @@ class TestStagingBufferAllocation:
         assert hook._alloc_B == batch.num_graphs
 
     def test_output_tensors_allocated_after_first_call(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         N = batch.num_nodes
         hook(_ctx(batch), _STAGE)
@@ -359,7 +363,7 @@ class TestStagingBufferAllocation:
         assert hook._num_neighbors.dtype == torch.int32
 
     def test_neighbor_matrix_shifts_allocated_with_pbc(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         N = batch.num_nodes
         hook(_ctx(batch), _STAGE)
@@ -368,7 +372,7 @@ class TestStagingBufferAllocation:
         assert hook._neighbor_matrix_shifts.shape == (N, hook.config.max_neighbors, 3)
 
     def test_neighbor_matrix_shifts_none_without_pbc(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=False)
         hook(_ctx(batch), _STAGE)
 
@@ -384,7 +388,7 @@ class TestCopyToStagingBuffers:
     """Verify staging buffers reflect the current batch after each call."""
 
     def test_positions_copied(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)  # allocates and copies
 
@@ -393,7 +397,7 @@ class TestCopyToStagingBuffers:
         )
 
     def test_batch_ptr_copied(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -401,7 +405,7 @@ class TestCopyToStagingBuffers:
         assert torch.equal(hook._buf_batch_ptr, expected_ptr)
 
     def test_cell_copied_when_pbc(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
@@ -409,7 +413,7 @@ class TestCopyToStagingBuffers:
         assert torch.allclose(hook._buf_cell, expected_cell)
 
     def test_updated_positions_reflected_on_next_call(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -432,7 +436,7 @@ class TestAllocNlKwargs:
 
     def test_naive_no_pbc_empty_kwargs(self, device: str):
         """No-PBC naive path requires no extra kwargs."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=False)
         hook(_ctx(batch), _STAGE)
 
@@ -440,7 +444,7 @@ class TestAllocNlKwargs:
 
     def test_naive_pbc_has_shift_kwargs(self, device: str):
         """PBC naive path must pre-compute shift-range tensors."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
@@ -465,7 +469,9 @@ class TestAllocNlKwargs:
         )
         batch = Batch.from_data_list([data]).to(device)
 
-        hook = NeighborListHook(_cfg(max_neighbors=64))
+        hook = NeighborListHook(
+            _cfg(max_neighbors=64), stage=DynamicsStage.BEFORE_COMPUTE
+        )
         hook(_ctx(batch), _STAGE)
 
         expected_keys = {
@@ -487,7 +493,7 @@ class TestAllocNlKwargs:
         Some kwargs (e.g. ``max_shifts_per_system``, ``max_atoms_per_system``)
         are plain Python ``int`` scalars as required by the nvalchemiops API.
         """
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
@@ -498,7 +504,7 @@ class TestAllocNlKwargs:
 
     def test_kwargs_on_correct_device(self, device: str):
         """Tensor-valued pre-allocated kwargs must live on the same device as the batch."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
@@ -519,7 +525,7 @@ class TestShapeInvalidation:
     """Staging buffers must be reallocated when N or B changes."""
 
     def test_realloc_on_N_change(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch_small = _line_batch(device)  # 3 atoms
         hook(_ctx(batch_small), _STAGE)
 
@@ -538,7 +544,7 @@ class TestShapeInvalidation:
         assert hook._buf_positions.shape == (5, 3)
 
     def test_realloc_on_B_change(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch_1g = _line_batch(device, n_graphs=1)
         hook(_ctx(batch_1g), _STAGE)
         assert hook._alloc_B == 1
@@ -550,7 +556,7 @@ class TestShapeInvalidation:
 
     def test_ref_positions_reset_on_N_change(self, device: str):
         """_ref_positions must be reset when atom count changes."""
-        hook = NeighborListHook(_cfg(), skin=0.5)
+        hook = NeighborListHook(_cfg(), skin=0.5, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
         assert hook._ref_positions is not None
@@ -569,7 +575,7 @@ class TestShapeInvalidation:
 
     def test_no_realloc_when_shape_unchanged(self, device: str):
         """Buffer objects must be the same Python objects on repeated calls."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -590,7 +596,9 @@ class TestNeighborListHookMatrix:
     """Integration tests for MATRIX output format."""
 
     def test_neighbor_matrix_written_to_batch(self, device: str):
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.MATRIX))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.MATRIX), stage=DynamicsStage.BEFORE_COMPUTE
+        )
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -598,7 +606,7 @@ class TestNeighborListHookMatrix:
         assert hasattr(batch, "num_neighbors")
 
     def test_cutoff_stamped_on_batch(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -606,7 +614,7 @@ class TestNeighborListHookMatrix:
 
     def test_nearby_atoms_are_neighbors(self, device: str):
         """Atoms 0 and 1 (dist=1.5) must appear in each other's neighbor list."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -618,7 +626,7 @@ class TestNeighborListHookMatrix:
 
     def test_far_atom_has_no_neighbors(self, device: str):
         """Atom 2 (dist>3.5 from both others) should have zero neighbors."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -626,7 +634,7 @@ class TestNeighborListHookMatrix:
         assert int(nn[2].item()) == 0, "isolated atom should have no neighbors"
 
     def test_no_self_neighbors(self, device: str):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -640,7 +648,7 @@ class TestNeighborListHookMatrix:
 
     def test_multi_graph_isolation(self, device: str):
         """Atoms in different graphs must not appear in each other's neighbor lists."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(
             device, n_graphs=2
         )  # 6 atoms: graph 0 = [0,1,2], graph 1 = [3,4,5]
@@ -658,7 +666,7 @@ class TestNeighborListHookMatrix:
 
     def test_idempotent_second_call(self, device: str):
         """Calling the hook twice should give the same neighbor counts."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
         nn_first = batch.num_neighbors.clone()
@@ -670,7 +678,9 @@ class TestNeighborListHookMatrix:
 
     def test_pbc_neighbor_found_across_boundary(self, device: str):
         """Atoms close only through PBC image must be listed as neighbors."""
-        hook = NeighborListHook(_cfg(cutoff=2.5, max_neighbors=8))
+        hook = NeighborListHook(
+            _cfg(cutoff=2.5, max_neighbors=8), stage=DynamicsStage.BEFORE_COMPUTE
+        )
         batch = _pbc_wrap_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -689,7 +699,9 @@ class TestNeighborListHookMatrix:
         )
         batch = Batch.from_data_list([data]).to(device)
 
-        hook = NeighborListHook(_cfg(cutoff=2.5, max_neighbors=8))
+        hook = NeighborListHook(
+            _cfg(cutoff=2.5, max_neighbors=8), stage=DynamicsStage.BEFORE_COMPUTE
+        )
         hook(_ctx(batch), _STAGE)
 
         nn = batch.num_neighbors.cpu()
@@ -698,7 +710,7 @@ class TestNeighborListHookMatrix:
     @pytest.mark.parametrize("int_dtype", [torch.int32, torch.int64])
     def test_matrix_with_int_dtypes(self, device: str, int_dtype: torch.dtype):
         """Neighbor list MATRIX format works with both int32 and int64 indices."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, int_dtype=int_dtype)
         hook(_ctx(batch), _STAGE)
 
@@ -718,14 +730,20 @@ class TestNeighborListHookCOO:
     """Integration tests for COO output format."""
 
     def test_edge_index_written_to_batch(self, device: str):
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
         assert hasattr(batch, "neighbor_list")
 
     def test_edge_index_shape(self, device: str):
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -737,7 +755,10 @@ class TestNeighborListHookCOO:
 
     def test_nearby_atoms_have_edges(self, device: str):
         """Atoms 0 and 1 (dist=1.5 < cutoff) must appear as an edge pair."""
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -746,7 +767,10 @@ class TestNeighborListHookCOO:
         assert (0, 1) in pairs or (1, 0) in pairs, "edge between atoms 0 and 1 expected"
 
     def test_neighbor_list_shifts_present_with_pbc(self, device: str):
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _pbc_wrap_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -755,7 +779,10 @@ class TestNeighborListHookCOO:
 
     def test_no_edges_for_isolated_atom(self, device: str):
         """Atom 2 (isolated, dist > cutoff to all others) should appear in no edges."""
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -766,7 +793,10 @@ class TestNeighborListHookCOO:
     @pytest.mark.parametrize("int_dtype", [torch.int32, torch.int64])
     def test_coo_with_int_dtypes(self, device: str, int_dtype: torch.dtype):
         """Neighbor list COO format works with both int32 and int64 indices."""
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         batch = _line_batch(device, int_dtype=int_dtype)
         hook(_ctx(batch), _STAGE)
 
@@ -784,11 +814,11 @@ class TestSkinCheck:
     """Verify Verlet skin-check behaviour."""
 
     def test_ref_positions_none_before_first_call_with_skin(self):
-        hook = NeighborListHook(_cfg(), skin=0.5)
+        hook = NeighborListHook(_cfg(), skin=0.5, stage=DynamicsStage.BEFORE_COMPUTE)
         assert hook._ref_positions is None
 
     def test_ref_positions_set_after_first_call(self, device: str):
-        hook = NeighborListHook(_cfg(), skin=0.5)
+        hook = NeighborListHook(_cfg(), skin=0.5, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -796,7 +826,7 @@ class TestSkinCheck:
         assert hook._ref_positions.shape == (batch.num_nodes, 3)
 
     def test_ref_positions_not_set_when_skin_zero(self, device: str):
-        hook = NeighborListHook(_cfg(), skin=0.0)
+        hook = NeighborListHook(_cfg(), skin=0.0, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -804,7 +834,7 @@ class TestSkinCheck:
 
     def test_neighbor_counts_stable_when_positions_unchanged(self, device: str):
         """Without displacement, the same neighbor counts should come back each step."""
-        hook = NeighborListHook(_cfg(), skin=1.0)
+        hook = NeighborListHook(_cfg(), skin=1.0, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
         nn_first = batch.num_neighbors.clone()
@@ -817,7 +847,7 @@ class TestSkinCheck:
 
     def test_rebuild_flags_true_on_first_call(self, device: str):
         """On the first call, rebuild_flags must be all-True (full rebuild)."""
-        hook = NeighborListHook(_cfg(), skin=1.0)
+        hook = NeighborListHook(_cfg(), skin=1.0, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
 
         # After alloc but before the NL call, flags are all-True.
@@ -835,7 +865,7 @@ class TestSkinCheck:
 
     def test_large_displacement_triggers_rebuild(self, device: str):
         """Moving atoms far enough must change the neighbor list."""
-        hook = NeighborListHook(_cfg(), skin=0.5)
+        hook = NeighborListHook(_cfg(), skin=0.5, stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         hook(_ctx(batch), _STAGE)
 
@@ -871,24 +901,27 @@ class TestCompilerDisable:
         )
 
     def test_alloc_output_tensors_disabled(self):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         self._check_disabled(hook._alloc_output_tensors)
 
     def test_alloc_staging_buffers_disabled(self):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         self._check_disabled(hook._alloc_staging_buffers)
 
     def test_update_edges_group_disabled(self):
-        hook = NeighborListHook(_cfg(fmt=NeighborListFormat.COO, max_neighbors=None))
+        hook = NeighborListHook(
+            _cfg(fmt=NeighborListFormat.COO, max_neighbors=None),
+            stage=DynamicsStage.BEFORE_COMPUTE,
+        )
         self._check_disabled(hook._update_edges_group)
 
     def test_init_ref_positions_disabled(self):
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         self._check_disabled(hook._init_ref_positions)
 
     def test_alloc_methods_actually_run(self, device: str):
         """Smoke test: disabled methods must still execute correctly."""
-        hook = NeighborListHook(_cfg())
+        hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device)
         N, B = batch.num_nodes, batch.num_graphs
 

--- a/test/dynamics/test_neighbor_list_hook.py
+++ b/test/dynamics/test_neighbor_list_hook.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for :mod:`nvalchemi.dynamics.hooks.neighbor_list`.
+"""Tests for :mod:`nvalchemi.hooks.neighbor_list`.
 
 Covers all improvements made to NeighborListHook:
 

--- a/test/dynamics/test_periodic_hook.py
+++ b/test/dynamics/test_periodic_hook.py
@@ -23,8 +23,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.dynamics.hooks.periodic import WrapPeriodicHook
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import Hook, HookContext, WrapPeriodicHook
 from nvalchemi.models.demo import DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -106,7 +105,7 @@ class TestWrapPeriodicHook:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -134,7 +133,7 @@ class TestWrapPeriodicHook:
         )
         positions_before = batch.positions.clone()
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -156,7 +155,7 @@ class TestWrapPeriodicHook:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -183,7 +182,7 @@ class TestWrapPeriodicHook:
         )
         positions_before = batch.positions.clone()
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -207,7 +206,7 @@ class TestWrapPeriodicHook:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -232,7 +231,7 @@ class TestWrapPeriodicHook:
         )
         positions_ref = batch.positions
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -263,7 +262,7 @@ class TestWrapPeriodicHook:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -274,19 +273,19 @@ class TestWrapPeriodicHook:
         assert torch.allclose(batch.positions, expected, atol=1e-5)
 
     def test_stage_is_after_post_update(self) -> None:
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         assert hook.stage == DynamicsStage.AFTER_POST_UPDATE
 
     def test_default_frequency_is_one(self) -> None:
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         assert hook.frequency == 1
 
     def test_custom_frequency(self) -> None:
-        hook = WrapPeriodicHook(frequency=10)
+        hook = WrapPeriodicHook(frequency=10, stage=DynamicsStage.AFTER_POST_UPDATE)
         assert hook.frequency == 10
 
     def test_is_hook(self) -> None:
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         assert isinstance(hook, Hook)
 
 
@@ -312,7 +311,7 @@ class TestWrapPeriodicHookDimensionSqueeze:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)  # must not raise
 
@@ -333,7 +332,7 @@ class TestWrapPeriodicHookDimensionSqueeze:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -353,7 +352,7 @@ class TestWrapPeriodicHookDimensionSqueeze:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         ctx = _make_ctx(batch, dynamics)
         hook(ctx, DynamicsStage.AFTER_POST_UPDATE)
 
@@ -381,7 +380,7 @@ class TestWrapPeriodicHookCompile:
             device=device,
         )
 
-        hook = WrapPeriodicHook()
+        hook = WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE)
         compiled = torch.compile(hook._wrap_positions, **self._compile_kwargs(device))
         compiled(batch)
 

--- a/test/dynamics/test_periodic_hook.py
+++ b/test/dynamics/test_periodic_hook.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for ``nvalchemi.dynamics.hooks.periodic`` — Tier 1 periodic hook.
+"""Unit tests for ``nvalchemi.hooks.periodic`` — Tier 1 periodic hook.
 
 Covers :class:`WrapPeriodicHook`.
 """

--- a/test/hooks/test_shared_hooks.py
+++ b/test/hooks/test_shared_hooks.py
@@ -21,13 +21,11 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.dynamics.hooks.logging import LoggingHook
-from nvalchemi.dynamics.hooks.neighbor_list import NeighborListHook
-from nvalchemi.dynamics.hooks.periodic import WrapPeriodicHook
 from nvalchemi.dynamics.hooks.profiling import ProfilerHook
 from nvalchemi.dynamics.hooks.safety import MaxForceClampHook, NaNDetectorHook
 from nvalchemi.dynamics.hooks.snapshot import SnapshotHook
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import HookContext, NeighborListHook, WrapPeriodicHook
 from nvalchemi.models.base import NeighborConfig
 
 # ---------------------------------------------------------------------------

--- a/test/hooks/test_shared_hooks.py
+++ b/test/hooks/test_shared_hooks.py
@@ -25,7 +25,12 @@ from nvalchemi.dynamics.hooks.profiling import ProfilerHook
 from nvalchemi.dynamics.hooks.safety import MaxForceClampHook, NaNDetectorHook
 from nvalchemi.dynamics.hooks.snapshot import SnapshotHook
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks import HookContext, NeighborListHook, WrapPeriodicHook
+from nvalchemi.hooks import (
+    BiasedPotentialHook,
+    HookContext,
+    NeighborListHook,
+    WrapPeriodicHook,
+)
 from nvalchemi.models.base import NeighborConfig
 
 # ---------------------------------------------------------------------------
@@ -134,6 +139,38 @@ class TestLoggingHook:
             hook(ctx, DynamicsStage.AFTER_STEP)
         assert len(captured) == 1
         assert len(captured[0][1]) == 2
+
+
+# ===========================================================================
+# BiasedPotentialHook
+# ===========================================================================
+
+
+class TestBiasedPotentialHook:
+    """BiasedPotentialHook fires correctly under DynamicsStage."""
+
+    def test_dynamics_stage_adds_bias(self) -> None:
+        """Bias is applied to forces and energy under DynamicsStage."""
+        batch = _make_batch(n_graphs=1, atoms_per_graph=2)
+        forces_before = batch.forces.clone()
+        energy_before = batch.energy.clone()
+
+        bias_e = torch.ones_like(batch.energy) * 0.5
+        bias_f = torch.ones_like(batch.forces) * 0.1
+
+        hook = BiasedPotentialHook(
+            bias_fn=lambda b: (bias_e, bias_f),
+            stage=DynamicsStage.AFTER_COMPUTE,
+        )
+        ctx = _make_ctx(batch)
+        hook(ctx, DynamicsStage.AFTER_COMPUTE)
+        assert torch.allclose(batch.forces, forces_before + 0.1)
+        assert torch.allclose(batch.energy, energy_before + 0.5)
+
+    def test_stage_none_default(self) -> None:
+        """BiasedPotentialHook defaults to stage=None."""
+        hook = BiasedPotentialHook(bias_fn=lambda b: (b.energy, b.forces))
+        assert hook.stage is None
 
 
 # ===========================================================================

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -890,7 +890,7 @@ class TestRealCheckpoint:
         )  # (3, 3) eV/Å
 
         # nvalchemi path: AtomicData → Batch → NeighborListHook → MACEWrapper.
-        from nvalchemi.dynamics.hooks import NeighborListHook
+        from nvalchemi.hooks import NeighborListHook
 
         data = AtomicData.from_atoms(atoms)
         batch = Batch.from_data_list([data])


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Moves three general-purpose hooks — `BiasedPotentialHook`, `NeighborListHook`, and `WrapPeriodicHook` — from `nvalchemi.dynamics.hooks` to `nvalchemi.hooks`, making them stage-agnostic and reusable outside of dynamics workflows. Also makes `Hook.stage` optional on the protocol, fixes `FreezeAtomsHook` protocol alignment, and updates all downstream imports.

### Impact on End Users

**Users of existing hooks (dynamics simulations):**

This is a **breaking change**. Two things change:

1. **Import path**: `from nvalchemi.dynamics.hooks import NeighborListHook` → `from nvalchemi.hooks import NeighborListHook`
2. **Explicit stage required**: Hooks no longer have a default `DynamicsStage` — you must pass `stage=` at construction or registration.

Before:
```python
from nvalchemi.dynamics.hooks import NeighborListHook, WrapPeriodicHook

hooks = [NeighborListHook(config), WrapPeriodicHook()]
```

After:
```python
from nvalchemi.hooks import NeighborListHook, WrapPeriodicHook
from nvalchemi.dynamics.base import DynamicsStage

hooks = [
    NeighborListHook(config, stage=DynamicsStage.BEFORE_COMPUTE),
    WrapPeriodicHook(stage=DynamicsStage.AFTER_POST_UPDATE),
]
```

If a user forgets to pass `stage=`, they get a clear `TypeError` at registration time (not mid-simulation):
```
TypeError: Hook NeighborListHook has no stage assigned.
Pass stage= to the hook constructor or to register_hook().
```

**Users developing custom hooks:**

Minor improvement — `Hook.stage` can now be `None`, and `register_hook(hook, stage=...)` can assign the stage at registration time. This enables hooks that are reusable across different workflow types (dynamics, training, active learning) without being tied to a specific stage enum.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #64

## Changes Made

- **Protocol**: `Hook.stage` type changed from `Enum` to `Enum | None`, allowing stage-agnostic hooks
- **Registry**: `register_hook()` gains optional `stage` parameter for deferred stage assignment; raises `TypeError` if stage is still `None` at registration and hook has no `_runs_on_stage`
- **Moved hooks**: `BiasedPotentialHook`, `NeighborListHook`, `WrapPeriodicHook` now live in `nvalchemi/hooks/` with `stage: Enum | None = None` default
- **Deleted old files**: `nvalchemi/dynamics/hooks/{bias,neighbor_list,periodic}.py` removed (no re-exports)
- **Co-located utility**: `wrap_positions_into_cell` and its `_wrap_positions` custom op moved from `_utils.py` into `nvalchemi/hooks/periodic.py`
- **Protocol fix**: `FreezeAtomsHook.__call__` signature corrected from `stage: DynamicsStage` to `stage: Enum`
- **Import updates**: All model files (7), example files (13), test files (6), and data files (1) updated to use new import paths with explicit `stage=DynamicsStage.X`

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

714 tests pass, 15 skipped (MACE checkpoint tests requiring `--slow`), 0 failures. No new tests needed — existing test coverage fully exercises the moved hooks through updated import paths.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The `wrap_positions_into_cell` GPU kernel wrapper (using `nvalchemiops.dynamics.utils`) was co-located into `nvalchemi/hooks/periodic.py` alongside `WrapPeriodicHook` rather than being left in `nvalchemi/dynamics/hooks/_utils.py`. This avoids a cross-package import while keeping the kernel wrapper with its sole consumer.

Dynamics-specific hooks (`NaNDetectorHook`, `MaxForceClampHook`, `SnapshotHook`, `LoggingHook`, `EnergyDriftMonitorHook`, `ProfilerHook`, `FreezeAtomsHook`, `ConvergedSnapshotHook`) remain in `nvalchemi.dynamics.hooks` as they are inherently tied to dynamics workflows.