### PR TITLE
fix(models): break autograd chain on energies buffer in Ewald + PME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   NPT runs. Cross-validated against ASE `MTKNPT`/`IsotropicMTKNPT` and
   TorchSim `npt_nose_hoover_isotropic`. Isotropic users will see their
   barostat mass `W` shrink by 3× (now matches canonical MTK).
+- **Ewald / PME energies buffer leak** (#82) — in-place `scatter_add_`
+  of gradient-carrying `per_atom_energies` chained each forward's Warp
+  backward tape onto `_energies_buf`, causing linear per-step slowdown
+  and unbounded GPU memory growth. `detach_()` the buffer after each
+  forward.
 
 ### Deprecated
 

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -468,12 +468,13 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             )
         self._energies_buf.zero_()
         self._energies_buf.scatter_add_(0, batch_idx, per_atom_energies)
+        # Clone so callers (e.g. BiasedPotentialHook in-place add_) see
+        # storage independent of the persistent buffer; detach so the next
+        # zero_() starts a fresh autograd chain (#82).
+        energy = self._energies_buf.unsqueeze(-1).clone()
+        self._energies_buf.detach_()
 
-        # Clone from pre-allocated buffer so the caller receives an independent tensor.
-        # Without cloning, the next forward pass would overwrite this tensor in-place.
-        model_output: dict[str, Any] = {
-            "energy": self._energies_buf.unsqueeze(-1).clone()
-        }
+        model_output: dict[str, Any] = {"energy": energy}
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -471,10 +471,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         # Clone so callers (e.g. BiasedPotentialHook in-place add_) see
         # storage independent of the persistent buffer; detach so the next
         # zero_() starts a fresh autograd chain (#82).
-        energy = self._energies_buf.unsqueeze(-1).clone()
+        model_output: dict[str, Any] = {
+            "energy": self._energies_buf.unsqueeze(-1).clone()
+        }
         self._energies_buf.detach_()
-
-        model_output: dict[str, Any] = {"energy": energy}
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -494,12 +494,13 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             )
         self._energies_buf.zero_()
         self._energies_buf.scatter_add_(0, batch_idx, per_atom_energies)
+        # Clone so callers (e.g. BiasedPotentialHook in-place add_) see
+        # storage independent of the persistent buffer; detach so the next
+        # zero_() starts a fresh autograd chain (#82).
+        energy = self._energies_buf.unsqueeze(-1).clone()
+        self._energies_buf.detach_()
 
-        # Clone from pre-allocated buffer so the caller receives an independent tensor.
-        # Without cloning, the next forward pass would overwrite this tensor in-place.
-        model_output: dict[str, Any] = {
-            "energy": self._energies_buf.unsqueeze(-1).clone()
-        }
+        model_output: dict[str, Any] = {"energy": energy}
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -497,10 +497,10 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         # Clone so callers (e.g. BiasedPotentialHook in-place add_) see
         # storage independent of the persistent buffer; detach so the next
         # zero_() starts a fresh autograd chain (#82).
-        energy = self._energies_buf.unsqueeze(-1).clone()
+        model_output: dict[str, Any] = {
+            "energy": self._energies_buf.unsqueeze(-1).clone()
+        }
         self._energies_buf.detach_()
-
-        model_output: dict[str, Any] = {"energy": energy}
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -648,6 +648,17 @@ class TestEwaldIntegration:
         assert out["forces"][:, 1].abs().max() < 1e-4
         assert out["forces"][:, 2].abs().max() < 1e-4
 
+    def test_energies_buffer_detached_after_forward(self):
+        """`_energies_buf` has no `grad_fn` after a grad-carrying forward (#82)."""
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is not None
+        assert w._energies_buf.grad_fn is None
+        assert not w._energies_buf.requires_grad
+
 
 # ===========================================================================
 # Hybrid forces tests

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -659,6 +659,21 @@ class TestEwaldIntegration:
         assert w._energies_buf.grad_fn is None
         assert not w._energies_buf.requires_grad
 
+    def test_consecutive_forwards_storage_independent(self):
+        """Energy from forward N and N+1 do not alias the same storage (#82)."""
+        w = _make_ewald()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        e1 = w(batch)["energy"]
+        snapshot = e1.detach().clone()
+        # Perturb so the next forward yields different values — a no-clone
+        # view of the persistent buffer would silently mutate e1.
+        batch.charges = batch.charges * 2.0
+        e2 = w(batch)["energy"]
+        assert e1.untyped_storage().data_ptr() != e2.untyped_storage().data_ptr()
+        assert torch.equal(e1, snapshot)
+        assert not torch.equal(e1, e2)
+
 
 # ===========================================================================
 # Hybrid forces tests

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -649,6 +649,21 @@ class TestPMEIntegration:
         assert w._energies_buf.grad_fn is None
         assert not w._energies_buf.requires_grad
 
+    def test_consecutive_forwards_storage_independent(self):
+        """Energy from forward N and N+1 do not alias the same storage (#82)."""
+        w = _make_pme()
+        batch = _make_charged_batch()
+        self._build_nl(batch, w)
+        e1 = w(batch)["energy"]
+        snapshot = e1.detach().clone()
+        # Perturb so the next forward yields different values — a no-clone
+        # view of the persistent buffer would silently mutate e1.
+        batch.charges = batch.charges * 2.0
+        e2 = w(batch)["energy"]
+        assert e1.untyped_storage().data_ptr() != e2.untyped_storage().data_ptr()
+        assert torch.equal(e1, snapshot)
+        assert not torch.equal(e1, e2)
+
     def test_hybrid_forces_energy_and_forces_returned(self):
         w = _make_pme()
         batch = _make_charged_batch()

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -638,6 +638,17 @@ class TestPMEIntegration:
             f"Ewald ({e_ewald:.4f}) and PME ({e_pme:.4f}) disagree on energy sign"
         )
 
+    def test_energies_buffer_detached_after_forward(self):
+        """`_energies_buf` has no `grad_fn` after a grad-carrying forward (#82)."""
+        w = _make_pme()
+        batch = _make_charged_batch()
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        self._build_nl(batch, w)
+        out = w(batch)
+        assert out["energy"].grad_fn is not None
+        assert w._energies_buf.grad_fn is None
+        assert not w._energies_buf.requires_grad
+
     def test_hybrid_forces_energy_and_forces_returned(self):
         w = _make_pme()
         batch = _make_charged_batch()


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

`EwaldModelWrapper` and `PMEModelWrapper` keeps a persistent `self._energies_buf` tensor and reuses it each forward via `zero_()` + `scatter_add_(0, batch_idx, per_atom_energies)`. Because `per_atom_energies` carries a `grad_fn` from the Warp backward tape, the in-place ops chain each step's autograd graph onto the buffer through PyTorch's version-counter mechanism. The buffer is owned by `self`, so the chain cannot be GC'd — per-step cost grows linearly and GPU memory climbs unboundedly in long MD runs. This PR calls `detach_()` after the clone to break the autograd chain.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A — bug surfaced during downstream MD integration work, not tracked in an existing issue.

## Changes Made

- `nvalchemi/models/ewald.py`, `nvalchemi/models/pme.py`: for `self._energies_buf`, zero buffer per `forward()`, scatter into it, call `detach_()` after the clone, so callers continue to receive a tensor with independent storage (matches the prior output contract; some downstream consumers mutate `batch.energy` in place).
- `test/models/test_ewald.py`, `test/models/test_pme.py`: add two regression tests per wrapper — one checks `_energies_buf.grad_fn is None`, one asserts consecutive forwards return energy tensors whose storage is independent of prior outputs.
- `CHANGELOG.md`: add entry under Unreleased.

## Testing

- [x] Unit tests pass locally
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

### Empirical verification

<img width="1633" height="622" alt="per_step_runtime_and_gpu_mem" src="https://github.com/user-attachments/assets/b797cabe-8558-442d-984b-b9adc58f44dd" />

1000 NVT Langevin steps, naphthalene (3,6,3) = 1944 atoms, PBC, AIMNet2 + electrostatics (`accuracy=1e-6`, `hybrid_forces=False`, `compile_model=True`), dt = 1.5 fs, T = 200 K, friction = 0.01, 50-step timing blocks.

Tested on: NVIDIA H100 NVL (95 GB, driver 570.195.03), ARM (Linux 6.8.0), PyTorch 2.11.0+cu130 (CUDA 13.0), Python 3.12.13.

| | step 50 ms/step | step 950 ms/step | last / first | GPU mem start | GPU mem end |
|---|---|---|---|---|---|
| Ewald (unfixed) | 146.5 | 456.9 | 3.1× | 175.8 MB | 196.5 MB |
| Ewald (fixed)   | 94.4  | 79.7  | 0.84 (warmup) | 174.7 MB | 174.7 MB |
| PME (unfixed)   | 111.8 | 568.6 | 5.1× | 183.9 MB | 204.6 MB |
| PME (fixed)     | 91.6  | 76.0  | 0.83 (warmup) | 182.8 MB | 182.8 MB |

Figure (per-step runtime + GPU memory vs step, all four configs) attached below.

**Numerical equivalence.** GPU `scatter_add_` is non-deterministic (atomic-add ordering), so neither variant is bit-exact against itself. Measured relative L2 deltas of per-atom positions and forces at step 20 (seed = 42): unfixed-vs-fixed deltas are within same-code run-to-run envelope for both models. No systematic shift.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

`nvalchemi/models/lj.py` has a superficially similar pattern but with `self._atomic_energies_buf` (a kernel output buffer) on the scatter.
