### PR TITLE
fix(models): preserve MACE atomic energies in float64 and reorder from_checkpoint pipeline

### DIFF
--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -450,19 +450,15 @@ class MACEWrapper(nn.Module, BaseModelMixin):
 
         Operations are applied in this order:
 
-        1. **Load** — ``torch.load`` the checkpoint.
-        2. **dtype** — cast model weights to the requested dtype.  The
-           atomic-energy table keeps its original backend dtype (float64)
-           for numerical stability.
+        1. **Load** — ``torch.load`` the checkpoint to the specified device.
+        2. **dtype** — cast model weights to the requested dtype.
         3. **cuEq** — convert to cuEquivariance format for GPU speedup.
         4. **compile** — ``torch.compile``; freezes parameters and sets eval
            mode.  The model is **inference-only** after this step.
 
         For best GPU throughput, use ``device=torch.device("cuda")``,
         ``enable_cueq=True``, ``dtype=torch.float32``, and
-        ``compile_model=True``.  Atomic energies are kept in the original
-        float64 precision regardless of the ``dtype`` setting, which
-        preserves numerical accuracy for large systems.  Example::
+        ``compile_model=True``.  Example::
 
             model = MACEWrapper.from_checkpoint(
                 "medium-mpa-0",
@@ -513,18 +509,11 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             cached_path, weights_only=False, map_location=device
         )
 
-        # Step 1: dtype conversion.  Atomic energies are preserved in their
-        # original dtype (float64) for numerical stability.
-        ae_fn = getattr(model, "atomic_energies_fn", None)
-        orig_ae = None
+        # Step 1: dtype conversion.
         if dtype is not None:
-            orig_ae = ae_fn.atomic_energies.clone() if ae_fn is not None else None
             model.to(dtype=dtype)
-            if orig_ae is not None:
-                ae_fn.atomic_energies = orig_ae.to(device=ae_fn.atomic_energies.device)
 
-        # Step 2: cuEq conversion.  _convert_mace_weights returns a new
-        # nn.Module, so the float64 restoration must be re-applied.
+        # Step 2: cuEq conversion.
         if enable_cueq:
             try:
                 import cuequivariance  # noqa: F401
@@ -536,12 +525,6 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             from mace.cli.convert_e3nn_cueq import run as _convert_mace_weights
 
             model = _convert_mace_weights(model, return_model=True, device=device)
-            if orig_ae is not None:
-                new_ae_fn = getattr(model, "atomic_energies_fn", None)
-                if new_ae_fn is not None:
-                    new_ae_fn.atomic_energies = orig_ae.to(
-                        device=new_ae_fn.atomic_energies.device
-                    )
 
         model = model.to(device)
 

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -516,13 +516,15 @@ class MACEWrapper(nn.Module, BaseModelMixin):
         # Step 1: dtype conversion.  Atomic energies are preserved in their
         # original dtype (float64) for numerical stability.
         ae_fn = getattr(model, "atomic_energies_fn", None)
+        orig_ae = None
         if dtype is not None:
             orig_ae = ae_fn.atomic_energies.clone() if ae_fn is not None else None
             model.to(dtype=dtype)
             if orig_ae is not None:
                 ae_fn.atomic_energies = orig_ae.to(device=ae_fn.atomic_energies.device)
 
-        # Step 2: cuEq conversion.
+        # Step 2: cuEq conversion.  _convert_mace_weights returns a new
+        # nn.Module, so the float64 restoration must be re-applied.
         if enable_cueq:
             try:
                 import cuequivariance  # noqa: F401
@@ -534,6 +536,12 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             from mace.cli.convert_e3nn_cueq import run as _convert_mace_weights
 
             model = _convert_mace_weights(model, return_model=True, device=device)
+            if orig_ae is not None:
+                new_ae_fn = getattr(model, "atomic_energies_fn", None)
+                if new_ae_fn is not None:
+                    new_ae_fn.atomic_energies = orig_ae.to(
+                        device=new_ae_fn.atomic_energies.device
+                    )
 
         model = model.to(device)
 

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -207,7 +207,8 @@ class MACEWrapper(nn.Module, BaseModelMixin):
         try:
             return next(self.parameters()).dtype
         except StopIteration:
-            return torch.float32
+            # MACE MP models default to float64
+            return torch.float64
 
     # ------------------------------------------------------------------
     # Input / output adaptation
@@ -447,17 +448,29 @@ class MACEWrapper(nn.Module, BaseModelMixin):
         (e.g. ``"medium-0b2"``), which are downloaded automatically to the
         MACE cache directory.
 
-        Operations are applied in this order to avoid numerical issues:
+        Operations are applied in this order:
 
         1. **Load** — ``torch.load`` the checkpoint.
-        2. **cuEq** — convert to cuEquivariance format (must happen while the
-           model is still in its original dtype, because
-           ``extract_config_mace_model`` reads the dtype via
-           ``torch.set_default_dtype``).
-        3. **dtype** — cast all weights (including atomic energies) uniformly
-           to the requested dtype.
+        2. **dtype** — cast model weights to the requested dtype.  The
+           atomic-energy table keeps its original backend dtype (float64)
+           for numerical stability.
+        3. **cuEq** — convert to cuEquivariance format for GPU speedup.
         4. **compile** — ``torch.compile``; freezes parameters and sets eval
            mode.  The model is **inference-only** after this step.
+
+        For best GPU throughput, use ``device=torch.device("cuda")``,
+        ``enable_cueq=True``, ``dtype=torch.float32``, and
+        ``compile_model=True``.  Atomic energies are kept in the original
+        float64 precision regardless of the ``dtype`` setting, which
+        preserves numerical accuracy for large systems.  Example::
+
+            model = MACEWrapper.from_checkpoint(
+                "medium-mpa-0",
+                device=torch.device("cuda"),
+                dtype=torch.float32,
+                enable_cueq=True,
+                compile_model=True,
+            )
 
         Parameters
         ----------
@@ -467,10 +480,10 @@ class MACEWrapper(nn.Module, BaseModelMixin):
         device : torch.device, optional
             Target device.  Defaults to CPU.
         enable_cueq : bool, optional
-            Convert to cuEquivariance format for GPU speedup.  Requires the
-            ``cuequivariance`` package.
+            Convert to cuEquivariance format for GPU speedup.  Defaults to
+            ``False``.  Requires the ``cuequivariance`` package.
         dtype : torch.dtype | None, optional
-            If set, cast model weights to this dtype after cuEq conversion.
+            If set, cast model weights to this dtype before cuEq conversion.
         compile_model : bool, optional
             Apply ``torch.compile``.  Sets eval mode and freezes parameters;
             the model is **inference-only** after this step.
@@ -500,7 +513,16 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             cached_path, weights_only=False, map_location=device
         )
 
-        # Step 1: cuEq conversion before dtype change.
+        # Step 1: dtype conversion.  Atomic energies are preserved in their
+        # original dtype (float64) for numerical stability.
+        ae_fn = getattr(model, "atomic_energies_fn", None)
+        orig_ae = ae_fn.atomic_energies.clone() if ae_fn is not None else None
+        if dtype is not None:
+            model.to(dtype=dtype)
+        if orig_ae is not None:
+            ae_fn.atomic_energies = orig_ae.to(device=ae_fn.atomic_energies.device)
+
+        # Step 2: cuEq conversion.
         if enable_cueq:
             try:
                 import cuequivariance  # noqa: F401
@@ -512,10 +534,6 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             from mace.cli.convert_e3nn_cueq import run as _convert_mace_weights
 
             model = _convert_mace_weights(model, return_model=True, device=device)
-
-        # Step 2: dtype conversion.
-        if dtype is not None:
-            model.to(dtype=dtype)
 
         model = model.to(device)
 

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -516,11 +516,11 @@ class MACEWrapper(nn.Module, BaseModelMixin):
         # Step 1: dtype conversion.  Atomic energies are preserved in their
         # original dtype (float64) for numerical stability.
         ae_fn = getattr(model, "atomic_energies_fn", None)
-        orig_ae = ae_fn.atomic_energies.clone() if ae_fn is not None else None
         if dtype is not None:
+            orig_ae = ae_fn.atomic_energies.clone() if ae_fn is not None else None
             model.to(dtype=dtype)
-        if orig_ae is not None:
-            ae_fn.atomic_energies = orig_ae.to(device=ae_fn.atomic_energies.device)
+            if orig_ae is not None:
+                ae_fn.atomic_energies = orig_ae.to(device=ae_fn.atomic_energies.device)
 
         # Step 2: cuEq conversion.
         if enable_cueq:

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -59,6 +59,11 @@ class _MockProduct:
     linear = _MockLinear()
 
 
+class _MockAtomicEnergiesFn:
+    def __init__(self, numbers: list[int]) -> None:
+        self.atomic_energies = torch.zeros(len(numbers), dtype=torch.float64)
+
+
 class MockMACEModel(torch.nn.Module):
     """Minimal MACE-like model for unit tests.
 
@@ -83,6 +88,8 @@ class MockMACEModel(torch.nn.Module):
         # Replicate the attribute path MACEWrapper.embedding_shapes probes:
         #   model.products[0].linear.irreps_out.dim
         self.products = [_MockProduct()]
+
+        self.atomic_energies_fn = _MockAtomicEnergiesFn(numbers)
 
         # Real parameter so _model_dtype works (next(model.parameters()).dtype).
         self._param = torch.nn.Linear(1, hidden_dim, bias=False)
@@ -643,7 +650,6 @@ class TestFromCheckpointErrors:
                 raise ImportError("no module named cuequivariance")
             return real_import(name, *args, **kwargs)
 
-        # Patch the checkpoint loader to return mock_model without network access.
         monkeypatch.setattr(
             "mace.calculators.foundations_models.download_mace_mp_checkpoint",
             lambda _: "unused",
@@ -751,8 +757,8 @@ class TestRealCheckpoint:
             pytest.skip(f"Checkpoint unavailable: {e}")
         assert w._model_dtype == torch.float32
 
-    def test_dtype_conversion_uniform(self):
-        """All weights including atomic energy are converted to the target dtype."""
+    def test_atomic_energies_preserved_in_float64(self):
+        """Atomic energies stay in float64 even when model is cast to float32."""
         try:
             w = MACEWrapper.from_checkpoint(
                 "small-0b", device=torch.device("cpu"), dtype=torch.float32
@@ -760,8 +766,7 @@ class TestRealCheckpoint:
         except Exception as e:
             pytest.skip(f"Checkpoint unavailable: {e}")
         ae = w.model.atomic_energies_fn.atomic_energies
-        # atomic_energies must match the model dtype so matmul with node_attrs works
-        assert ae.dtype == torch.float32
+        assert ae.dtype == torch.float64
 
     def test_export_and_reload(self, real_wrapper_cpu, tmp_path):
         path = tmp_path / "small_ob.pt"

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -59,15 +59,6 @@ class _MockProduct:
     linear = _MockLinear()
 
 
-class _MockAtomicEnergiesFn(torch.nn.Module):
-    def __init__(self, numbers: list[int]) -> None:
-        super().__init__()
-        self.register_buffer(
-            "atomic_energies",
-            torch.zeros(len(numbers), dtype=torch.float64),
-        )
-
-
 class MockMACEModel(torch.nn.Module):
     """Minimal MACE-like model for unit tests.
 
@@ -92,8 +83,6 @@ class MockMACEModel(torch.nn.Module):
         # Replicate the attribute path MACEWrapper.embedding_shapes probes:
         #   model.products[0].linear.irreps_out.dim
         self.products = [_MockProduct()]
-
-        self.atomic_energies_fn = _MockAtomicEnergiesFn(numbers)
 
         # Real parameter so _model_dtype works (next(model.parameters()).dtype).
         self._param = torch.nn.Linear(1, hidden_dim, bias=False)
@@ -761,8 +750,8 @@ class TestRealCheckpoint:
             pytest.skip(f"Checkpoint unavailable: {e}")
         assert w._model_dtype == torch.float32
 
-    def test_atomic_energies_preserved_in_float64(self):
-        """Atomic energies stay in float64 even when model is cast to float32."""
+    def test_dtype_conversion_uniform(self):
+        """All weights including atomic energy are converted to the target dtype."""
         try:
             w = MACEWrapper.from_checkpoint(
                 "small-0b", device=torch.device("cpu"), dtype=torch.float32
@@ -770,11 +759,7 @@ class TestRealCheckpoint:
         except Exception as e:
             pytest.skip(f"Checkpoint unavailable: {e}")
         ae = w.model.atomic_energies_fn.atomic_energies
-        assert ae.dtype == torch.float64
-
-        batch = _water_batch(dtype=torch.float32)
-        out = w.forward(batch)
-        assert out["energy"].shape == (1, 1)
+        assert ae.dtype == torch.float32
 
     def test_export_and_reload(self, real_wrapper_cpu, tmp_path):
         path = tmp_path / "small_ob.pt"

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -59,9 +59,13 @@ class _MockProduct:
     linear = _MockLinear()
 
 
-class _MockAtomicEnergiesFn:
+class _MockAtomicEnergiesFn(torch.nn.Module):
     def __init__(self, numbers: list[int]) -> None:
-        self.atomic_energies = torch.zeros(len(numbers), dtype=torch.float64)
+        super().__init__()
+        self.register_buffer(
+            "atomic_energies",
+            torch.zeros(len(numbers), dtype=torch.float64),
+        )
 
 
 class MockMACEModel(torch.nn.Module):
@@ -767,6 +771,10 @@ class TestRealCheckpoint:
             pytest.skip(f"Checkpoint unavailable: {e}")
         ae = w.model.atomic_energies_fn.atomic_energies
         assert ae.dtype == torch.float64
+
+        batch = _water_batch(dtype=torch.float32)
+        out = w.forward(batch)
+        assert out["energy"].shape == (1, 1)
 
     def test_export_and_reload(self, real_wrapper_cpu, tmp_path):
         path = tmp_path / "small_ob.pt"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Fix MACEWrapper `from_checkpoint` to preserve atomic energies in float64 during dtype conversion, correct the `_model_dtype` fallback, reorder dtype/cuEq operations, and add GPU performance documentation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

## Changes Made

- Preserve `atomic_energies_fn.atomic_energies` in float64 when `dtype=torch.float32` is passed to `from_checkpoint`, preventing numerical drift on large systems
- Change `_model_dtype` fallback from `torch.float32` to `torch.float64` to match MACE MP native precision
- Reorder `from_checkpoint` pipeline: dtype conversion now runs before cuEq conversion (load → dtype → cuEq → compile)
- Add GPU performance tips with code example to `from_checkpoint` docstring
- Add `_MockAtomicEnergiesFn` to `MockMACEModel` in tests and update `test_dtype_conversion_uniform` → `test_atomic_energies_preserved_in_float64` to assert float64

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The `from_checkpoint` operation order is now: load → dtype → cuEq → compile. This ensures cuEq sees the final weight precision and configures its kernels accordingly. Atomic energies are saved before `model.to(dtype=...)` and restored afterward so they remain in their original float64 regardless of the compute dtype.