### PR TITLE
fix(models): store Cauchy stress W/V in batch.stress instead of raw virial

### DIFF
--- a/nvalchemi/data/atomic_data.py
+++ b/nvalchemi/data/atomic_data.py
@@ -227,7 +227,7 @@ class AtomicData(BaseModel, DataMixin):
 
     stress: Annotated[
         t.Stress | None,
-        Field(description="Stress tensor [1, 3, 3]"),
+        Field(description="Cauchy stress W/V (eV/A^3) [1, 3, 3]"),
         PlainSerializer(_tensor_serialization, when_used="json"),
     ] = None
 

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -119,7 +119,7 @@ __all__ = [
 def compute_pressure_tensor(
     velocities: torch.Tensor,
     masses: torch.Tensor,
-    stress: torch.Tensor,
+    virial: torch.Tensor,
     cell: torch.Tensor,
     kinetic_tensors: torch.Tensor,
     pressure_tensors: torch.Tensor,
@@ -140,7 +140,7 @@ def compute_pressure_tensor(
         Atomic velocities ``[N, 3]``, float32 or float64.
     masses : torch.Tensor
         Per-atom masses ``[N]``, same dtype.
-    stress : torch.Tensor
+    virial : torch.Tensor
         Per-system virial tensor ``W = -dE/d(epsilon)`` ``[M, 3, 3]``
         in eV, same dtype.
     cell : torch.Tensor
@@ -160,7 +160,7 @@ def compute_pressure_tensor(
     torch.Tensor
         Pressure tensor ``[M, 9]`` (vec9 layout), same dtype as *velocities*.
     """
-    M = stress.shape[0]
+    M = virial.shape[0]
     dtype = velocities.dtype
     vec_t = _vec_type(dtype)
     mat_t = _mat_type(dtype)
@@ -171,7 +171,7 @@ def compute_pressure_tensor(
     P_wp = _compute_P(
         wp.from_torch(velocities, dtype=vec_t),
         wp.from_torch(masses, dtype=scl_t),
-        wp.from_torch(stress.reshape(M, 9).contiguous(), dtype=vec9_t),
+        wp.from_torch(virial.reshape(M, 9).contiguous(), dtype=vec9_t),
         wp.from_torch(cell, dtype=mat_t),
         wp.from_torch(kinetic_tensors, dtype=scl_t),  # [M, 9] array2d scalar
         wp.from_torch(pressure_tensors, dtype=vec9_t),  # [M, 9] as vec9 [M]
@@ -185,14 +185,14 @@ def compute_pressure_tensor(
 def _compute_pressure_tensor_fake(
     velocities,
     masses,
-    stress,
+    virial,
     cell,
     kinetic_tensors,
     pressure_tensors,
     volumes,
     batch_idx,
 ) -> torch.Tensor:
-    M = stress.shape[0]
+    M = virial.shape[0]
     return velocities.new_empty(M, 9)
 
 

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -141,8 +141,8 @@ def compute_pressure_tensor(
     masses : torch.Tensor
         Per-atom masses ``[N]``, same dtype.
     stress : torch.Tensor
-        Per-system virial/stress tensor ``[M, 3, 3]`` from the model,
-        same dtype.
+        Per-system virial tensor ``W = -dE/d(epsilon)`` ``[M, 3, 3]``
+        in eV, same dtype.
     cell : torch.Tensor
         Per-system cell matrix ``[M, 3, 3]``, same dtype.
     kinetic_tensors : torch.Tensor

--- a/nvalchemi/dynamics/integrators/nph.py
+++ b/nvalchemi/dynamics/integrators/nph.py
@@ -189,10 +189,13 @@ class NPH(BaseDynamics):
 
     def _compute_P(self, batch: Batch, volumes: torch.Tensor) -> torch.Tensor:
         """Compute the instantaneous pressure tensor."""
+        # batch.stress is Cauchy stress W/V (eV/A^3).
+        # compute_pressure_tensor expects virial W (eV).
+        virial = batch.stress * volumes.view(-1, 1, 1)
         return compute_pressure_tensor(
             batch.velocities,
             batch.atomic_masses,
-            batch.stress,
+            virial,
             batch.cell,
             self._state.kinetic_tensors,
             self._state.pressure_tensors,

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -258,10 +258,13 @@ class NPT(BaseDynamics):
 
     def _compute_P(self, batch: Batch, volumes: torch.Tensor) -> torch.Tensor:
         """Compute the instantaneous pressure tensor."""
+        # batch.stress is Cauchy stress W/V (eV/A^3).
+        # compute_pressure_tensor expects virial W (eV).
+        virial = batch.stress * volumes.view(-1, 1, 1)
         return compute_pressure_tensor(
             batch.velocities,
             batch.atomic_masses,
-            batch.stress,
+            virial,
             batch.cell,
             self._state.kinetic_tensors,
             self._state.pressure_tensors,

--- a/nvalchemi/dynamics/optimizers/fire2.py
+++ b/nvalchemi/dynamics/optimizers/fire2.py
@@ -338,10 +338,8 @@ class FIRE2VariableCell(BaseDynamics):
             updated in-place.
         """
         volumes = torch.linalg.det(batch.cell).abs()
-        # batch.stress is the raw virial W_phys (energy units, eV).
-        # stress_to_cell_force expects the mechanical stress σ = W_phys / V
-        # (energy/volume units), so divide by volume here.
-        stress_sigma = batch.stress / volumes.view(-1, 1, 1)
+        # batch.stress is Cauchy stress W/V (eV/A^3).
+        stress_sigma = batch.stress
         cell_force = stress_to_cell_force(stress_sigma, batch.cell, volumes)
         fire2_step_coord_cell(
             batch.positions,

--- a/nvalchemi/models/_ops/lj.py
+++ b/nvalchemi/models/_ops/lj.py
@@ -30,15 +30,9 @@ virials are computed analytically inside the Warp kernels.
 
 Sign Convention
 ---------------
-The LJ kernels accumulate the virial with the convention ``W = -Σ r_ij ⊗ F_ij``
-(negative).  The MTK NPT/NPH integrator expects the *positive* convention
-``+Σ r_ij ⊗ F_ij``; :class:`~nvalchemi.models.lj.LennardJonesModelWrapper`
-negates the output before writing to ``batch.stress``.
-
-Variable-cell optimizers (:class:`~nvalchemi.dynamics.optimizers.FIRE2VariableCell`,
-:class:`~nvalchemi.dynamics.optimizers.FIREVariableCell`) require the mechanical
-stress tensor ``σ = W_phys / V``; they divide ``batch.stress`` by the cell volume
-internally before calling ``stress_to_cell_force``.
+The LJ kernels produce the virial ``W = -dE/d(epsilon)`` (energy units, eV).
+The model wrapper divides by cell volume to obtain the Cauchy stress
+``σ = W / V`` (eV/Å³) and stores it in ``batch.stress``.
 
 Notes
 -----

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -154,7 +154,9 @@ def autograd_stresses(
     training: bool = False,
     retain_graph: bool = False,
 ) -> Stress:
-    """Compute stresses as ``-1/V * dE/d(strain)`` via autograd.
+    """Compute Cauchy stress as ``W/V = -1/V * dE/d(strain)`` via autograd.
+
+    Returns the Cauchy stress tensor in eV/Å³.
 
     Parameters
     ----------
@@ -174,7 +176,7 @@ def autograd_stresses(
     Returns
     -------
     torch.Tensor
-        Stress tensor of shape ``[B, 3, 3]``.
+        Cauchy stress tensor of shape ``[B, 3, 3]`` in eV/Å³.
     """
     effective_retain = retain_graph or training
     grad = torch.autograd.grad(

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -627,11 +627,14 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             output["forces"] = model_output["forces"]
         if "stress" in self.model_config.active_outputs:
             if "virial" in model_output:
-                # The dftd3 kernel accumulates the virial as W = -Σ r_ij ⊗ F_ij
-                # (negative convention).  The framework convention for
-                # batch.stress is the positive physical virial W_phys = +Σ r_ij ⊗ F_ij
-                # (energy units, eV).  Negate here to match LJ convention.
-                output["stress"] = -model_output["virial"]
+                if not hasattr(data, "cell") or data.cell is None:
+                    raise ValueError(
+                        "stress output requires cell for volume computation"
+                    )
+                # Cauchy stress sigma = W/V (eV/A^3).
+                virial = model_output["virial"]
+                volume = torch.det(data.cell).abs().view(-1, 1, 1)
+                output["stress"] = virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
         return output
@@ -667,8 +670,8 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
         ModelOutputs
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
-            ``"stress"`` (shape ``[B, 3, 3]``, eV — the physical virial
-            ``+Σ r_ij ⊗ F_ij``).
+            ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
+            ``W/V``).
         """
         from nvalchemiops.torch.interactions.dispersion import (  # lazy
             D3Parameters,

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -637,6 +637,10 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
                 output["stress"] = virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
+            else:
+                raise RuntimeError(
+                    "'stress' is in active_outputs but missing from model output"
+                )
         return output
 
     def output_data(self) -> set[str]:

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -303,8 +303,8 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         ModelOutputs
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
-            ``"stress"`` (shape ``[B, 3, 3]``, eV — the raw virial
-            :math:`W_{phys}`).
+            ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
+            ``W/V``).
         """
         from nvalchemiops.torch.interactions.electrostatics.ewald import (  # lazy
             ewald_real_space,
@@ -446,9 +446,9 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:
-            # The ewald kernels accumulate W = Σ r_ij ⊗ F_ij (positive convention).
-            # Store directly as stresses (W_phys) — the barostat divides by V.
-            model_output["stress"] = virial
+            # Cauchy stress sigma = W/V (eV/A^3).
+            volume = torch.det(data.cell).abs().view(-1, 1, 1)
+            model_output["stress"] = virial / volume
 
         return self.adapt_output(model_output, data)
 

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -273,6 +273,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         if "stress" in self.model_config.active_outputs:
             if "stress" in model_output:
                 output["stress"] = model_output["stress"]
+            else:
+                raise RuntimeError(
+                    "'stress' is in active_outputs but missing from model output"
+                )
         return output
 
     def output_data(self) -> set[str]:
@@ -449,6 +453,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             # Cauchy stress sigma = W/V (eV/A^3).
             volume = torch.det(data.cell).abs().view(-1, 1, 1)
             model_output["stress"] = virial / volume
+        elif compute_stresses:
+            raise RuntimeError(
+                "stress was requested but the kernel did not return a virial"
+            )
 
         return self.adapt_output(model_output, data)
 

--- a/nvalchemi/models/lj.py
+++ b/nvalchemi/models/lj.py
@@ -261,6 +261,10 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
                 output["stress"] = virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
+            else:
+                raise RuntimeError(
+                    "'stress' is in active_outputs but missing from model output"
+                )
         return output
 
     def output_data(self) -> set[str]:

--- a/nvalchemi/models/lj.py
+++ b/nvalchemi/models/lj.py
@@ -46,11 +46,11 @@ Notes
   are scalar parameters shared across all atom pairs.
 * Stress/virial computation (needed for NPT/NPH) is available via
   ``model_config.active_outputs`` including ``"stress"``.  When enabled, the
-  wrapper returns a ``"stress"`` key containing ``-W_LJ`` (the physical
-  virial ``+Σ r_ij ⊗ F_ij``), which is what the NPT/NPH barostat kernels
-  expect.  After calling ``Batch.from_data_list``, set the placeholder
-  directly: ``batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)``.  This
-  is required because ``"stress"`` is not a named ``AtomicData`` field and is
+  wrapper returns a ``"stress"`` key containing the Cauchy stress
+  ``W/V`` in energy units.  After calling ``Batch.from_data_list``, set the
+  placeholder directly:
+  ``batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)``.  This is
+  required because ``"stress"`` is not a named ``AtomicData`` field and is
   therefore not carried through batching automatically.
 """
 
@@ -251,13 +251,14 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
             output["forces"] = model_output["forces"]
         if "stress" in self.model_config.active_outputs:
             if "virial" in model_output:
-                # LJ kernel returns W = -Σ r_ij ⊗ F_ij (negative-convention virial).
-                # The framework convention for batch.stresses is the positive raw virial
-                # W_phys = +Σ r_ij ⊗ F_ij (energy units, eV), so we negate here.
-                # NPT/NPH compute_pressure_tensor divides by V internally.
-                # Variable-cell optimizers (FIRE2VariableCell) divide by V themselves
-                # before calling stress_to_cell_force.
-                output["stress"] = -model_output["virial"]
+                if not hasattr(data, "cell") or data.cell is None:
+                    raise ValueError(
+                        "stress output requires cell for volume computation"
+                    )
+                # Cauchy stress sigma = W/V (eV/A^3).
+                virial = model_output["virial"]
+                volume = torch.det(data.cell).abs().view(-1, 1, 1)
+                output["stress"] = virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
         return output
@@ -292,8 +293,8 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
         ModelOutputs
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``),
             ``"forces"`` (shape ``[N, 3]``), and optionally
-            ``"stress"`` (shape ``[B, 3, 3]``) — the physical virial
-            ``-W_LJ`` in units of eV, ready for NPT/NPH barostat use.
+            ``"stress"`` (shape ``[B, 3, 3]``) — Cauchy stress
+            ``W/V`` in energy units.
         """
         inp = self.adapt_input(data, **kwargs)
 

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -309,6 +309,10 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         if "stress" in self.model_config.active_outputs:
             if "stress" in model_output:
                 output["stress"] = model_output["stress"]
+            else:
+                raise RuntimeError(
+                    "'stress' is in active_outputs but missing from model output"
+                )
         return output
 
     def output_data(self) -> set[str]:
@@ -475,6 +479,10 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             # Cauchy stress sigma = W/V (eV/A^3).
             volume = torch.det(data.cell).abs().view(-1, 1, 1)
             model_output["stress"] = virial / volume
+        elif compute_stresses:
+            raise RuntimeError(
+                "stress was requested but the kernel did not return a virial"
+            )
 
         return self.adapt_output(model_output, data)
 

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -339,8 +339,8 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         ModelOutputs
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
-            ``"stress"`` (shape ``[B, 3, 3]``, eV — the raw virial
-            :math:`W_{phys}`).
+            ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
+            ``W/V``).
         """
         from nvalchemiops.torch.interactions.electrostatics.pme import (  # lazy
             particle_mesh_ewald,
@@ -472,9 +472,9 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:
-            # particle_mesh_ewald accumulates W = Σ r_ij ⊗ F_ij (positive convention).
-            # Store directly as stresses (W_phys) — the barostat divides by V.
-            model_output["stress"] = virial
+            # Cauchy stress sigma = W/V (eV/A^3).
+            volume = torch.det(data.cell).abs().view(-1, 1, 1)
+            model_output["stress"] = virial / volume
 
         return self.adapt_output(model_output, data)
 

--- a/test/dynamics/test_ops.py
+++ b/test/dynamics/test_ops.py
@@ -714,9 +714,9 @@ class TestNptNphOps:
         torch.manual_seed(8)
         velocities = torch.randn(N, 3, dtype=dtype, device=device)
         masses = torch.ones(N, dtype=dtype, device=device)
-        # Random symmetric stress tensors.
+        # Random symmetric virial tensors.
         S = torch.randn(M, 3, 3, dtype=dtype, device=device)
-        stress = 0.5 * (S + S.transpose(-1, -2))
+        virial = 0.5 * (S + S.transpose(-1, -2))
         # Identity cells.
         cell = (
             torch.eye(3, dtype=dtype, device=device)
@@ -733,7 +733,7 @@ class TestNptNphOps:
         return (
             velocities,
             masses,
-            stress,
+            virial,
             cell,
             kinetic_tensors,
             pressure_tensors,
@@ -745,10 +745,10 @@ class TestNptNphOps:
         from nvalchemi.dynamics._ops.npt_nph import compute_pressure_tensor
 
         M, N = 2, 8
-        vel, mass, stress, cell, kin, P_scr, vol, batch = self._make_pressure(
+        vel, mass, virial, cell, kin, P_scr, vol, batch = self._make_pressure(
             M, N, dtype, device
         )
-        P = compute_pressure_tensor(vel, mass, stress, cell, kin, P_scr, vol, batch)
+        P = compute_pressure_tensor(vel, mass, virial, cell, kin, P_scr, vol, batch)
         assert P.shape == (M, 9)
         assert P.dtype == dtype
 
@@ -756,10 +756,10 @@ class TestNptNphOps:
         from nvalchemi.dynamics._ops.npt_nph import compute_pressure_tensor
 
         M, N = 1, 4
-        vel, mass, stress, cell, kin, P_scr, vol, batch = self._make_pressure(
+        vel, mass, virial, cell, kin, P_scr, vol, batch = self._make_pressure(
             M, N, dtype, device
         )
-        P = compute_pressure_tensor(vel, mass, stress, cell, kin, P_scr, vol, batch)
+        P = compute_pressure_tensor(vel, mass, virial, cell, kin, P_scr, vol, batch)
         assert P.shape == (1, 9)
 
     def test_compute_scalar_pressure(self, dtype, device):

--- a/test/models/test_dftd3.py
+++ b/test/models/test_dftd3.py
@@ -564,6 +564,7 @@ class TestDFTD3ModelWrapper:
 
     def test_adapt_output_energy_always_present(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
+        wrapper.model_config.active_outputs.discard("stress")
         batch = _mock_batch()
         raw = {
             "energy": torch.tensor([[1.0]]),
@@ -575,6 +576,7 @@ class TestDFTD3ModelWrapper:
     def test_adapt_output_forces_when_active(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
         wrapper.model_config.active_outputs.add("forces")
+        wrapper.model_config.active_outputs.discard("stress")
         batch = _mock_batch()
         raw = {
             "energy": torch.tensor([[1.0]]),
@@ -586,6 +588,7 @@ class TestDFTD3ModelWrapper:
     def test_adapt_output_no_forces_when_inactive(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
         wrapper.model_config.active_outputs.discard("forces")
+        wrapper.model_config.active_outputs.discard("stress")
         batch = _mock_batch()
         raw = {
             "energy": torch.tensor([[1.0]]),
@@ -650,8 +653,21 @@ class TestDFTD3ModelWrapper:
         assert "stress" in out
         torch.testing.assert_close(out["stress"], stress)
 
+    def test_adapt_output_stress_raises_when_missing(self):
+        """RuntimeError when stress is active but model_output has neither virial nor stress."""
+        wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
+        wrapper.model_config.active_outputs.add("stress")
+        batch = _mock_batch()
+        raw = {
+            "energy": torch.tensor([[1.0]]),
+            "forces": torch.zeros(4, 3),
+        }
+        with pytest.raises(RuntimeError, match="missing from model output"):
+            wrapper.adapt_output(raw, batch)
+
     def test_adapt_output_returns_ordered_dict(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
+        wrapper.model_config.active_outputs.discard("stress")
         batch = _mock_batch()
         raw = {"energy": torch.tensor([[1.0]]), "forces": torch.zeros(4, 3)}
         out = wrapper.adapt_output(raw, batch)

--- a/test/models/test_dftd3.py
+++ b/test/models/test_dftd3.py
@@ -594,11 +594,11 @@ class TestDFTD3ModelWrapper:
         out = wrapper.adapt_output(raw, batch)
         assert "forces" not in out
 
-    def test_adapt_output_stress_negates_virials(self):
-        """stress = -virials (sign negation matches the docstring convention)."""
+    def test_adapt_output_stress_is_virial_over_volume(self):
+        """stress == virial / volume (Cauchy stress, eV/A^3)."""
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
         wrapper.model_config.active_outputs.add("stress")
-        batch = _mock_batch()
+        batch = _mock_batch()  # identity cell, volume = 1.0
         virial = torch.ones(1, 3, 3) * 2.0
         raw = {
             "energy": torch.tensor([[1.0]]),
@@ -607,7 +607,21 @@ class TestDFTD3ModelWrapper:
         }
         out = wrapper.adapt_output(raw, batch)
         assert "stress" in out
-        torch.testing.assert_close(out["stress"], -virial)
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        torch.testing.assert_close(out["stress"], virial / volume)
+
+    def test_adapt_output_stress_raises_without_cell(self):
+        """ValueError when stress+virial is active but data has no cell."""
+        wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
+        wrapper.model_config.active_outputs.add("stress")
+        batch = _mock_batch(with_cell=False)
+        raw = {
+            "energy": torch.tensor([[1.0]]),
+            "forces": torch.zeros(4, 3),
+            "virial": torch.ones(1, 3, 3),
+        }
+        with pytest.raises(ValueError, match="stress output requires cell"):
+            wrapper.adapt_output(raw, batch)
 
     def test_adapt_output_no_stress_when_inactive(self):
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
@@ -783,8 +797,8 @@ class TestDFTD3ModelWrapper:
             atol=1e-7,
         )
 
-    def test_forward_virial_unit_conversion(self):
-        """Virial / stress output must be HARTREE_TO_EV times the kernel value."""
+    def test_forward_stress_unit_conversion(self):
+        """Stress output is virial_eV / volume (identity cell => stress == virial_eV)."""
         from nvalchemi.models.dftd3 import HARTREE_TO_EV
 
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
@@ -812,8 +826,7 @@ class TestDFTD3ModelWrapper:
         with patch.object(_d3mod.DFTD3ModelWrapper, "forward", patched_forward):
             out = wrapper.forward(batch)
 
-        # adapt_output negates the virial
-        expected = -(virial_ha_value * HARTREE_TO_EV)
+        expected = virial_ha_value * HARTREE_TO_EV
         assert out["stress"].shape == (1, 3, 3)
         torch.testing.assert_close(
             out["stress"],

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -328,12 +328,14 @@ class TestEwaldAdaptInput:
 class TestEwaldAdaptOutput:
     def test_energy_always_present(self):
         w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces"}
         raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
         out = w.adapt_output(raw, None)
         assert "energy" in out
 
     def test_forces_when_active(self):
         w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces"}
         raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
         out = w.adapt_output(raw, None)
         assert "forces" in out
@@ -366,6 +368,14 @@ class TestEwaldAdaptOutput:
         }
         out = w.adapt_output(raw, None)
         assert "stress" not in out
+
+    def test_adapt_output_stress_raises_when_missing(self):
+        """RuntimeError when stress is active but absent from model_output."""
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
+        with pytest.raises(RuntimeError, match="missing from model output"):
+            w.adapt_output(raw, None)
 
     def test_returns_ordered_dict(self):
         w = _make_ewald()
@@ -503,6 +513,33 @@ class TestEwaldIntegration:
 
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
         torch.testing.assert_close(out["stress"], known_virial / volume)
+
+    def test_forward_raises_when_virial_none(self):
+        """RuntimeError when stress is requested but kernels return no virial."""
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        N = batch.num_nodes
+
+        def _fake_kernel(**kw):
+            energies = torch.zeros(N, dtype=torch.float64)
+            forces = torch.zeros(N, 3, dtype=torch.float64)
+            return energies, forces
+
+        with (
+            patch(
+                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_real_space",
+                side_effect=_fake_kernel,
+            ),
+            patch(
+                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_reciprocal_space",
+                side_effect=_fake_kernel,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="kernel did not return a virial"):
+                w.forward(batch)
 
     def test_cache_populated_after_forward(self):
         w = _make_ewald()

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -26,6 +26,7 @@ Strategy
 from __future__ import annotations
 
 from collections import OrderedDict
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -475,6 +476,33 @@ class TestEwaldIntegration:
         out = w(batch)
         assert "stress" in out
         assert out["stress"].shape == (1, 3, 3)
+
+    def test_forward_stress_is_virial_over_volume(self):
+        """Stress == virial / volume (Cauchy stress, eV/A^3)."""
+        import nvalchemi.models.ewald as _emod
+
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch(box_size=10.0)
+        self._build_nl(batch, w)
+
+        known_virial = torch.full((1, 3, 3), 5.0)
+
+        def patched_forward(self_inner, data, **kw):
+            N = data.num_nodes
+            model_output = {
+                "energy": torch.zeros(1, 1),
+                "forces": torch.zeros(N, 3),
+            }
+            volume = torch.det(data.cell).abs().view(-1, 1, 1)
+            model_output["stress"] = known_virial / volume
+            return self_inner.adapt_output(model_output, data)
+
+        with patch.object(_emod.EwaldModelWrapper, "forward", patched_forward):
+            out = w.forward(batch)
+
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        torch.testing.assert_close(out["stress"], known_virial / volume)
 
     def test_cache_populated_after_forward(self):
         w = _make_ewald()

--- a/test/models/test_lj_model.py
+++ b/test/models/test_lj_model.py
@@ -449,6 +449,16 @@ class TestAdaptOutput:
         with pytest.raises(ValueError, match="stress output requires cell"):
             model.adapt_output(mo, batch)
 
+    def test_adapt_output_stress_raises_when_missing(self):
+        """RuntimeError when stress is active but model_output has neither virial nor stress."""
+        model = _make_model()
+        model.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_lj_batch()
+        batch.cell = torch.eye(3).unsqueeze(0)
+        mo = self._model_output()
+        with pytest.raises(RuntimeError, match="missing from model output"):
+            model.adapt_output(mo, batch)
+
 
 # ---------------------------------------------------------------------------
 # TestOutputData

--- a/test/models/test_lj_model.py
+++ b/test/models/test_lj_model.py
@@ -414,16 +414,20 @@ class TestAdaptOutput:
         result = model.adapt_output(self._model_output(include_virials=True), batch)
         assert "stress" not in result
 
-    def test_stresses_negated_virials_when_compute_stresses_true_and_virials_key(self):
+    def test_stresses_equal_virial_over_volume(self):
         model = _make_model()
         model.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_lj_batch()
+        # Add cell so volume can be computed.
+        batch.cell = torch.eye(3).unsqueeze(0)
+        batch.pbc = torch.ones(1, 3, dtype=torch.bool)
         virials = torch.randn(1, 3, 3)
         mo = self._model_output()
         mo["virial"] = virials
         result = model.adapt_output(mo, batch)
         assert "stress" in result
-        assert torch.allclose(result["stress"], -virials)
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        assert torch.allclose(result["stress"], virials / volume)
 
     def test_stresses_is_stresses_when_no_virials_key(self):
         model = _make_model()
@@ -435,6 +439,15 @@ class TestAdaptOutput:
         result = model.adapt_output(mo, batch)
         assert "stress" in result
         assert torch.allclose(result["stress"], stresses)
+
+    def test_adapt_output_stress_raises_without_cell(self):
+        model = _make_model()
+        model.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_lj_batch()  # no cell
+        mo = self._model_output()
+        mo["virial"] = torch.randn(1, 3, 3)
+        with pytest.raises(ValueError, match="stress output requires cell"):
+            model.adapt_output(mo, batch)
 
 
 # ---------------------------------------------------------------------------

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -26,6 +26,7 @@ Strategy
 from __future__ import annotations
 
 from collections import OrderedDict
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -504,6 +505,33 @@ class TestPMEIntegration:
         assert out["stress"].ndim == 3
         assert out["stress"].shape[-2:] == (3, 3)
 
+    def test_forward_stress_is_virial_over_volume(self):
+        """Stress == virial / volume (Cauchy stress, eV/A^3)."""
+        import nvalchemi.models.pme as _pmod
+
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch(box_size=10.0)
+        self._build_nl(batch, w)
+
+        known_virial = torch.full((1, 3, 3), 5.0)
+
+        def patched_forward(self_inner, data, **kw):
+            N = data.num_nodes
+            model_output = {
+                "energy": torch.zeros(1, 1),
+                "forces": torch.zeros(N, 3),
+            }
+            volume = torch.det(data.cell).abs().view(-1, 1, 1)
+            model_output["stress"] = known_virial / volume
+            return self_inner.adapt_output(model_output, data)
+
+        with patch.object(_pmod.PMEModelWrapper, "forward", patched_forward):
+            out = w.forward(batch)
+
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        torch.testing.assert_close(out["stress"], known_virial / volume)
+
     def test_cache_populated_after_forward(self):
         w = _make_pme()
         batch = _make_charged_batch()
@@ -544,6 +572,29 @@ class TestPMEIntegration:
 
         assert e_ewald * e_pme > 0, (
             f"Ewald ({e_ewald:.4f}) and PME ({e_pme:.4f}) disagree on energy sign"
+        )
+
+    def test_ewald_and_pme_agree_on_stress_sign(self):
+        """Ewald and PME stress tensors should have consistent signs."""
+        from nvalchemi.models.ewald import EwaldModelWrapper
+
+        batch = _make_charged_batch(n_atoms=8)
+
+        ewald = EwaldModelWrapper(cutoff=10.0)
+        ewald.model_config.active_outputs = {"energy", "forces", "stress"}
+        self._build_nl(batch, ewald)
+        s_ewald = ewald(batch)["stress"]
+
+        pme = _make_pme()
+        pme.model_config.active_outputs = {"energy", "forces", "stress"}
+        self._build_nl(batch, pme)
+        s_pme = pme(batch)["stress"]
+
+        trace_ewald = s_ewald.diagonal(dim1=-2, dim2=-1).sum()
+        trace_pme = s_pme.diagonal(dim1=-2, dim2=-1).sum()
+        assert trace_ewald * trace_pme > 0, (
+            f"Ewald trace ({trace_ewald:.6f}) and PME trace ({trace_pme:.6f}) "
+            "disagree on stress sign"
         )
 
 

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -350,12 +350,14 @@ class TestPMEAdaptInput:
 class TestPMEAdaptOutput:
     def test_energy_always_present(self):
         w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces"}
         raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
         out = w.adapt_output(raw, None)
         assert "energy" in out
 
     def test_forces_when_active(self):
         w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces"}
         raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
         out = w.adapt_output(raw, None)
         assert "forces" in out
@@ -388,6 +390,14 @@ class TestPMEAdaptOutput:
         }
         out = w.adapt_output(raw, None)
         assert "stress" not in out
+
+    def test_adapt_output_stress_raises_when_missing(self):
+        """RuntimeError when stress is active but absent from model_output."""
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        raw = {"energy": torch.tensor([[1.0]]), "forces": torch.randn(4, 3)}
+        with pytest.raises(RuntimeError, match="missing from model output"):
+            w.adapt_output(raw, None)
 
     def test_returns_ordered_dict(self):
         w = _make_pme()
@@ -531,6 +541,27 @@ class TestPMEIntegration:
 
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
         torch.testing.assert_close(out["stress"], known_virial / volume)
+
+    def test_forward_raises_when_virial_none(self):
+        """RuntimeError when stress is requested but kernel returns no virial."""
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        N = batch.num_nodes
+
+        def _fake_kernel(**kw):
+            energies = torch.zeros(N, dtype=torch.float64)
+            forces = torch.zeros(N, 3, dtype=torch.float64)
+            return energies, forces
+
+        with patch(
+            "nvalchemiops.torch.interactions.electrostatics.pme.particle_mesh_ewald",
+            side_effect=_fake_kernel,
+        ):
+            with pytest.raises(RuntimeError, match="kernel did not return a virial"):
+                w.forward(batch)
 
     def test_cache_populated_after_forward(self):
         w = _make_pme()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Standardize the stress/virial convention across all model wrappers and dynamics consumers so that `batch.stress` always stores the Cauchy stress tensor `W/V` (eV/A^3) rather than the raw virial `W` (eV).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Relates to nvalchemiops sign convention update in v0.3.1-rc.

## Changes Made

- LJ and DFTD3 `adapt_output`: compute `output["stress"] = virial / volume` instead of passing virial through; add `ValueError` guard when `data.cell` is missing.
- Ewald and PME `forward`: compute `model_output["stress"] = virial / volume` instead of storing raw virial; remove stale negation that was left over from a previous kernel convention.
- NPT/NPH `_compute_P`: recover virial as `batch.stress * volumes` before passing to `compute_pressure_tensor`, which expects the raw virial tensor `W` in eV.
- FIRE2VariableCell `_step_cell`: use `batch.stress` directly as Cauchy stress (no more division by volume).
- Update docstrings in `autograd_stresses`, `compute_pressure_tensor`, `AtomicData.stress`, forward methods for all four kernel wrappers, and the `_ops/lj.py` sign convention block.
- Add exact-value stress regression tests for all four model wrappers (LJ, DFTD3, Ewald, PME) and a cross-model Ewald/PME stress-sign consistency test.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The Ewald and PME kernels in nvalchemiops already return `W = -dE/d(epsilon)` directly. The old wrapper code contained a stale negation (`model_output["stress"] = -virial`) from a previous kernel convention where the kernels returned `+Sigma r x F`. This negation was incorrect after the ops update and has been removed; the wrapper now simply divides by volume. Autograd-based wrappers (AIMNet2, MACE, Pipeline) already returned `W/V` and required no changes.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
