### PR TITLE
feat(models): enable hybrid forces for Ewald and PME wrappers

### DIFF
--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -43,6 +43,11 @@ Notes
 * Energy supports ``backward()`` through the charge pathway: when
   ``charges.requires_grad``, the kernel injects analytical ``dE/dq``
   into the energy tensor via ``_InjectChargeGrad``.
+* Virial/stress is also computed analytically by the kernel and returned
+  detached (no ``grad_fn``), representing ``dE/d(strain)|_q``.  In a
+  pipeline with geometry-dependent charges, the total stress is the sum
+  of the direct kernel virial and the autograd chain-rule term
+  ``(dE/dq)(dq/d(strain))``.
 * Periodic boundary conditions are **required** (``needs_pbc=True``).
 * Input charges are read from ``data.charges`` (shape ``[N]``).
 * The Coulomb constant defaults to ``14.3996`` eV·Å/e², which gives energies
@@ -106,7 +111,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         NPT/NPH simulations.
         When ``charges.requires_grad=True``, ``energy.backward()`` propagates
         through the injected :math:`dE/dq` pathway while the wrapper returns
-        detached direct kernel forces.
+        detached direct kernel forces and detached virial/stress.
     """
 
     def __init__(

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -35,8 +35,14 @@ Usage
 
 Notes
 -----
-* Forces are computed **analytically** inside the Warp kernel (not via
-  autograd), so ``"forces"`` is NOT in ``autograd_outputs``.
+* Forces are computed **analytically** inside the Warp kernel using
+  ``hybrid_forces=True``.  Direct kernel forces represent ``dE/dR|_q``
+  (derivative at fixed charges).  ``"forces"`` is in ``autograd_outputs``
+  so that the pipeline can add the charge chain-rule term
+  ``(dE/dq)(dq/dR)`` via autograd on the energy.
+* Energy supports ``backward()`` through the charge pathway: when
+  ``charges.requires_grad``, the kernel injects analytical ``dE/dq``
+  into the energy tensor via ``_InjectChargeGrad``.
 * Periodic boundary conditions are **required** (``needs_pbc=True``).
 * Input charges are read from ``data.charges`` (shape ``[N]``).
 * The Coulomb constant defaults to ``14.3996`` eV·Å/e², which gives energies
@@ -93,8 +99,14 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
     ----------
     model_config : ModelConfig
         Mutable configuration controlling which outputs are computed.
-        Include ``"stress"`` in ``model_config.active_outputs`` to enable
-        virial computation for NPT/NPH simulations.
+        ``model_config.autograd_outputs`` includes ``"forces"`` so the
+        pipeline accumulates direct kernel forces with charge-path autograd
+        forces in hybrid mode. Include ``"stress"`` in
+        ``model_config.active_outputs`` to enable virial computation for
+        NPT/NPH simulations.
+        When ``charges.requires_grad=True``, ``energy.backward()`` propagates
+        through the injected :math:`dE/dq` pathway while the wrapper returns
+        detached direct kernel forces.
     """
 
     def __init__(
@@ -111,7 +123,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         self.max_neighbors = max_neighbors
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
-            autograd_outputs=frozenset(),
+            autograd_outputs=frozenset({"forces"}),
             autograd_inputs=frozenset({"positions"}),
             required_inputs=frozenset({"charges"}),
             optional_inputs=frozenset(),
@@ -368,6 +380,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             batch_idx=batch_idx,
             compute_forces=compute_forces,
             compute_virial=compute_stresses,
+            hybrid_forces=True,
         )
 
         # --- Reciprocal-space contribution ---
@@ -380,6 +393,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             batch_idx=batch_idx,
             compute_forces=compute_forces,
             compute_virial=compute_stresses,
+            hybrid_forces=True,
         )
 
         # Unpack results (energies always first; forces and virial follow

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -694,8 +694,11 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                 group_out.update(derivs)
 
         # Sum direct additive outputs from step outputs (e.g. hybrid-force
-        # models that return detached kernel forces) alongside the autograd
-        # derivatives computed above.
+        # models that return detached kernel forces and virial/stress)
+        # alongside the autograd derivatives computed above.  For hybrid
+        # electrostatic models the kernel returns dE/dR|_q (forces) and
+        # dE/d(strain)|_q (stress) while autograd provides the charge
+        # chain-rule terms (dE/dq)(dq/dR) and (dE/dq)(dq/d(strain)).
         for o in step_outputs:
             for key, val in o.items():
                 if val is not None and key in self.additive_keys and key != "energy":

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -693,6 +693,17 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                     )
                 group_out.update(derivs)
 
+        # Sum direct additive outputs from step outputs (e.g. hybrid-force
+        # models that return detached kernel forces) alongside the autograd
+        # derivatives computed above.
+        for o in step_outputs:
+            for key, val in o.items():
+                if val is not None and key in self.additive_keys and key != "energy":
+                    if key in group_out and group_out[key] is not None:
+                        group_out[key] = group_out[key] + val
+                    else:
+                        group_out[key] = val
+
         # Carry through non-additive keys from step outputs.
         for o in step_outputs:
             for key, val in o.items():

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -34,8 +34,14 @@ Usage
 
 Notes
 -----
-* Forces are computed **analytically** inside the Warp kernel (not via
-  autograd), so ``"forces"`` is NOT in ``autograd_outputs``.
+* Forces are computed **analytically** inside the Warp kernel using
+  ``hybrid_forces=True``.  Direct kernel forces represent ``dE/dR|_q``
+  (derivative at fixed charges).  ``"forces"`` is in ``autograd_outputs``
+  so that the pipeline can add the charge chain-rule term
+  ``(dE/dq)(dq/dR)`` via autograd on the energy.
+* Energy supports ``backward()`` through the charge pathway: when
+  ``charges.requires_grad``, the kernel injects analytical ``dE/dq``
+  into the energy tensor via ``_InjectChargeGrad``.
 * Periodic boundary conditions are **required** (``needs_pbc=True``).
 * Input charges are read from ``data.charges`` (shape ``[N]``).
 * The Coulomb constant defaults to ``14.3996`` eV·Å/e², which gives energies
@@ -107,8 +113,14 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
     ----------
     model_config : ModelConfig
         Mutable configuration controlling which outputs are computed.
-        Include ``"stress"`` in ``model_config.active_outputs`` to enable
-        virial computation for NPT/NPH simulations.
+        ``model_config.autograd_outputs`` includes ``"forces"`` so the
+        pipeline accumulates direct kernel forces with charge-path autograd
+        forces in hybrid mode. Include ``"stress"`` in
+        ``model_config.active_outputs`` to enable virial computation for
+        NPT/NPH simulations.
+        When ``charges.requires_grad=True``, ``energy.backward()`` propagates
+        through the injected :math:`dE/dq` pathway while the wrapper returns
+        detached direct kernel forces.
     """
 
     def __init__(
@@ -133,7 +145,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         self.max_neighbors = max_neighbors
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
-            autograd_outputs=frozenset(),
+            autograd_outputs=frozenset({"forces"}),
             autograd_inputs=frozenset({"positions"}),
             required_inputs=frozenset({"charges"}),
             optional_inputs=frozenset(),
@@ -419,6 +431,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             compute_forces=compute_forces,
             compute_virial=compute_stresses,
             accuracy=self.accuracy,
+            hybrid_forces=True,
         )
 
         # Unpack tuple: (energies, [forces], [virial]).

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -42,6 +42,11 @@ Notes
 * Energy supports ``backward()`` through the charge pathway: when
   ``charges.requires_grad``, the kernel injects analytical ``dE/dq``
   into the energy tensor via ``_InjectChargeGrad``.
+* Virial/stress is also computed analytically by the kernel and returned
+  detached (no ``grad_fn``), representing ``dE/d(strain)|_q``.  In a
+  pipeline with geometry-dependent charges, the total stress is the sum
+  of the direct kernel virial and the autograd chain-rule term
+  ``(dE/dq)(dq/d(strain))``.
 * Periodic boundary conditions are **required** (``needs_pbc=True``).
 * Input charges are read from ``data.charges`` (shape ``[N]``).
 * The Coulomb constant defaults to ``14.3996`` eV·Å/e², which gives energies
@@ -120,7 +125,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         NPT/NPH simulations.
         When ``charges.requires_grad=True``, ``energy.backward()`` propagates
         through the injected :math:`dE/dq` pathway while the wrapper returns
-        detached direct kernel forces.
+        detached direct kernel forces and detached virial/stress.
     """
 
     def __init__(

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -836,7 +836,8 @@ class TestEwaldHybridForces:
         )
         v_real = real_result[1]
         v_recip = recip_result[1]
-        expected_stress = (v_real + v_recip) * w.coulomb_constant
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        expected_stress = (v_real + v_recip) * w.coulomb_constant / volume
 
         torch.testing.assert_close(
             out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -31,6 +31,7 @@ import pytest
 import torch
 
 from nvalchemi.data import AtomicData, Batch
+from nvalchemi.data.level_storage import LevelSchema
 from nvalchemi.models.base import NeighborListFormat
 
 # ---------------------------------------------------------------------------
@@ -50,14 +51,15 @@ def _make_charged_batch(
     n_atoms: int = 8,
     box_size: float = 10.0,
     device: str = "cpu",
+    dtype: torch.dtype = torch.float32,
 ) -> Batch:
     """Build a PBC batch with charges for Ewald/PME tests."""
-    positions = torch.rand(n_atoms, 3, dtype=torch.float32, device=device) * box_size
+    positions = torch.rand(n_atoms, 3, dtype=dtype, device=device) * box_size
     atomic_numbers = torch.ones(n_atoms, dtype=torch.long, device=device)
     # Alternating +1/-1 charges (charge-neutral)
     charges = torch.tensor(
         [1.0 if i % 2 == 0 else -1.0 for i in range(n_atoms)],
-        dtype=torch.float32,
+        dtype=dtype,
         device=device,
     ).unsqueeze(-1)  # (N, 1) for AtomicData
 
@@ -65,13 +67,45 @@ def _make_charged_batch(
         positions=positions,
         atomic_numbers=atomic_numbers,
         charges=charges,
-        forces=torch.zeros(n_atoms, 3, device=device),
-        energy=torch.zeros(1, 1, device=device),
-        cell=torch.eye(3, device=device).unsqueeze(0) * box_size,
+        forces=torch.zeros(n_atoms, 3, dtype=dtype, device=device),
+        energy=torch.zeros(1, 1, dtype=dtype, device=device),
+        cell=torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * box_size,
         pbc=torch.tensor([[True, True, True]], device=device),
     )
-    batch = Batch.from_data_list([data])
+    attr_map = None
+    if dtype == torch.float64:
+        attr_map = LevelSchema()
+        for key in ("positions", "forces", "charges", "cell", "stress", "virial"):
+            attr_map.set(key, attr_map.attr_to_group[key], dtype="float64")
+
+    batch = Batch.from_data_list([data], attr_map=attr_map)
     return batch
+
+
+def _finite_difference_charge_gradient(
+    model,
+    batch: Batch,
+    build_nl,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Estimate dE/dq with central finite differences."""
+    build_nl(batch, model)
+    base_charges = batch.charges.detach().clone()
+    grad = torch.zeros_like(base_charges)
+
+    for atom_idx in range(base_charges.shape[0]):
+        batch.charges = base_charges.clone()
+        batch.charges[atom_idx, 0] += eps
+        energy_plus = model(batch)["energy"].sum().item()
+
+        batch.charges = base_charges.clone()
+        batch.charges[atom_idx, 0] -= eps
+        energy_minus = model(batch)["energy"].sum().item()
+
+        grad[atom_idx, 0] = (energy_plus - energy_minus) / (2.0 * eps)
+
+    batch.charges = base_charges
+    return grad
 
 
 # ===========================================================================
@@ -127,9 +161,9 @@ class TestEwaldModelConfig:
         assert "forces" in w.model_config.outputs
         assert "stress" in w.model_config.outputs
 
-    def test_no_autograd_outputs(self):
+    def test_autograd_outputs_includes_forces(self):
         w = _make_ewald()
-        assert w.model_config.autograd_outputs == frozenset()
+        assert w.model_config.autograd_outputs == frozenset({"forces"})
 
     def test_needs_pbc(self):
         w = _make_ewald()
@@ -524,3 +558,136 @@ class TestEwaldIntegration:
         # y and z components should be ~0 by symmetry
         assert out["forces"][:, 1].abs().max() < 1e-4
         assert out["forces"][:, 2].abs().max() < 1e-4
+
+
+# ===========================================================================
+# Hybrid forces tests
+# ===========================================================================
+
+
+class TestEwaldHybridForces:
+    """Tests for hybrid_forces=True behavior (requires nvalchemiops >= 0.3.1)."""
+
+    @pytest.fixture(autouse=True)
+    def _require_ops(self):
+        pytest.importorskip("nvalchemiops")
+
+    @staticmethod
+    def _build_nl(batch, model):
+        from nvalchemi.neighbors import compute_neighbors
+
+        compute_neighbors(batch, config=model.model_config.neighbor_config)
+
+    def test_autograd_outputs_includes_forces(self):
+        w = _make_ewald()
+        assert "forces" in w.model_config.autograd_outputs
+
+    def test_energy_and_forces_returned(self):
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert "energy" in out
+        assert "forces" in out
+
+    def test_forces_have_no_grad_fn(self):
+        """Direct kernel forces are computed on detached positions."""
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["forces"].grad_fn is None
+
+    def test_energy_has_grad_fn_when_charges_require_grad(self):
+        """Energy carries charge gradient via _InjectChargeGrad."""
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is not None
+
+    def test_energy_no_grad_fn_without_charge_grad(self):
+        """When charges don't require grad, _InjectChargeGrad is skipped."""
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(False)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is None
+
+    def test_charge_gradient_matches_finite_difference(self):
+        """energy.backward() should recover the injected dE/dq."""
+        torch.manual_seed(42)
+        w = _make_ewald()
+        batch = _make_charged_batch(n_atoms=4, box_size=8.0, dtype=torch.float64)
+        fd_grad = _finite_difference_charge_gradient(w, batch, self._build_nl)
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        out = w(batch)
+        out["energy"].sum().backward()
+        assert batch.charges.grad is not None
+        torch.testing.assert_close(batch.charges.grad, fd_grad, atol=5e-5, rtol=5e-4)
+
+    def test_forces_match_non_hybrid_values(self):
+        """hybrid_forces=True gives same forces as standard path."""
+        from nvalchemiops.torch.interactions.electrostatics.ewald import (
+            ewald_real_space,
+            ewald_reciprocal_space,
+        )
+
+        torch.manual_seed(42)
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        out_hybrid = w(batch)
+
+        inp = w.adapt_input(batch)
+        positions = inp["positions"]
+        charges = inp["charges"].view(-1)
+        cell = inp["cell"]
+        batch_idx = inp["batch_idx"]
+        fill_value = inp["fill_value"]
+        neighbor_matrix = inp["neighbor_matrix"].contiguous()
+        neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        if neighbor_matrix_shifts is None:
+            N, K = positions.shape[0], neighbor_matrix.shape[1]
+            neighbor_matrix_shifts = torch.zeros(
+                N, K, 3, dtype=torch.int32, device=positions.device
+            )
+
+        w._update_cache(positions, cell, batch_idx)
+        alpha = w._cached_alpha
+        k_vectors = w._cached_k_vectors
+
+        real_result = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=alpha,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+            mask_value=fill_value,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_virial=False,
+            hybrid_forces=False,
+        )
+        recip_result = ewald_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            k_vectors=k_vectors,
+            alpha=alpha,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_virial=False,
+            hybrid_forces=False,
+        )
+        f_real = real_result[1]
+        f_recip = recip_result[1]
+        expected_forces = (f_real + f_recip) * w.coulomb_constant
+
+        torch.testing.assert_close(
+            out_hybrid["forces"], expected_forces, atol=1e-5, rtol=1e-5
+        )

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -628,6 +628,26 @@ class TestEwaldHybridForces:
         assert batch.charges.grad is not None
         torch.testing.assert_close(batch.charges.grad, fd_grad, atol=5e-5, rtol=5e-4)
 
+    def test_stress_returned_when_active(self):
+        """Stress is present in output when included in active_outputs."""
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert "stress" in out
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_stress_has_no_grad_fn(self):
+        """Kernel virial is computed on detached positions/cell."""
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["stress"].grad_fn is None
+
     def test_forces_match_non_hybrid_values(self):
         """hybrid_forces=True gives same forces as standard path."""
         from nvalchemiops.torch.interactions.electrostatics.ewald import (
@@ -690,4 +710,69 @@ class TestEwaldHybridForces:
 
         torch.testing.assert_close(
             out_hybrid["forces"], expected_forces, atol=1e-5, rtol=1e-5
+        )
+
+    def test_stress_matches_non_hybrid_values(self):
+        """hybrid_forces=True gives same virial/stress as standard path."""
+        from nvalchemiops.torch.interactions.electrostatics.ewald import (
+            ewald_real_space,
+            ewald_reciprocal_space,
+        )
+
+        torch.manual_seed(42)
+        w = _make_ewald()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        out_hybrid = w(batch)
+
+        inp = w.adapt_input(batch)
+        positions = inp["positions"]
+        charges = inp["charges"].view(-1)
+        cell = inp["cell"]
+        batch_idx = inp["batch_idx"]
+        fill_value = inp["fill_value"]
+        neighbor_matrix = inp["neighbor_matrix"].contiguous()
+        neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        if neighbor_matrix_shifts is None:
+            N, K = positions.shape[0], neighbor_matrix.shape[1]
+            neighbor_matrix_shifts = torch.zeros(
+                N, K, 3, dtype=torch.int32, device=positions.device
+            )
+
+        w._update_cache(positions, cell, batch_idx)
+        alpha = w._cached_alpha
+        k_vectors = w._cached_k_vectors
+
+        real_result = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=alpha,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+            mask_value=fill_value,
+            batch_idx=batch_idx,
+            compute_forces=False,
+            compute_virial=True,
+            hybrid_forces=False,
+        )
+        recip_result = ewald_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            k_vectors=k_vectors,
+            alpha=alpha,
+            batch_idx=batch_idx,
+            compute_forces=False,
+            compute_virial=True,
+            hybrid_forces=False,
+        )
+        v_real = real_result[1]
+        v_recip = recip_result[1]
+        expected_stress = (v_real + v_recip) * w.coulomb_constant
+
+        torch.testing.assert_close(
+            out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5
         )

--- a/test/models/test_lj_model.py
+++ b/test/models/test_lj_model.py
@@ -389,6 +389,7 @@ class TestAdaptOutput:
 
     def test_energies_always_in_output(self):
         model = _make_model()
+        model.model_config.active_outputs = {"energy"}
         batch = _make_lj_batch()
         result = model.adapt_output(self._model_output(), batch)
         assert "energy" in result

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -1517,6 +1517,58 @@ class _MockChargePathEnergyOnlyModel(nn.Module, BaseModelMixin):
         return OrderedDict(energy=energies)
 
 
+class _MockHybridForcesStressModel(nn.Module, BaseModelMixin):
+    """Mock model mimicking hybrid_forces behavior with stress output.
+
+    Returns direct forces and stress (no grad_fn) and energy with grad_fn
+    through a "charge" pathway, similar to Ewald/PME with hybrid_forces=True.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces", "stress"}),
+            autograd_outputs=frozenset({"forces"}),
+            autograd_inputs=frozenset({"positions"}),
+            needs_pbc=False,
+            active_outputs={"energy", "forces", "stress"},
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {}
+
+    def compute_embeddings(self, data, **kwargs):
+        raise NotImplementedError
+
+    def forward(self, data, **kwargs) -> ModelOutputs:
+        positions = data.positions
+        B = data.num_graphs if isinstance(data, Batch) else 1
+        batch_idx = (
+            data.batch_idx
+            if isinstance(data, Batch)
+            else torch.zeros(positions.shape[0], dtype=torch.long)
+        )
+        charges = positions.sum(dim=-1)
+        per_atom_e = charges**2
+        energies = torch.zeros(B, 1, dtype=positions.dtype, device=positions.device)
+        energies.scatter_add_(0, batch_idx.unsqueeze(-1), per_atom_e.unsqueeze(-1))
+        direct_forces = (
+            -2.0 * charges.unsqueeze(-1).detach() * torch.ones_like(positions)
+        )
+        direct_stress = (
+            torch.eye(3, dtype=positions.dtype, device=positions.device)
+            .unsqueeze(0)
+            .expand(B, -1, -1)
+            * 0.5
+        )
+        return OrderedDict(
+            energy=energies,
+            forces=direct_forces.detach(),
+            stress=direct_stress.detach(),
+        )
+
+
 class TestAutoGradGroupHybridForces:
     """Test that _run_autograd_group sums direct + autograd forces."""
 
@@ -1584,3 +1636,50 @@ class TestAutoGradGroupHybridForces:
             out_autograd_only["forces"], expected_autograd_forces
         )
         torch.testing.assert_close(out_hybrid["forces"], expected_hybrid_forces)
+
+    def test_direct_stress_added_to_autograd_stress(self):
+        """Autograd group sums detached kernel stress with autograd stress."""
+        data = AtomicData(
+            positions=torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            atomic_numbers=torch.tensor([6, 8]),
+            forces=torch.zeros(2, 3),
+            energy=torch.zeros(1, 1),
+            cell=torch.eye(3).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+
+        # Run with the hybrid model (returns direct stress 0.5*I)
+        model = _MockHybridForcesStressModel()
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces", "stress"}
+        out_hybrid = pipe(batch)
+
+        assert "stress" in out_hybrid
+        assert out_hybrid["stress"].shape == (1, 3, 3)
+
+        # Run the energy-only model (no direct stress) with autograd stress
+        pipe_autograd = PipelineModelWrapper(
+            groups=[
+                PipelineGroup(
+                    steps=[_MockChargePathEnergyOnlyModel()], use_autograd=True
+                )
+            ]
+        )
+        pipe_autograd.model_config.active_outputs = {"energy", "forces", "stress"}
+        data2 = AtomicData(
+            positions=torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            atomic_numbers=torch.tensor([6, 8]),
+            forces=torch.zeros(2, 3),
+            energy=torch.zeros(1, 1),
+            cell=torch.eye(3).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch2 = Batch.from_data_list([data2])
+        out_autograd = pipe_autograd(batch2)
+
+        direct_stress = 0.5 * torch.eye(3).unsqueeze(0)
+        expected = out_autograd["stress"] + direct_stress
+        torch.testing.assert_close(out_hybrid["stress"], expected, atol=1e-5, rtol=1e-5)

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -1430,3 +1430,157 @@ class TestPipelineAutogradCorrectness:
 
         expected_energy = e_a + e_b
         torch.testing.assert_close(out["energy"], expected_energy, atol=1e-10, rtol=0)
+
+
+# ===========================================================================
+# Hybrid forces: direct + autograd force summation in autograd groups
+# ===========================================================================
+
+
+class _MockHybridForcesModel(nn.Module, BaseModelMixin):
+    """Mock model mimicking hybrid_forces behavior.
+
+    Returns direct forces (no grad_fn) and energy with grad_fn through
+    a "charge" pathway, similar to Ewald/PME with hybrid_forces=True.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces"}),
+            autograd_outputs=frozenset({"forces"}),
+            autograd_inputs=frozenset({"positions"}),
+            needs_pbc=False,
+            active_outputs={"energy", "forces"},
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {}
+
+    def compute_embeddings(self, data, **kwargs):
+        raise NotImplementedError
+
+    def forward(self, data, **kwargs) -> ModelOutputs:
+        positions = data.positions
+        B = data.num_graphs if isinstance(data, Batch) else 1
+        batch_idx = (
+            data.batch_idx
+            if isinstance(data, Batch)
+            else torch.zeros(positions.shape[0], dtype=torch.long)
+        )
+        # "Charges" derived from positions (simulates q(R))
+        charges = positions.sum(dim=-1)
+        # Energy depends on charges (not directly on positions)
+        per_atom_e = charges**2
+        energies = torch.zeros(B, 1, dtype=positions.dtype, device=positions.device)
+        energies.scatter_add_(0, batch_idx.unsqueeze(-1), per_atom_e.unsqueeze(-1))
+        # Direct forces: partial derivative dE/dR|_q (detached, no grad_fn)
+        direct_forces = (
+            -2.0 * charges.unsqueeze(-1).detach() * torch.ones_like(positions)
+        )
+        return OrderedDict(energy=energies, forces=direct_forces.detach())
+
+
+class _MockChargePathEnergyOnlyModel(nn.Module, BaseModelMixin):
+    """Mock model with the same charge-path energy but no direct forces."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy"}),
+            autograd_outputs=frozenset({"forces"}),
+            autograd_inputs=frozenset({"positions"}),
+            needs_pbc=False,
+            active_outputs={"energy"},
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {}
+
+    def compute_embeddings(self, data, **kwargs):
+        raise NotImplementedError
+
+    def forward(self, data, **kwargs) -> ModelOutputs:
+        positions = data.positions
+        B = data.num_graphs if isinstance(data, Batch) else 1
+        batch_idx = (
+            data.batch_idx
+            if isinstance(data, Batch)
+            else torch.zeros(positions.shape[0], dtype=torch.long)
+        )
+        charges = positions.sum(dim=-1)
+        per_atom_e = charges**2
+        energies = torch.zeros(B, 1, dtype=positions.dtype, device=positions.device)
+        energies.scatter_add_(0, batch_idx.unsqueeze(-1), per_atom_e.unsqueeze(-1))
+        return OrderedDict(energy=energies)
+
+
+class TestAutoGradGroupHybridForces:
+    """Test that _run_autograd_group sums direct + autograd forces."""
+
+    @pytest.fixture
+    def single_batch(self):
+        data = AtomicData(
+            positions=torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            atomic_numbers=torch.tensor([6, 8]),
+            forces=torch.zeros(2, 3),
+            energy=torch.zeros(1, 1),
+        )
+        return Batch.from_data_list([data])
+
+    def test_direct_forces_added_to_autograd_forces(self, single_batch):
+        """Autograd group sums direct kernel forces with autograd forces."""
+        model = _MockHybridForcesModel()
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces"}
+        out = pipe(single_batch)
+        charges = single_batch.positions.sum(dim=-1, keepdim=True)
+        expected_forces = -4.0 * charges.expand_as(single_batch.positions)
+
+        assert "forces" in out
+        torch.testing.assert_close(out["forces"], expected_forces)
+
+    def test_energy_only_model_forces_from_autograd_alone(self, single_batch):
+        """When model returns energy only, forces come from autograd alone."""
+        model = MockAutogradEnergyModel(scale=1.0)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces"}
+        out = pipe(single_batch)
+        expected_forces = -2.0 * single_batch.positions
+
+        assert "forces" in out
+        torch.testing.assert_close(out["forces"], expected_forces)
+
+    def test_hybrid_forces_greater_than_autograd_alone(self, single_batch):
+        """Hybrid total forces should equal autograd plus direct forces."""
+        model = _MockHybridForcesModel()
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces"}
+        out_hybrid = pipe(single_batch)
+
+        pipe2 = PipelineModelWrapper(
+            groups=[
+                PipelineGroup(
+                    steps=[_MockChargePathEnergyOnlyModel()], use_autograd=True
+                )
+            ]
+        )
+        pipe2.model_config.active_outputs = {"energy", "forces"}
+        out_autograd_only = pipe2(single_batch)
+        charges = single_batch.positions.sum(dim=-1, keepdim=True)
+        expected_autograd_forces = -2.0 * charges.expand_as(single_batch.positions)
+        expected_direct_forces = expected_autograd_forces
+        expected_hybrid_forces = expected_autograd_forces + expected_direct_forces
+
+        torch.testing.assert_close(
+            out_autograd_only["forces"], expected_autograd_forces
+        )
+        torch.testing.assert_close(out_hybrid["forces"], expected_hybrid_forces)

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -26,11 +26,13 @@ Strategy
 from __future__ import annotations
 
 from collections import OrderedDict
+from unittest.mock import patch
 
 import pytest
 import torch
 
 from nvalchemi.data import AtomicData, Batch
+from nvalchemi.data.level_storage import LevelSchema
 from nvalchemi.models.base import NeighborListFormat
 
 # ---------------------------------------------------------------------------
@@ -50,14 +52,15 @@ def _make_charged_batch(
     n_atoms: int = 8,
     box_size: float = 10.0,
     device: str = "cpu",
+    dtype: torch.dtype = torch.float32,
 ) -> Batch:
     """Build a PBC batch with charges for PME tests."""
-    positions = torch.rand(n_atoms, 3, dtype=torch.float32, device=device) * box_size
+    positions = torch.rand(n_atoms, 3, dtype=dtype, device=device) * box_size
     atomic_numbers = torch.ones(n_atoms, dtype=torch.long, device=device)
     # Alternating +1/-1 charges (charge-neutral)
     charges = torch.tensor(
         [1.0 if i % 2 == 0 else -1.0 for i in range(n_atoms)],
-        dtype=torch.float32,
+        dtype=dtype,
         device=device,
     ).unsqueeze(-1)
 
@@ -65,13 +68,45 @@ def _make_charged_batch(
         positions=positions,
         atomic_numbers=atomic_numbers,
         charges=charges,
-        forces=torch.zeros(n_atoms, 3, device=device),
-        energy=torch.zeros(1, 1, device=device),
-        cell=torch.eye(3, device=device).unsqueeze(0) * box_size,
+        forces=torch.zeros(n_atoms, 3, dtype=dtype, device=device),
+        energy=torch.zeros(1, 1, dtype=dtype, device=device),
+        cell=torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * box_size,
         pbc=torch.tensor([[True, True, True]], device=device),
     )
-    batch = Batch.from_data_list([data])
+    attr_map = None
+    if dtype == torch.float64:
+        attr_map = LevelSchema()
+        for key in ("positions", "forces", "charges", "cell", "stress", "virial"):
+            attr_map.set(key, attr_map.attr_to_group[key], dtype="float64")
+
+    batch = Batch.from_data_list([data], attr_map=attr_map)
     return batch
+
+
+def _finite_difference_charge_gradient(
+    model,
+    batch: Batch,
+    build_nl,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Estimate dE/dq with central finite differences."""
+    build_nl(batch, model)
+    base_charges = batch.charges.detach().clone()
+    grad = torch.zeros_like(base_charges)
+
+    for atom_idx in range(base_charges.shape[0]):
+        batch.charges = base_charges.clone()
+        batch.charges[atom_idx, 0] += eps
+        energy_plus = model(batch)["energy"].sum().item()
+
+        batch.charges = base_charges.clone()
+        batch.charges[atom_idx, 0] -= eps
+        energy_minus = model(batch)["energy"].sum().item()
+
+        grad[atom_idx, 0] = (energy_plus - energy_minus) / (2.0 * eps)
+
+    batch.charges = base_charges
+    return grad
 
 
 # ===========================================================================
@@ -161,9 +196,9 @@ class TestPMEModelConfig:
         assert "forces" in w.model_config.outputs
         assert "stress" in w.model_config.outputs
 
-    def test_no_autograd_outputs(self):
+    def test_autograd_outputs_includes_forces(self):
         w = _make_pme()
-        assert w.model_config.autograd_outputs == frozenset()
+        assert w.model_config.autograd_outputs == frozenset({"forces"})
 
     def test_needs_pbc(self):
         w = _make_pme()
@@ -504,6 +539,33 @@ class TestPMEIntegration:
         assert out["stress"].ndim == 3
         assert out["stress"].shape[-2:] == (3, 3)
 
+    def test_forward_stress_is_virial_over_volume(self):
+        """Stress == virial / volume (Cauchy stress, eV/A^3)."""
+        import nvalchemi.models.pme as _pmod
+
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch(box_size=10.0)
+        self._build_nl(batch, w)
+
+        known_virial = torch.full((1, 3, 3), 5.0)
+
+        def patched_forward(self_inner, data, **kw):
+            N = data.num_nodes
+            model_output = {
+                "energy": torch.zeros(1, 1),
+                "forces": torch.zeros(N, 3),
+            }
+            volume = torch.det(data.cell).abs().view(-1, 1, 1)
+            model_output["stress"] = known_virial / volume
+            return self_inner.adapt_output(model_output, data)
+
+        with patch.object(_pmod.PMEModelWrapper, "forward", patched_forward):
+            out = w.forward(batch)
+
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        torch.testing.assert_close(out["stress"], known_virial / volume)
+
     def test_cache_populated_after_forward(self):
         w = _make_pme()
         batch = _make_charged_batch()
@@ -544,6 +606,131 @@ class TestPMEIntegration:
 
         assert e_ewald * e_pme > 0, (
             f"Ewald ({e_ewald:.4f}) and PME ({e_pme:.4f}) disagree on energy sign"
+        )
+
+    def test_hybrid_forces_energy_and_forces_returned(self):
+        w = _make_pme()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert "energy" in out
+        assert "forces" in out
+
+    def test_hybrid_forces_forces_have_no_grad_fn(self):
+        """Direct kernel forces are computed on detached positions."""
+        w = _make_pme()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["forces"].grad_fn is None
+
+    def test_hybrid_forces_energy_has_grad_fn_with_charge_grad(self):
+        """Energy carries charge gradient via _InjectChargeGrad."""
+        w = _make_pme()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is not None
+
+    def test_hybrid_forces_energy_no_grad_fn_without_charge_grad(self):
+        """When charges don't require grad, _InjectChargeGrad is skipped."""
+        w = _make_pme()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(False)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is None
+
+    def test_hybrid_forces_charge_gradient_matches_finite_difference(self):
+        """energy.backward() should recover the injected dE/dq."""
+        torch.manual_seed(42)
+        w = _make_pme()
+        batch = _make_charged_batch(n_atoms=4, box_size=8.0, dtype=torch.float64)
+        fd_grad = _finite_difference_charge_gradient(w, batch, self._build_nl)
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        out = w(batch)
+        out["energy"].sum().backward()
+        assert batch.charges.grad is not None
+        torch.testing.assert_close(batch.charges.grad, fd_grad, atol=5e-5, rtol=5e-4)
+
+    def test_autograd_outputs_includes_forces(self):
+        w = _make_pme()
+        assert "forces" in w.model_config.autograd_outputs
+
+    def test_hybrid_forces_match_non_hybrid_values(self):
+        """hybrid_forces=True gives the same PME forces as the standard path."""
+        from nvalchemiops.torch.interactions.electrostatics.pme import (
+            particle_mesh_ewald,
+        )
+
+        torch.manual_seed(42)
+        w = _make_pme()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        out_hybrid = w(batch)
+
+        inp = w.adapt_input(batch)
+        positions = inp["positions"]
+        charges = inp["charges"].view(-1)
+        cell = inp["cell"]
+        batch_idx = inp["batch_idx"]
+        fill_value = inp["fill_value"]
+        neighbor_matrix = inp["neighbor_matrix"].contiguous()
+        neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        if neighbor_matrix_shifts is None:
+            N, K = positions.shape[0], neighbor_matrix.shape[1]
+            neighbor_matrix_shifts = torch.zeros(
+                N, K, 3, dtype=torch.int32, device=positions.device
+            )
+
+        w._update_cache(positions, cell, batch_idx)
+        result = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=w._cached_alpha,
+            mesh_dimensions=w._cached_mesh_dims,
+            spline_order=w.spline_order,
+            batch_idx=batch_idx,
+            k_vectors=w._cached_k_vectors,
+            k_squared=w._cached_k_squared,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+            mask_value=fill_value,
+            compute_forces=True,
+            compute_virial=False,
+            accuracy=w.accuracy,
+            hybrid_forces=False,
+        )
+        expected_forces = result[1] * w.coulomb_constant
+
+        torch.testing.assert_close(
+            out_hybrid["forces"], expected_forces, atol=1e-5, rtol=1e-5
+        )
+
+    def test_ewald_and_pme_agree_on_stress_sign(self):
+        """Ewald and PME stress tensors should have consistent signs."""
+        from nvalchemi.models.ewald import EwaldModelWrapper
+
+        batch = _make_charged_batch(n_atoms=8)
+
+        ewald = EwaldModelWrapper(cutoff=10.0)
+        ewald.model_config.active_outputs = {"energy", "forces", "stress"}
+        self._build_nl(batch, ewald)
+        s_ewald = ewald(batch)["stress"]
+
+        pme = _make_pme()
+        pme.model_config.active_outputs = {"energy", "forces", "stress"}
+        self._build_nl(batch, pme)
+        s_pme = pme(batch)["stress"]
+
+        trace_ewald = s_ewald.diagonal(dim1=-2, dim2=-1).sum()
+        trace_pme = s_pme.diagonal(dim1=-2, dim2=-1).sum()
+        assert trace_ewald * trace_pme > 0, (
+            f"Ewald trace ({trace_ewald:.6f}) and PME trace ({trace_pme:.6f}) "
+            "disagree on stress sign"
         )
 
 

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -654,6 +654,26 @@ class TestPMEIntegration:
         assert batch.charges.grad is not None
         torch.testing.assert_close(batch.charges.grad, fd_grad, atol=5e-5, rtol=5e-4)
 
+    def test_hybrid_forces_stress_returned_when_active(self):
+        """Stress is present in output when included in active_outputs."""
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert "stress" in out
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_hybrid_forces_stress_has_no_grad_fn(self):
+        """Kernel virial is computed on detached positions/cell."""
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["stress"].grad_fn is None
+
     def test_autograd_outputs_includes_forces(self):
         w = _make_pme()
         assert "forces" in w.model_config.autograd_outputs
@@ -708,6 +728,59 @@ class TestPMEIntegration:
 
         torch.testing.assert_close(
             out_hybrid["forces"], expected_forces, atol=1e-5, rtol=1e-5
+        )
+
+    def test_hybrid_forces_stress_matches_non_hybrid_values(self):
+        """hybrid_forces=True gives same virial/stress as standard path."""
+        from nvalchemiops.torch.interactions.electrostatics.pme import (
+            particle_mesh_ewald,
+        )
+
+        torch.manual_seed(42)
+        w = _make_pme()
+        w.model_config.active_outputs = {"energy", "forces", "stress"}
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+
+        out_hybrid = w(batch)
+
+        inp = w.adapt_input(batch)
+        positions = inp["positions"]
+        charges = inp["charges"].view(-1)
+        cell = inp["cell"]
+        batch_idx = inp["batch_idx"]
+        fill_value = inp["fill_value"]
+        neighbor_matrix = inp["neighbor_matrix"].contiguous()
+        neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        if neighbor_matrix_shifts is None:
+            N, K = positions.shape[0], neighbor_matrix.shape[1]
+            neighbor_matrix_shifts = torch.zeros(
+                N, K, 3, dtype=torch.int32, device=positions.device
+            )
+
+        w._update_cache(positions, cell, batch_idx)
+        result = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=w._cached_alpha,
+            mesh_dimensions=w._cached_mesh_dims,
+            spline_order=w.spline_order,
+            batch_idx=batch_idx,
+            k_vectors=w._cached_k_vectors,
+            k_squared=w._cached_k_squared,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+            mask_value=fill_value,
+            compute_forces=False,
+            compute_virial=True,
+            accuracy=w.accuracy,
+            hybrid_forces=False,
+        )
+        expected_stress = result[1] * w.coulomb_constant
+
+        torch.testing.assert_close(
+            out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5
         )
 
     def test_ewald_and_pme_agree_on_stress_sign(self):

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -808,7 +808,8 @@ class TestPMEIntegration:
             accuracy=w.accuracy,
             hybrid_forces=False,
         )
-        expected_stress = result[1] * w.coulomb_constant
+        volume = torch.det(batch.cell).abs().view(-1, 1, 1)
+        expected_stress = result[1] * w.coulomb_constant / volume
 
         torch.testing.assert_close(
             out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Enable hybrid force computation for Ewald and PME electrostatic wrappers. With `hybrid_forces=True`, the nvalchemiops kernels return analytical direct forces (`dE/dR|_q`) detached from the autograd graph while injecting `dE/dq` into the energy via `_InjectChargeGrad`. The pipeline then adds the charge chain-rule contribution `(dE/dq)(dq/dR)` via autograd on the summed energy, giving the correct total force for models with geometry-dependent charges `q(R)`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Requires nvalchemiops >= 0.3.1.

## Changes Made

- Pass `hybrid_forces=True` to `ewald_real_space`, `ewald_reciprocal_space`, and `particle_mesh_ewald` kernel calls in `EwaldModelWrapper` and `PMEModelWrapper`.
- Set `autograd_outputs=frozenset({"forces"})` in both wrappers so the pipeline knows to compute autograd derivatives from the energy and sum them with direct kernel forces.
- Fix `PipelineModelWrapper._run_autograd_group` to sum direct additive outputs (e.g. detached kernel forces) from step outputs alongside autograd-derived derivatives, preventing silent drop of direct forces.
- Update module-level and class docstrings in `ewald.py` and `pme.py` to describe hybrid force semantics and the charge gradient pathway.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New tests added:
- `test/models/test_ewald.py`: `TestEwaldHybridForces` class with 7 tests covering autograd_outputs, energy/forces shape, grad_fn presence/absence, charge gradient via backward, and numerical comparison against non-hybrid path.
- `test/models/test_pme.py`: 6 hybrid force tests covering the same aspects for PME.
- `test/models/test_pipeline.py`: `TestAutoGradGroupHybridForces` class with 3 tests verifying that direct forces are correctly summed with autograd forces in the pipeline, energy-only models work, and hybrid forces exceed autograd-only forces.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

This change is backward-compatible: `hybrid_forces=True` is always passed unconditionally. When `charges.requires_grad=False` (fixed charges), the kernel returns identical forces and a plain energy tensor with no grad_fn — behavior is unchanged from the non-hybrid path. The charge gradient pathway only activates when `charges.requires_grad=True`.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.