### PR TITLE
fix(coverage): tolerate missing source files in report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ omit = [
 ]
 show_missing = true
 fail_under = 75
+# Warn instead of aborting on missing source files (e.g. stale cached
+# baseline referencing files deleted in the current PR).
+ignore_errors = true
 
 [tool.coverage.xml]
 output = "nvalchemi.coverage.xml"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Set `ignore_errors = true` under `[tool.coverage.report]` so `coverage xml`
and `coverage report` emit a warning instead of aborting when the combined
coverage database references source files no longer on disk. This happens
in CI when a cached `.coverage.baseline` from a prior main run references
files that have been deleted or renamed in the current PR.

See the upstream remedy:
<https://coverage.readthedocs.io/en/7.13.4/messages.html#error-no-source>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Closes #76

## Changes Made

- Added `ignore_errors = true` to `[tool.coverage.report]` in `pyproject.toml`

## Testing

- [x] Unit tests pass locally (`make pytest`) — N/A: config-only change, no code touched
- [x] Linting passes (`make lint`) — pre-commit hooks ran clean on commit
- [ ] New tests added for new functionality meets coverage expectations? — N/A

Behaviour verification: `coverage xml` / `coverage report` now warn instead
of aborting on missing sources. Files that ARE present on disk are still
reported normally; `fail_under = 75` still applies to those files. No
existing passing CI path changes behaviour.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md) — not applicable; CI config fix, not a user-facing change
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes — N/A
- [ ] I have updated the documentation (if applicable) — N/A

## Additional Notes

Scope intentionally minimal: a single TOML line (plus a short comment).

Two larger hardening ideas were considered and dropped:

1. **Topology-aware cache keys** (hashing `nvalchemi/**/*.py` paths into
   the cache key). Would correctly invalidate stale baselines, but would
   also force a full run on any main-side topology drift, degrading cache
   reuse for unrelated PRs.
2. **Baseline-aware "new-file" full-run promotion**. Would force a full
   run only when a PR adds paths the baseline doesn't know about. More
   precise but adds non-trivial YAML + Python logic to the workflow for a
   narrow case. Current consequence of not doing this: a PR that adds a
   new source file may show 0% coverage on that file until main's next
   full run refreshes the baseline. Human review of the coverage diff
   catches this; no CI failure results.

Both can be revisited if the accepted consequence becomes a real problem.