### PR TITLE
feat(models): add cutoff smoothing to DFTD3ModelWrapper

### DIFF
--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -493,6 +493,18 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
         param_file: Path | str | None = None,
     ) -> None:
         super().__init__()
+        if cutoff <= 0.0:
+            raise ValueError(f"cutoff must be positive, got {cutoff!r}")
+        if a1 < 0.0:
+            raise ValueError(f"a1 must be non-negative, got {a1!r}")
+        if a2 < 0.0:
+            raise ValueError(f"a2 must be non-negative, got {a2!r}")
+        if s8 < 0.0:
+            raise ValueError(f"s8 must be non-negative, got {s8!r}")
+        if not (0.0 <= smoothing_fraction < 1.0):
+            raise ValueError(
+                f"smoothing_fraction must be in [0, 1), got {smoothing_fraction!r}"
+            )
         self.a1 = a1
         self.a2 = a2
         self.s8 = s8
@@ -501,6 +513,8 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
         self.k3 = k3
         self.s6 = s6
         self.smoothing_fraction = smoothing_fraction
+        if max_neighbors is not None and max_neighbors <= 0:
+            raise ValueError(f"max_neighbors must be positive, got {max_neighbors!r}")
         self.max_neighbors = max_neighbors
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -50,6 +50,9 @@ Notes
   parses it in-memory, and caches the result automatically.
 * Stress/virial computation (needed for NPT/NPH) is available via
   ``model_config.active_outputs`` including ``"stress"``.
+* The reference Fortran DFT-D3 implementation uses a cutoff of 95 Bohr
+  (~50 Å) with no smoothing.  This wrapper defaults to a shorter cutoff
+  (15 Å) with C5-style smoothing controlled by ``smoothing_fraction``.
 """
 
 from __future__ import annotations
@@ -444,14 +447,17 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
     s8 : float
         C8 coefficient scaling factor (dimensionless, functional-specific).
     cutoff : float, optional
-        Interaction cutoff in Å.  Defaults to ``50.0`` Å (approx 95 Bohr),
-        which covers virtually all D3 interactions.
+        Interaction cutoff in Å.  Defaults to ``15.0`` Å.
     k1 : float, optional
         Steepness of the CN counting function (1/Bohr).  Defaults to ``16.0``.
     k3 : float, optional
         Gaussian width for CN interpolation.  Defaults to ``-4.0``.
     s6 : float, optional
         C6 scaling factor.  Defaults to ``1.0``.
+    smoothing_fraction : float, optional
+        Fraction of the cutoff radius over which the interaction is smoothly
+        tapered to zero.  Smoothing begins at ``cutoff * (1 - smoothing_fraction)``
+        and reaches zero at ``cutoff``.  Defaults to ``0.2``.
     max_neighbors : int, optional
         Maximum neighbors per atom for the neighbor matrix.  Defaults to 128.
     auto_download : bool, optional
@@ -477,10 +483,11 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
         a1: float,
         a2: float,
         s8: float,
-        cutoff: float = 50.0,
+        cutoff: float = 15.0,
         k1: float = 16.0,
         k3: float = -4.0,
         s6: float = 1.0,
+        smoothing_fraction: float = 0.2,
         max_neighbors: int | None = None,
         auto_download: bool = True,
         param_file: Path | str | None = None,
@@ -493,6 +500,7 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
         self.k1 = k1
         self.k3 = k3
         self.s6 = s6
+        self.smoothing_fraction = smoothing_fraction
         self.max_neighbors = max_neighbors
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
@@ -607,7 +615,7 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             if "virial" in model_output:
                 # The dftd3 kernel accumulates the virial as W = -Σ r_ij ⊗ F_ij
                 # (negative convention).  The framework convention for
-                # batch.stresses is the positive physical virial W_phys = +Σ r_ij ⊗ F_ij
+                # batch.stress is the positive physical virial W_phys = +Σ r_ij ⊗ F_ij
                 # (energy units, eV).  Negate here to match LJ convention.
                 output["stress"] = -model_output["virial"]
             elif "stress" in model_output:
@@ -685,6 +693,9 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             cn_ref=self.cn_ref,
         )
 
+        smoothing_on = self.cutoff * (1.0 - self.smoothing_fraction)
+        smoothing_off = self.cutoff
+
         result = dftd3(
             positions=positions_bohr,
             numbers=numbers,
@@ -694,6 +705,8 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             k1=self.k1,
             k3=self.k3,
             s6=self.s6,
+            s5_smoothing_on=smoothing_on * ANGSTROM_TO_BOHR,
+            s5_smoothing_off=smoothing_off * ANGSTROM_TO_BOHR,
             d3_params=d3_params,
             fill_value=fill_value,
             batch_idx=batch_idx,

--- a/test/models/test_dftd3.py
+++ b/test/models/test_dftd3.py
@@ -385,10 +385,11 @@ class TestDFTD3ModelWrapper:
 
     def test_default_params(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
-        assert wrapper.cutoff == pytest.approx(50.0)
+        assert wrapper.cutoff == pytest.approx(15.0)
         assert wrapper.k1 == pytest.approx(16.0)
         assert wrapper.k3 == pytest.approx(-4.0)
         assert wrapper.s6 == pytest.approx(1.0)
+        assert wrapper.smoothing_fraction == pytest.approx(0.2)
         assert wrapper.max_neighbors is None
 
     def test_custom_cutoff_and_max_neighbors(self):
@@ -397,6 +398,11 @@ class TestDFTD3ModelWrapper:
         )
         assert wrapper.cutoff == pytest.approx(30.0)
         assert wrapper.max_neighbors == 64
+
+    def test_custom_smoothing_fraction(self):
+        """Constructor stores a user-supplied smoothing_fraction."""
+        wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8, smoothing_fraction=0.3)
+        assert wrapper.smoothing_fraction == pytest.approx(0.3)
 
     def test_d3_params_registered_as_buffers(self):
         """rcov, r4r2, c6ab, cn_ref must be registered nn.Module buffers."""
@@ -815,6 +821,46 @@ class TestDFTD3ModelWrapper:
             rtol=1e-5,
             atol=1e-7,
         )
+
+    def test_forward_passes_smoothing_to_kernel(self):
+        """Smoothing distances are converted to Bohr and forwarded to dftd3()."""
+        from nvalchemi.models.dftd3 import ANGSTROM_TO_BOHR
+
+        cutoff = 20.0
+        smoothing_fraction = 0.2
+        wrapper = _make_d3_wrapper(
+            a1=0.4,
+            a2=4.4,
+            s8=0.8,
+            cutoff=cutoff,
+            smoothing_fraction=smoothing_fraction,
+        )
+        wrapper.model_config.active_outputs.add("forces")
+        wrapper.model_config.active_outputs.discard("stress")
+
+        batch = _mock_batch(n=4, b=1, with_cell=False)
+        captured: dict = {}
+
+        def fake_dftd3(**kwargs):
+            captured["s5_smoothing_on"] = kwargs["s5_smoothing_on"]
+            captured["s5_smoothing_off"] = kwargs["s5_smoothing_off"]
+            N = kwargs["positions"].shape[0]
+            B = kwargs.get("num_systems", 1)
+            return torch.zeros(B), torch.zeros(N, 3), torch.zeros(N)
+
+        modules = self._make_nvalchemiops_mock()
+        modules["nvalchemiops.torch.interactions.dispersion"].dftd3 = fake_dftd3
+        modules["nvalchemiops.torch.interactions.dispersion"].D3Parameters = MagicMock(
+            return_value=MagicMock()
+        )
+
+        with patch.dict("sys.modules", modules):
+            wrapper.forward(batch)
+
+        expected_on = cutoff * (1.0 - smoothing_fraction) * ANGSTROM_TO_BOHR
+        expected_off = cutoff * ANGSTROM_TO_BOHR
+        assert captured["s5_smoothing_on"] == pytest.approx(expected_on)
+        assert captured["s5_smoothing_off"] == pytest.approx(expected_off)
 
 
 # ===========================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Add cutoff smoothing support to `DFTD3ModelWrapper` by passing `s5_smoothing_on` and `s5_smoothing_off` to the `nvalchemiops` `dftd3` kernel. The default cutoff is changed from 50 Å to 15 Å, and a new `smoothing_fraction` parameter (default 0.2) controls the taper region. The reference Fortran DFT-D3 implementation uses ~95 Bohr (~50 Å) with no smoothing; this wrapper uses a shorter cutoff with smoothing for better performance in dynamics simulations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

## Changes Made

- Added `smoothing_fraction` parameter to `DFTD3ModelWrapper.__init__` (default `0.2`)
- Changed default `cutoff` from `50.0` to `15.0` Å
- Compute `s5_smoothing_on` and `s5_smoothing_off` in `forward()` and pass them (in Bohr) to the `dftd3` kernel
- Updated class and module docstrings to document smoothing behavior and reference implementation differences

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The `nvalchemiops` `dftd3` kernel defaults `s5_smoothing_on/off` to `1e10` (no smoothing). This change explicitly sets them based on `cutoff` and `smoothing_fraction`, matching the approach used in the reference `DFTD3ModelWrapper` implementation.