### PR TITLE
fix(coverage): tolerate missing source files in report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ omit = [
 ]
 show_missing = true
 fail_under = 75
+# Warn instead of aborting on missing source files (e.g. stale cached
+# baseline referencing files deleted in the current PR).
+ignore_errors = true
 
 [tool.coverage.xml]
 output = "nvalchemi.coverage.xml"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Set `ignore_errors = true` under `[tool.coverage.report]` so `coverage report` emits a warning instead of aborting when the combined coverage database references source files no longer on disk. This happens in CI when a cached `.coverage.baseline` from a prior main run references files that have been deleted or renamed in the current PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Closes #76

## Changes Made

- Added `ignore_errors = true` to `[tool.coverage.report]` in `pyproject.toml`

## Testing

- [x] Unit tests pass locally (`make pytest`) — N/A: config-only change, no code touched
- [x] Linting passes (`make lint`) — pre-commit hooks ran clean on commit
- [ ] New tests added for new functionality meets coverage expectations? — N/A

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md) — not applicable; CI config fix, not a user-facing change
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes — N/A
- [ ] I have updated the documentation (if applicable) — N/A
