### PR TITLE
Feat/optional max batch size

### DIFF
--- a/nvalchemi/dynamics/sampler.py
+++ b/nvalchemi/dynamics/sampler.py
@@ -55,11 +55,15 @@ class SizeAwareSampler(Sampler[int]):
     max_atoms : int | None
         Maximum total atoms across all samples in a batch. ``None`` disables
         the atom count constraint (GPU memory estimate may still apply).
+        At least one of ``max_atoms`` or ``max_batch_size`` must be set.
     max_edges : int | None
         Maximum total edges across all samples in a batch. ``None`` disables
         the edge count constraint.
-    max_batch_size : int
-        Maximum number of samples (graphs) in a batch.
+    max_batch_size : int | None
+        Maximum number of samples (graphs) in a batch. ``None`` disables the
+        graph-count constraint, letting ``max_atoms`` (and/or ``max_edges``)
+        alone control batch capacity. At least one of ``max_atoms`` or
+        ``max_batch_size`` must be set.
     bin_width : int
         Atom-count bin width for grouping samples. Default 1.
     shuffle : bool
@@ -76,7 +80,8 @@ class SizeAwareSampler(Sampler[int]):
         ``num_edges > max_edges`` — such samples can never be placed into
         any batch and indicate a configuration error.
     ValueError
-        If ``max_batch_size < 1``, ``bin_width < 1``, or
+        If both ``max_atoms`` and ``max_batch_size`` are ``None``,
+        ``max_batch_size < 1``, ``bin_width < 1``, or
         ``max_gpu_memory_fraction`` is not in ``(0.0, 1.0]``.
 
     Examples
@@ -89,9 +94,9 @@ class SizeAwareSampler(Sampler[int]):
     def __init__(
         self,
         dataset: Any,
-        max_atoms: int | None,
-        max_edges: int | None,
-        max_batch_size: int,
+        max_atoms: int | None = None,
+        max_edges: int | None = None,
+        max_batch_size: int | None = None,
         bin_width: int = 1,
         shuffle: bool = False,
         max_gpu_memory_fraction: float = 0.8,
@@ -106,11 +111,14 @@ class SizeAwareSampler(Sampler[int]):
         max_atoms : int | None
             Maximum total atoms across all samples in a batch. ``None`` disables
             the atom count constraint (GPU memory estimate may still apply).
+            At least one of ``max_atoms`` or ``max_batch_size`` must be set.
         max_edges : int | None
             Maximum total edges across all samples in a batch. ``None`` disables
             the edge count constraint.
-        max_batch_size : int
-            Maximum number of samples (graphs) in a batch.
+        max_batch_size : int | None
+            Maximum number of samples (graphs) in a batch. ``None`` disables
+            the graph-count constraint. At least one of ``max_atoms`` or
+            ``max_batch_size`` must be set.
         bin_width : int
             Atom-count bin width for grouping samples. Default 1.
         shuffle : bool
@@ -125,13 +133,16 @@ class SizeAwareSampler(Sampler[int]):
         RuntimeError
             If any sample exceeds ``max_atoms`` or ``max_edges`` constraints.
         ValueError
-            If ``max_batch_size < 1``, ``bin_width < 1``, or
+            If both ``max_atoms`` and ``max_batch_size`` are ``None``,
+            ``max_batch_size < 1``, ``bin_width < 1``, or
             ``max_gpu_memory_fraction`` is not in ``(0.0, 1.0]``.
         TypeError
             If dataset does not implement required interface.
         """
         # Validate parameters
-        if max_batch_size < 1:
+        if max_atoms is None and max_batch_size is None:
+            raise ValueError("At least one of max_atoms or max_batch_size must be set.")
+        if max_batch_size is not None and max_batch_size < 1:
             raise ValueError(f"max_batch_size must be >= 1, got {max_batch_size}")
         if bin_width < 1:
             raise ValueError(f"bin_width must be >= 1, got {bin_width}")
@@ -275,6 +286,10 @@ class SizeAwareSampler(Sampler[int]):
             else:
                 effective_max_atoms = gpu_max_atoms
 
+        effective_max_batch: int | float = (
+            self._max_batch_size if self._max_batch_size is not None else float("inf")
+        )
+
         data_list: list[AtomicData] = []
         total_atoms = 0
         total_edges = 0
@@ -299,7 +314,7 @@ class SizeAwareSampler(Sampler[int]):
                 num_atoms, num_edges = self._sample_meta[idx]
 
                 # Check capacity constraints
-                if len(data_list) >= self._max_batch_size:
+                if len(data_list) >= effective_max_batch:
                     break
                 if (
                     effective_max_atoms is not None
@@ -325,7 +340,7 @@ class SizeAwareSampler(Sampler[int]):
                 self._consumed.add(idx)
 
             # Stop if batch is full
-            if len(data_list) >= self._max_batch_size:
+            if len(data_list) >= effective_max_batch:
                 break
 
         if not data_list:

--- a/test/dynamics/test_sampler.py
+++ b/test/dynamics/test_sampler.py
@@ -200,6 +200,52 @@ class TestSizeAwareSamplerConstruction:
                 max_batch_size=-1,
             )
 
+    def test_both_none_raises_valueerror(self) -> None:
+        """Both max_atoms=None and max_batch_size=None should raise ValueError."""
+        samples = [(10, 20)]
+        dataset = MockDataset(samples)
+
+        with pytest.raises(
+            ValueError, match="At least one of max_atoms or max_batch_size"
+        ):
+            SizeAwareSampler(
+                dataset=dataset,
+                max_atoms=None,
+                max_edges=200,
+                max_batch_size=None,
+            )
+
+    def test_max_batch_size_only(self) -> None:
+        """max_atoms=None with max_batch_size set should work (batch-size-only mode)."""
+        samples = [(10, 20), (15, 30), (8, 16), (12, 24), (5, 10)]
+        dataset = MockDataset(samples)
+
+        sampler = SizeAwareSampler(
+            dataset=dataset,
+            max_atoms=None,
+            max_edges=None,
+            max_batch_size=3,
+        )
+
+        batch = sampler.build_initial_batch()
+        assert batch.num_graphs == 3
+
+    def test_max_atoms_only(self) -> None:
+        """max_batch_size=None with max_atoms set should work (atom-only mode)."""
+        samples = [(5, 10), (5, 10), (5, 10), (5, 10), (5, 10)]
+        dataset = MockDataset(samples)
+
+        sampler = SizeAwareSampler(
+            dataset=dataset,
+            max_atoms=20,
+            max_edges=None,
+            max_batch_size=None,
+        )
+
+        batch = sampler.build_initial_batch()
+        assert batch.num_nodes <= 20
+        assert batch.num_graphs == 4
+
     def test_invalid_bin_width(self) -> None:
         """bin_width < 1 should raise ValueError."""
         samples = [(10, 20)]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Make both `max_atoms` and `max_batch_size` optional on `SizeAwareSampler`, requiring at least one to be set. Previously `max_batch_size` was a required `int`, forcing users to manually adjust it whenever system sizes changed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

## Changes Made

- Changed `max_batch_size` from `int` to `int | None = None` and `max_atoms`/`max_edges` defaults to `None` in `SizeAwareSampler.__init__`
- Added validation that raises `ValueError` when both `max_atoms` and `max_batch_size` are `None`
- Guarded `_max_batch_size` comparisons in `build_initial_batch` to treat `None` as unbounded
- Updated class and `__init__` docstrings to document new types, defaults, and constraints

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Three new tests added:
- `test_both_none_raises_valueerror` -- both `None` raises `ValueError`
- `test_max_batch_size_only` -- batch-size-only mode works
- `test_max_atoms_only` -- atom-only mode works with unbounded batch size

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have updated the documentation (if applicable)