### PR TITLE
fix: correct virial sign, pressure mode forwarding, barostat mass, and cell KE in NPT/NPH integrators

### DIFF
--- a/nvalchemi/dynamics/_ops/_bridge.py
+++ b/nvalchemi/dynamics/_ops/_bridge.py
@@ -101,36 +101,6 @@ def _to_per_system(
     return torch.full((M,), float(val), dtype=dtype, device=device)
 
 
-PRESSURE_MODE_CODES: dict[str, int] = {
-    "isotropic": 0,
-    "anisotropic": 1,
-    "triclinic": 2,
-}
-
-PRESSURE_MODE_NAMES: dict[int, str] = {v: k for k, v in PRESSURE_MODE_CODES.items()}
-
-
-def _pressure_mode_name(mode_code: int) -> str:
-    """Return the ops mode string for an integer pressure-mode code.
-
-    Parameters
-    ----------
-    mode_code : int
-        0 = isotropic, 1 = anisotropic, 2 = triclinic.
-
-    Returns
-    -------
-    str
-        The corresponding mode name.
-    """
-    try:
-        return PRESSURE_MODE_NAMES[mode_code]
-    except KeyError as exc:
-        raise ValueError(
-            f"Unknown pressure mode code: {mode_code}. Expected 0, 1, or 2."
-        ) from exc
-
-
 def _vec_type(dtype: torch.dtype) -> type:
     """Return ``wp.vec3f`` or ``wp.vec3d`` from a torch float dtype.
 

--- a/nvalchemi/dynamics/_ops/_bridge.py
+++ b/nvalchemi/dynamics/_ops/_bridge.py
@@ -89,15 +89,16 @@ def _to_per_system(
         *dtype*.
     """
     if isinstance(val, torch.Tensor):
-        if val.ndim == 0:
-            return val.expand(M).contiguous()
-        leading = val.shape[0]
+        tensor = val.to(device=device, dtype=dtype)
+        if tensor.ndim == 0:
+            return tensor.expand(M).contiguous()
+        leading = tensor.shape[0]
         if leading not in (1, M):
             raise ValueError(
                 f"Expected leading dimension 1 or {M} for per-system broadcast, "
-                f"got shape {tuple(val.shape)}."
+                f"got shape {tuple(tensor.shape)}."
             )
-        return val.expand((M, *val.shape[1:])).contiguous()
+        return tensor.expand((M, *tensor.shape[1:])).contiguous()
     return torch.full((M,), float(val), dtype=dtype, device=device)
 
 

--- a/nvalchemi/dynamics/_ops/_bridge.py
+++ b/nvalchemi/dynamics/_ops/_bridge.py
@@ -68,12 +68,13 @@ def _to_per_system(
     device: torch.device,
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    """Broadcast a scalar or rank-0/rank-1 tensor to shape ``[M]``.
+    """Broadcast a scalar or tensor to shape ``[M, *trailing]``.
 
     Parameters
     ----------
     val : float or torch.Tensor
-        Scalar value or tensor of shape ``[]``, ``[1]``, or ``[M]``.
+        Scalar value or tensor of shape ``[]``, ``[1, *trailing]``, or
+        ``[M, *trailing]``.
     M : int
         Number of systems.
     device : torch.device
@@ -84,11 +85,50 @@ def _to_per_system(
     Returns
     -------
     torch.Tensor
-        Contiguous tensor of shape ``[M]`` on *device* with *dtype*.
+        Contiguous tensor of shape ``[M, *trailing]`` on *device* with
+        *dtype*.
     """
     if isinstance(val, torch.Tensor):
-        return val.expand(M).to(device=device, dtype=dtype).contiguous()
+        if val.ndim == 0:
+            return val.expand(M).contiguous()
+        leading = val.shape[0]
+        if leading not in (1, M):
+            raise ValueError(
+                f"Expected leading dimension 1 or {M} for per-system broadcast, "
+                f"got shape {tuple(val.shape)}."
+            )
+        return val.expand((M, *val.shape[1:])).contiguous()
     return torch.full((M,), float(val), dtype=dtype, device=device)
+
+
+PRESSURE_MODE_CODES: dict[str, int] = {
+    "isotropic": 0,
+    "anisotropic": 1,
+    "triclinic": 2,
+}
+
+PRESSURE_MODE_NAMES: dict[int, str] = {v: k for k, v in PRESSURE_MODE_CODES.items()}
+
+
+def _pressure_mode_name(mode_code: int) -> str:
+    """Return the ops mode string for an integer pressure-mode code.
+
+    Parameters
+    ----------
+    mode_code : int
+        0 = isotropic, 1 = anisotropic, 2 = triclinic.
+
+    Returns
+    -------
+    str
+        The corresponding mode name.
+    """
+    try:
+        return PRESSURE_MODE_NAMES[mode_code]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown pressure mode code: {mode_code}. Expected 0, 1, or 2."
+        ) from exc
 
 
 def _vec_type(dtype: torch.dtype) -> type:

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -89,12 +89,7 @@ from nvalchemiops.dynamics.utils.cell_filter import (
     stress_to_cell_force as _stress_to_cell,
 )
 
-from nvalchemi.dynamics._ops._bridge import (
-    _mat_type,
-    _pressure_mode_name,
-    _scalar_type,
-    _vec_type,
-)
+from nvalchemi.dynamics._ops._bridge import _mat_type, _scalar_type, _vec_type
 
 
 def _vec9_type(dtype: torch.dtype):
@@ -402,7 +397,7 @@ def nph_velocity_half_step(
     dt: torch.Tensor,
     batch_idx: torch.Tensor,
     cells_inv: torch.Tensor,
-    pressure_mode: int = 0,
+    pressure_mode: str = "isotropic",
 ) -> None:
     """NPH particle velocity half-step coupled to barostat strain rate.
 
@@ -429,9 +424,9 @@ def nph_velocity_half_step(
         Per-atom system index ``[N]``, int32, non-decreasing.
     cells_inv : torch.Tensor
         Pre-computed inverse cell matrices ``[M, 3, 3]``, same dtype.
-    pressure_mode : int, optional
-        Pressure control mode: 0 = isotropic, 1 = anisotropic,
-        2 = triclinic.  Default 0.
+    pressure_mode : str, optional
+        Pressure control mode: ``"isotropic"``, ``"anisotropic"``,
+        or ``"triclinic"``.  Default ``"isotropic"``.
     """
     N = velocities.shape[0]
     dtype = velocities.dtype
@@ -449,7 +444,7 @@ def nph_velocity_half_step(
         batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
         num_atoms_per_system=wp.from_torch(num_atoms_per_system, dtype=wp.int32),
         cells_inv=wp.from_torch(cells_inv, dtype=mat_t),
-        mode=_pressure_mode_name(pressure_mode),
+        mode=pressure_mode,
     )
 
 
@@ -464,7 +459,7 @@ def _nph_velocity_half_step_fake(
     dt,
     batch_idx,
     cells_inv,
-    pressure_mode=0,
+    pressure_mode="isotropic",
 ) -> None:
     pass
 
@@ -625,7 +620,7 @@ def npt_velocity_half_step(
     dt: torch.Tensor,
     batch_idx: torch.Tensor,
     cells_inv: torch.Tensor,
-    pressure_mode: int = 0,
+    pressure_mode: str = "isotropic",
 ) -> None:
     """NPT particle velocity half-step coupled to thermostat and barostat.
 
@@ -655,9 +650,9 @@ def npt_velocity_half_step(
         Per-atom system index ``[N]``, int32, non-decreasing.
     cells_inv : torch.Tensor
         Pre-computed inverse cell matrices ``[M, 3, 3]``, same dtype.
-    pressure_mode : int, optional
-        Pressure control mode: 0 = isotropic, 1 = anisotropic,
-        2 = triclinic.  Default 0.
+    pressure_mode : str, optional
+        Pressure control mode: ``"isotropic"``, ``"anisotropic"``,
+        or ``"triclinic"``.  Default ``"isotropic"``.
     """
     N = velocities.shape[0]
     dtype = velocities.dtype
@@ -677,7 +672,7 @@ def npt_velocity_half_step(
         batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
         num_atoms_per_system=wp.from_torch(num_atoms_per_system, dtype=wp.int32),
         cells_inv=wp_cell_inv,
-        mode=_pressure_mode_name(pressure_mode),
+        mode=pressure_mode,
     )
 
 
@@ -693,7 +688,7 @@ def _npt_velocity_half_step_fake(
     dt,
     batch_idx,
     cells_inv,
-    pressure_mode=0,
+    pressure_mode="isotropic",
 ) -> None:
     pass
 

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -89,12 +89,58 @@ from nvalchemiops.dynamics.utils.cell_filter import (
     stress_to_cell_force as _stress_to_cell,
 )
 
-from nvalchemi.dynamics._ops._bridge import _mat_type, _scalar_type, _vec_type
+from nvalchemi.dynamics._ops._bridge import (
+    _mat_type,
+    _pressure_mode_name,
+    _scalar_type,
+    _vec_type,
+)
 
 
 def _vec9_type(dtype: torch.dtype):
     """Return the warp vec9 type matching the given torch float dtype."""
     return vec9f if dtype == torch.float32 else vec9d
+
+
+def _target_pressure_wp_array(target_pressure: torch.Tensor):
+    """Convert a target-pressure tensor to the matching Warp array dtype.
+
+    Parameters
+    ----------
+    target_pressure : torch.Tensor
+        ``[M]`` (isotropic), ``[M, 3]`` (anisotropic), or
+        ``[M, 3, 3]`` (triclinic).
+
+    Returns
+    -------
+    wp.array
+        Warp array with scalar, vec3, or vec9 dtype as appropriate.
+    """
+    dtype = target_pressure.dtype
+    scl_t = _scalar_type(dtype)
+    vec_t = _vec_type(dtype)
+    vec9_t = _vec9_type(dtype)
+    if target_pressure.ndim == 1:
+        return wp.from_torch(target_pressure.contiguous(), dtype=scl_t)
+    if target_pressure.ndim == 2:
+        if target_pressure.shape[-1] != 3:
+            raise ValueError(
+                "Anisotropic target pressure must have shape [M, 3], got "
+                f"{tuple(target_pressure.shape)}."
+            )
+        return wp.from_torch(target_pressure.contiguous(), dtype=vec_t)
+    if target_pressure.ndim == 3:
+        if target_pressure.shape[-2:] != (3, 3):
+            raise ValueError(
+                "Triclinic target pressure must have shape [M, 3, 3], got "
+                f"{tuple(target_pressure.shape)}."
+            )
+        reshaped = target_pressure.reshape(target_pressure.shape[0], 9).contiguous()
+        return wp.from_torch(reshaped, dtype=vec9_t)
+    raise ValueError(
+        "Target pressure must be rank-1, rank-2, or rank-3, got "
+        f"{target_pressure.ndim}."
+    )
 
 
 __all__ = [
@@ -128,7 +174,12 @@ def compute_pressure_tensor(
 ) -> torch.Tensor:
     """Compute the full instantaneous pressure tensor for each system.
 
-    ``P = (2·KE_tensor + virial) / V``
+    The *stress* parameter follows the **tension-positive** convention
+    (positive = tensile, negative = compressive).  This function negates
+    it internally to obtain the ops-convention virial ``W = -stress``
+    before computing:
+
+    ``P = (KE_tensor + W) / V = (KE_tensor - stress) / V``
 
     Pre-allocated scratch arrays (*kinetic_tensors*, *pressure_tensors*,
     *volumes*) are zeroed internally before use; allocate them once and
@@ -141,8 +192,8 @@ def compute_pressure_tensor(
     masses : torch.Tensor
         Per-atom masses ``[N]``, same dtype.
     stress : torch.Tensor
-        Per-system virial/stress tensor ``[M, 3, 3]`` from the model,
-        same dtype.
+        Per-system stress tensor ``[M, 3, 3]`` in the tension-positive
+        convention, same dtype.
     cell : torch.Tensor
         Per-system cell matrix ``[M, 3, 3]``, same dtype.
     kinetic_tensors : torch.Tensor
@@ -166,12 +217,11 @@ def compute_pressure_tensor(
     mat_t = _mat_type(dtype)
     scl_t = _scalar_type(dtype)
     vec9_t = _vec9_type(dtype)
-    # virial_tensors must be vec9; kinetic_tensors must be array2d [M,9] scalar;
-    # pressure_tensors must be vec9 [M].
+    virial = (-stress).reshape(M, 9).contiguous()
     P_wp = _compute_P(
         wp.from_torch(velocities, dtype=vec_t),
         wp.from_torch(masses, dtype=scl_t),
-        wp.from_torch(stress.reshape(M, 9).contiguous(), dtype=vec9_t),
+        wp.from_torch(virial, dtype=vec9_t),
         wp.from_torch(cell, dtype=mat_t),
         wp.from_torch(kinetic_tensors, dtype=scl_t),  # [M, 9] array2d scalar
         wp.from_torch(pressure_tensors, dtype=vec9_t),  # [M, 9] as vec9 [M]
@@ -296,7 +346,8 @@ def nph_barostat_half_step(
     pressure_tensor : torch.Tensor
         Instantaneous pressure tensor ``[M, 3, 3]``, same dtype.
     target_pressure : torch.Tensor
-        Target pressure ``[M]``, same dtype.
+        Target pressure ``[M]`` (isotropic), ``[M, 3]`` (anisotropic),
+        or ``[M, 3, 3]`` (triclinic).
     volumes : torch.Tensor
         Per-system cell volumes ``[M]``, same dtype.
     W : torch.Tensor
@@ -315,7 +366,7 @@ def nph_barostat_half_step(
     _nph_baro_half(
         wp.from_torch(cell_velocity, dtype=mat_t),
         wp.from_torch(pressure_tensor, dtype=vec9_t),  # [M, 9] as vec9 [M]
-        wp.from_torch(target_pressure, dtype=scl_t),
+        _target_pressure_wp_array(target_pressure),
         wp.from_torch(volumes, dtype=scl_t),
         wp.from_torch(W, dtype=scl_t),
         wp.from_torch(kinetic_energy, dtype=scl_t),
@@ -351,13 +402,13 @@ def nph_velocity_half_step(
     dt: torch.Tensor,
     batch_idx: torch.Tensor,
     cells_inv: torch.Tensor,
+    pressure_mode: int = 0,
 ) -> None:
     """NPH particle velocity half-step coupled to barostat strain rate.
 
     Applies ``v += 0.5*(F/m - (1 + 1/N_f)*ε̇·v)*dt`` where ε̇ = ḣ·h⁻¹.
     Modifies *velocities* in-place.
 
-    .. note::
     Parameters
     ----------
     velocities : torch.Tensor
@@ -378,6 +429,9 @@ def nph_velocity_half_step(
         Per-atom system index ``[N]``, int32, non-decreasing.
     cells_inv : torch.Tensor
         Pre-computed inverse cell matrices ``[M, 3, 3]``, same dtype.
+    pressure_mode : int, optional
+        Pressure control mode: 0 = isotropic, 1 = anisotropic,
+        2 = triclinic.  Default 0.
     """
     N = velocities.shape[0]
     dtype = velocities.dtype
@@ -395,6 +449,7 @@ def nph_velocity_half_step(
         batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
         num_atoms_per_system=wp.from_torch(num_atoms_per_system, dtype=wp.int32),
         cells_inv=wp.from_torch(cells_inv, dtype=mat_t),
+        mode=_pressure_mode_name(pressure_mode),
     )
 
 
@@ -409,6 +464,7 @@ def _nph_velocity_half_step_fake(
     dt,
     batch_idx,
     cells_inv,
+    pressure_mode=0,
 ) -> None:
     pass
 
@@ -439,7 +495,8 @@ def npt_barostat_half_step(
     pressure_tensor : torch.Tensor
         Instantaneous pressure ``[M, 3, 3]``, same dtype.
     target_pressure : torch.Tensor
-        Target pressure ``[M]``, same dtype.
+        Target pressure ``[M]`` (isotropic), ``[M, 3]`` (anisotropic),
+        or ``[M, 3, 3]`` (triclinic).
     volumes : torch.Tensor
         Per-system cell volumes ``[M]``, same dtype.
     W : torch.Tensor
@@ -461,7 +518,7 @@ def npt_barostat_half_step(
     _npt_baro_half(
         wp.from_torch(cell_velocity, dtype=mat_t),
         wp.from_torch(pressure_tensor, dtype=vec9_t),  # [M, 9] as vec9 [M]
-        wp.from_torch(target_pressure, dtype=scl_t),
+        _target_pressure_wp_array(target_pressure),
         wp.from_torch(volumes, dtype=scl_t),
         wp.from_torch(W, dtype=scl_t),
         wp.from_torch(kinetic_energy, dtype=scl_t),
@@ -568,6 +625,7 @@ def npt_velocity_half_step(
     dt: torch.Tensor,
     batch_idx: torch.Tensor,
     cells_inv: torch.Tensor,
+    pressure_mode: int = 0,
 ) -> None:
     """NPT particle velocity half-step coupled to thermostat and barostat.
 
@@ -597,6 +655,9 @@ def npt_velocity_half_step(
         Per-atom system index ``[N]``, int32, non-decreasing.
     cells_inv : torch.Tensor
         Pre-computed inverse cell matrices ``[M, 3, 3]``, same dtype.
+    pressure_mode : int, optional
+        Pressure control mode: 0 = isotropic, 1 = anisotropic,
+        2 = triclinic.  Default 0.
     """
     N = velocities.shape[0]
     dtype = velocities.dtype
@@ -616,6 +677,7 @@ def npt_velocity_half_step(
         batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
         num_atoms_per_system=wp.from_torch(num_atoms_per_system, dtype=wp.int32),
         cells_inv=wp_cell_inv,
+        mode=_pressure_mode_name(pressure_mode),
     )
 
 
@@ -631,6 +693,7 @@ def _npt_velocity_half_step_fake(
     dt,
     batch_idx,
     cells_inv,
+    pressure_mode=0,
 ) -> None:
     pass
 

--- a/nvalchemi/dynamics/integrators/nph.py
+++ b/nvalchemi/dynamics/integrators/nph.py
@@ -37,11 +37,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics._ops._bridge import (
-    PRESSURE_MODE_CODES,
-    _make_state_batch,
-    _to_per_system,
-)
+from nvalchemi.dynamics._ops._bridge import _make_state_batch, _to_per_system
 from nvalchemi.dynamics._ops.npt_nph import (
     compute_barostat_mass,
     compute_pressure_tensor,
@@ -252,7 +248,7 @@ class NPH(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
-            PRESSURE_MODE_CODES[self.pressure_coupling],
+            self.pressure_coupling,
         )
         npt_position_update(
             batch.positions,
@@ -290,7 +286,7 @@ class NPH(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
-            PRESSURE_MODE_CODES[self.pressure_coupling],
+            self.pressure_coupling,
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)

--- a/nvalchemi/dynamics/integrators/nph.py
+++ b/nvalchemi/dynamics/integrators/nph.py
@@ -37,7 +37,11 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics._ops._bridge import _make_state_batch, _to_per_system
+from nvalchemi.dynamics._ops._bridge import (
+    PRESSURE_MODE_CODES,
+    _make_state_batch,
+    _to_per_system,
+)
 from nvalchemi.dynamics._ops.npt_nph import (
     compute_barostat_mass,
     compute_pressure_tensor,
@@ -138,6 +142,8 @@ class NPH(BaseDynamics):
         kT_est = torch.full((M,), 300.0 * KB_EV, dtype=dtype, device=dev)
         W = torch.zeros(M, dtype=dtype, device=dev)
         compute_barostat_mass(kT_est, barostat_time, num_atoms_per_system, W)
+        if self.pressure_coupling != "isotropic":
+            W = W / 3
         self._state = _make_state_batch(
             {
                 "dt": dt,
@@ -167,6 +173,8 @@ class NPH(BaseDynamics):
         )
         W = torch.zeros(n, dtype=dtype, device=dev)
         compute_barostat_mass(kT_est, barostat_time, num_atoms_per_system, W)
+        if self.pressure_coupling != "isotropic":
+            W = W / 3
         return _make_state_batch(
             {
                 "dt": _to_per_system(self._dt_init, n, dev, dtype),
@@ -244,6 +252,7 @@ class NPH(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
+            PRESSURE_MODE_CODES[self.pressure_coupling],
         )
         npt_position_update(
             batch.positions,
@@ -281,6 +290,7 @@ class NPH(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
+            PRESSURE_MODE_CODES[self.pressure_coupling],
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -41,7 +41,11 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics._ops._bridge import _make_state_batch, _to_per_system
+from nvalchemi.dynamics._ops._bridge import (
+    PRESSURE_MODE_CODES,
+    _make_state_batch,
+    _to_per_system,
+)
 from nvalchemi.dynamics._ops.nose_hoover import nhc_compute_masses
 from nvalchemi.dynamics._ops.npt_nph import (
     compute_barostat_mass,
@@ -62,6 +66,43 @@ if TYPE_CHECKING:
     from nvalchemi.models.base import BaseModelMixin
 
 __all__ = ["NPT"]
+
+
+def _cell_dof_count(pressure_coupling: str) -> int:
+    """Return the active barostat cell degrees of freedom for a mode."""
+    return 9 if pressure_coupling == "triclinic" else 3
+
+
+def _cell_kinetic_energy(
+    cell_velocity: torch.Tensor,
+    W: torch.Tensor,
+    cells_inv: torch.Tensor,
+    pressure_coupling: str,
+) -> torch.Tensor:
+    """Compute cell kinetic energy using the strain rate ε̇ = ḣ h⁻¹.
+
+    Parameters
+    ----------
+    cell_velocity : torch.Tensor
+        Cell velocity matrix ḣ ``[M, 3, 3]``.
+    W : torch.Tensor
+        Barostat inertia ``[M]``.
+    cells_inv : torch.Tensor
+        Inverse cell matrices h⁻¹ ``[M, 3, 3]``.
+    pressure_coupling : str
+        One of ``"isotropic"``, ``"anisotropic"``, ``"triclinic"``.
+
+    Returns
+    -------
+    torch.Tensor
+        Cell kinetic energy ``[M]``.
+    """
+    eps_dot = cell_velocity @ cells_inv
+    if pressure_coupling == "triclinic":
+        active = eps_dot.reshape(eps_dot.shape[0], -1)
+    else:
+        active = torch.diagonal(eps_dot, dim1=-2, dim2=-1)
+    return 0.5 * W * (active * active).sum(dim=-1)
 
 
 class NPT(BaseDynamics):
@@ -158,14 +199,17 @@ class NPT(BaseDynamics):
         num_atoms_per_system = counts.to(dtype=torch.int32, device=dev)
         W = torch.zeros(M, dtype=dtype, device=dev)
         compute_barostat_mass(kT, tau_p, num_atoms_per_system, W)
+        if self.pressure_coupling != "isotropic":
+            W = W / 3
         Q = nhc_compute_masses(
             kT, tau_t, batch.atomic_masses, batch.batch_idx.int(), self.chain_length
         )
-        # Barostat NHC: 3 dummy atoms per system → N_f = 9 DOFs (3×3 cell).
-        dummy_b_masses = torch.ones(M * 3, dtype=dtype, device=dev)
+        cell_dofs = _cell_dof_count(self.pressure_coupling)
+        dummy_b_particles = 3 if cell_dofs == 9 else 1
+        dummy_b_masses = torch.ones(M * dummy_b_particles, dtype=dtype, device=dev)
         dummy_b_batch = torch.arange(
             M, device=dev, dtype=torch.int32
-        ).repeat_interleave(3)
+        ).repeat_interleave(dummy_b_particles)
         Q_b = nhc_compute_masses(
             kT, tau_t, dummy_b_masses, dummy_b_batch, self.chain_length
         )
@@ -211,6 +255,8 @@ class NPT(BaseDynamics):
         dummy_batch_idx = torch.zeros(n, dtype=torch.int32, device=dev)
         W = torch.zeros(n, dtype=dtype, device=dev)
         compute_barostat_mass(kT, tau_p, num_atoms_per_system, W)
+        if self.pressure_coupling != "isotropic":
+            W = W / 3
         Q = nhc_compute_masses(
             kT[:1],
             tau_t[:1],
@@ -219,8 +265,10 @@ class NPT(BaseDynamics):
             self.chain_length,
         )
         Q = Q.expand(n, -1).contiguous()
-        dummy_b_masses = torch.ones(3, dtype=dtype, device=dev)
-        dummy_b_batch = torch.zeros(3, dtype=torch.int32, device=dev)
+        cell_dofs = _cell_dof_count(self.pressure_coupling)
+        dummy_b_particles = 3 if cell_dofs == 9 else 1
+        dummy_b_masses = torch.ones(dummy_b_particles, dtype=dtype, device=dev)
+        dummy_b_batch = torch.zeros(dummy_b_particles, dtype=torch.int32, device=dev)
         Q_b_single = nhc_compute_masses(
             kT[:1], tau_t[:1], dummy_b_masses, dummy_b_batch, self.chain_length
         )
@@ -308,12 +356,18 @@ class NPT(BaseDynamics):
         scale = torch.exp(-self._state.nhc_eta_dot[:, 0] * self._state.dt * 0.5)
         batch.velocities.mul_(scale[batch.batch_idx].unsqueeze(-1))
 
-        # Barostat thermostat half step (acts on cell DOFs; KE_cell ≈ 0.5*W*Tr(h_dot^T*h_dot)).
-        # Compute approximate cell kinetic energy from cell_velocity.
-        cell_v_flat = self._state.cell_velocity.reshape(M, -1)
-        ke_cell = 0.5 * self._state.W * (cell_v_flat * cell_v_flat).sum(dim=-1)
-        # cell DOFs = 9 (3x3 matrix), represented as 3 pseudo-atoms with 3 DOFs each.
-        cell_ndof_tensor = torch.full((M,), 9, dtype=torch.int32, device=batch.device)
+        ke_cell = _cell_kinetic_energy(
+            self._state.cell_velocity,
+            self._state.W,
+            cells_inv,
+            self.pressure_coupling,
+        )
+        cell_ndof_tensor = torch.full(
+            (M,),
+            _cell_dof_count(self.pressure_coupling),
+            dtype=torch.int32,
+            device=batch.device,
+        )
         npt_thermostat_half_step(
             self._state.nhc_b_eta,
             self._state.nhc_b_eta_dot,
@@ -324,7 +378,6 @@ class NPT(BaseDynamics):
             self.chain_length,
             self._state.dt,
         )
-        # Scale cell velocity by exp(-b_eta_dot[:,0] * dt/2).
         b_scale = torch.exp(-self._state.nhc_b_eta_dot[:, 0] * self._state.dt * 0.5)
         self._state.cell_velocity.mul_(b_scale.view(M, 1, 1))
 
@@ -352,6 +405,7 @@ class NPT(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
+            PRESSURE_MODE_CODES[self.pressure_coupling],
         )
         npt_position_update(
             batch.positions,
@@ -392,6 +446,7 @@ class NPT(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
+            PRESSURE_MODE_CODES[self.pressure_coupling],
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
@@ -407,10 +462,18 @@ class NPT(BaseDynamics):
             self._state.dt,
         )
 
-        # Barostat thermostat half step.
-        cell_v_flat = self._state.cell_velocity.reshape(M, -1)
-        ke_cell = 0.5 * self._state.W * (cell_v_flat * cell_v_flat).sum(dim=-1)
-        cell_ndof_tensor = torch.full((M,), 9, dtype=torch.int32, device=batch.device)
+        ke_cell = _cell_kinetic_energy(
+            self._state.cell_velocity,
+            self._state.W,
+            cells_inv,
+            self.pressure_coupling,
+        )
+        cell_ndof_tensor = torch.full(
+            (M,),
+            _cell_dof_count(self.pressure_coupling),
+            dtype=torch.int32,
+            device=batch.device,
+        )
         npt_thermostat_half_step(
             self._state.nhc_b_eta,
             self._state.nhc_b_eta_dot,

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -41,11 +41,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 
 from nvalchemi.data import Batch
-from nvalchemi.dynamics._ops._bridge import (
-    PRESSURE_MODE_CODES,
-    _make_state_batch,
-    _to_per_system,
-)
+from nvalchemi.dynamics._ops._bridge import _make_state_batch, _to_per_system
 from nvalchemi.dynamics._ops.nose_hoover import nhc_compute_masses
 from nvalchemi.dynamics._ops.npt_nph import (
     compute_barostat_mass,
@@ -405,7 +401,7 @@ class NPT(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
-            PRESSURE_MODE_CODES[self.pressure_coupling],
+            self.pressure_coupling,
         )
         npt_position_update(
             batch.positions,
@@ -446,7 +442,7 @@ class NPT(BaseDynamics):
             self._state.dt,
             batch.batch_idx.int(),
             cells_inv,
-            PRESSURE_MODE_CODES[self.pressure_coupling],
+            self.pressure_coupling,
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -205,6 +205,59 @@ class TestNPHIntegrator:
         assert nph._state.W.shape == (M,)
         assert nph._state.cell_velocity.shape == (M, 3, 3)
 
+    # ------------------------------------------------------------------
+    # Non-isotropic modes
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_W_divided_for_non_isotropic(self, mode, pressure):
+        """Barostat mass W is divided by 3 for non-isotropic modes."""
+        nph_iso = NPH(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            pressure=1.0,
+            barostat_time=100.0,
+            pressure_coupling="isotropic",
+        )
+        nph_aniso = NPH(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            pressure=pressure,
+            barostat_time=100.0,
+            pressure_coupling=mode,
+        )
+        batch = _make_barostat_batch()
+        nph_iso._init_state(batch)
+        nph_aniso._init_state(batch)
+        assert torch.allclose(nph_iso._state.W / 3, nph_aniso._state.W, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_pre_post_update_runs_for_non_isotropic_modes(self, mode, pressure):
+        """pre_update and post_update complete for non-isotropic modes."""
+        nph = NPH(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            pressure=pressure,
+            barostat_time=100.0,
+            pressure_coupling=mode,
+        )
+        batch = _make_barostat_batch()
+        nph._init_state(batch)
+        nph.pre_update(batch)
+        nph.post_update(batch)
+
 
 # ---------------------------------------------------------------------------
 # NPT tests
@@ -337,3 +390,110 @@ class TestNPTIntegrator:
         npt5._init_state(batch)
         assert npt5._state.nhc_Q.shape[1] == 5
         assert npt5._state.nhc_b_Q.shape[1] == 5
+
+    # ------------------------------------------------------------------
+    # Non-isotropic modes
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_init_state_preserves_pressure_shape(self, mode, pressure):
+        """_init_state keeps anisotropic [M,3] and triclinic [M,3,3] shapes."""
+        npt = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=pressure,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling=mode,
+        )
+        batch = _make_barostat_batch()
+        npt._init_state(batch)
+        assert npt._state.pressure.shape == pressure.shape
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("isotropic", 1.0),
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_nhc_b_Q_shape_all_modes(self, mode, pressure):
+        """Barostat NHC chain masses have shape [M, chain_length] for all modes."""
+        chain_length = 3
+        npt = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=pressure,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling=mode,
+            chain_length=chain_length,
+        )
+        batch = _make_barostat_batch()
+        npt._init_state(batch)
+        M = batch.num_graphs
+        assert npt._state.nhc_b_Q.shape == (M, chain_length)
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_W_divided_for_non_isotropic(self, mode, pressure):
+        """Barostat mass W is divided by 3 for non-isotropic modes."""
+        npt_iso = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=1.0,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling="isotropic",
+        )
+        npt_aniso = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=pressure,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling=mode,
+        )
+        batch = _make_barostat_batch()
+        npt_iso._init_state(batch)
+        npt_aniso._init_state(batch)
+        assert torch.allclose(npt_iso._state.W / 3, npt_aniso._state.W, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "mode,pressure",
+        [
+            ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
+            ("triclinic", torch.eye(3).unsqueeze(0)),
+        ],
+    )
+    def test_pre_post_update_runs_for_non_isotropic_modes(self, mode, pressure):
+        """pre_update and post_update complete for non-isotropic modes."""
+        npt = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=pressure,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling=mode,
+        )
+        batch = _make_barostat_batch()
+        npt._init_state(batch)
+        npt.pre_update(batch)
+        npt.post_update(batch)

--- a/test/dynamics/test_ops.py
+++ b/test/dynamics/test_ops.py
@@ -726,7 +726,7 @@ class TestNptNphOps:
         )
         kinetic_tensors = torch.zeros(M, 9, dtype=dtype, device=device)  # [M,9] array2d
         pressure_tensors = torch.zeros(M, 9, dtype=dtype, device=device)  # [M,9] vec9
-        volumes = torch.zeros(M, dtype=dtype, device=device)
+        volumes = torch.full((M,), 2.0, dtype=dtype, device=device)
         sizes = [N // M] * M
         sizes[-1] += N - sum(sizes)
         batch = _batch_idx(sizes, device)
@@ -840,6 +840,31 @@ class TestNptNphOps:
             positions, velocities, cell, cell_vel, dt, cells_inv, batch_idx
         )
         assert positions.shape == pos_orig.shape
+
+    def test_compute_pressure_tensor_tension_positive_convention(self, dtype, device):
+        """Bridge negates tension-positive stress to ops virial convention.
+
+        With zero velocities (no kinetic contribution), the pressure
+        tensor should be P = -stress / V.  A positive (tensile) stress
+        should yield negative pressure.
+        """
+        from nvalchemi.dynamics._ops.npt_nph import compute_pressure_tensor
+
+        M, N = 1, 4
+        vel = torch.zeros(N, 3, dtype=dtype, device=device)
+        mass = torch.ones(N, dtype=dtype, device=device)
+        stress = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * 3.0
+        cell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * 10.0
+        kin = torch.zeros(M, 9, dtype=dtype, device=device)
+        P_scr = torch.zeros(M, 9, dtype=dtype, device=device)
+        vol = torch.full((M,), 1.0, dtype=dtype, device=device)
+        batch = torch.zeros(N, dtype=torch.int32, device=device)
+        P = compute_pressure_tensor(vel, mass, stress, cell, kin, P_scr, vol, batch)
+        P_mat = P.reshape(M, 3, 3)
+        P_diag = torch.diagonal(P_mat, dim1=-2, dim2=-1)
+        assert (P_diag < 0).all(), (
+            f"Tensile stress should give negative pressure, got diag {P_diag}"
+        )
 
     def test_stress_to_cell_force_shape(self, dtype, device):
         from nvalchemi.dynamics._ops.npt_nph import stress_to_cell_force


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Fix multiple bugs in the NPT and NPH integrators related to virial sign conventions, pressure coupling mode forwarding, barostat mass scaling, and cell kinetic energy computation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Companion to NVIDIA/nvalchemi-toolkit-ops#66 which fixed the ops-layer strain rate, cell kinetic energy, and virial sign bugs. This PR applies the corresponding toolkit-side fixes: forwarding the `pressure_coupling` mode string and `cells_inv` through the bridge, correcting the virial sign convention at the bridge boundary, fixing barostat mass scaling and NHC DOF counts for non-isotropic modes, and aligning cell kinetic energy with the corrected ops kernel.

## Changes Made

### Bug 1 — Virial sign convention (tension-positive bridge)

The `compute_pressure_tensor` bridge wrapper now accepts stress in the tension-positive convention (matching `batch.stress` and ASE) and internally negates it (`virial = -stress`) before passing to the ops kernel which expects compression-positive virial. Previously the raw stress was passed through without negation, producing pressure with the wrong sign.

### Bug 2 — Pressure coupling mode not forwarded to ops kernels

- `npt_velocity_half_step` and `nph_velocity_half_step` now accept a `pressure_mode` string parameter (defaulting to `"isotropic"`) and pass it directly to the underlying ops drag kernels. Previously only isotropic drag was ever applied regardless of the `pressure_coupling` setting. The integrators pass `self.pressure_coupling` through without any intermediate encoding.
- `npt_barostat_half_step` and `nph_barostat_half_step` now use `_target_pressure_wp_array` to correctly convert scalar `[M]`, anisotropic `[M,3]`, or triclinic `[M,3,3]` target pressure tensors to the matching Warp array dtype. Previously only scalar was supported.
- `_to_per_system` in `_bridge.py` was generalized to preserve trailing dimensions so that anisotropic and triclinic pressure tensors are broadcast correctly.

### Bug 3 — Barostat mass not divided by 3 for non-isotropic modes

In both NPT and NPH `_init_state` and `_make_new_state`, the barostat inertia W (computed by the ops kernel as `(N_f + d) * kT * tau_P^2`) is now divided by 3 for non-isotropic modes. The ops kernel computes W for the full 3x3 cell; for anisotropic/triclinic modes each diagonal (or individual) DOF should carry W/3.

### Cell kinetic energy: ḣ → ε̇

Cell kinetic energy was computed from `||ḣ||^2` (raw cell velocities) instead of `||ε̇||^2` (strain rate `ε̇ = ḣ h⁻¹`). A new `_cell_kinetic_energy` helper computes the strain rate and takes the mode-aware Frobenius norm (diagonal only for isotropic/anisotropic, full matrix for triclinic). This aligns the toolkit with the ops `compute_cell_kinetic_energy` kernel.

### Barostat NHC DOF count

The barostat thermostat NHC now uses the correct number of dummy particles: 1 (3 DOFs) for isotropic/anisotropic modes and 3 (9 DOFs) for triclinic. Previously 3 dummy particles (9 DOFs) were used unconditionally.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New tests added:
- `test_npt_nph.py`: pressure shape preservation for anisotropic/triclinic, NHC barostat chain mass shape for all modes, W/3 verification for non-isotropic modes, pre/post_update smoke tests for anisotropic and triclinic modes (both NPT and NPH).
- `test_ops.py`: `test_compute_pressure_tensor_tension_positive_convention` verifying that positive (tensile) stress yields negative pressure through the bridge. Fixed `volumes` initialization from `torch.zeros` to `torch.full(..., 2.0)` to avoid division by zero.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

All six modified files and their roles:
- `_bridge.py`: generalized `_to_per_system` to preserve trailing dimensions for anisotropic/triclinic pressure tensors
- `npt_nph.py`: `_target_pressure_wp_array` helper, virial negation in `compute_pressure_tensor`, `pressure_mode: str` parameter on velocity half-step functions
- `npt.py`: `_cell_dof_count`, `_cell_kinetic_energy` helpers, W/3 scaling, mode forwarding, NHC DOF fix
- `nph.py`: W/3 scaling, mode forwarding
- `test_npt_nph.py`: 10 new test cases covering non-isotropic modes for both NPT and NPH
- `test_ops.py`: 1 new test case for virial sign convention, volumes fix in helper

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
