### PR TITLE
Bumping `torch` minimum version to 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,6 @@ via NVIDIA Warp:
 ### Requirements
 
 - Python 3.11–3.13
-- PyTorch >= 2.5.1
+- PyTorch >= 2.8
 - `nvalchemi-toolkit-ops[torch]` >= 0.3.1
 - Optional: `[mace]`, `[aimnet]`, `[ase]`, `[pymatgen]` extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11,<3.14"
 license = {file="LICENSE"}
 dependencies = [
     "nvalchemi-toolkit-ops[torch]>=0.3.1",
-    "torch>=2.5.1",
+    "torch>=2.8",
     "loguru",
     "numpy",
     "jaxtyping>=0.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ requires-dist = [
     { name = "pymatgen", marker = "extra == 'pymatgen'", specifier = ">=2025.10.7" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "tensordict", specifier = ">=0.11.0" },
-    { name = "torch", specifier = ">=2.5.1" },
+    { name = "torch", specifier = ">=2.8" },
     { name = "zarr", specifier = ">=3" },
 ]
 provides-extras = ["aimnet", "ase", "mace", "pymatgen"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR addresses #84 by bumping the minimum PyTorch version to 2.8, which was the minimum tested version that supports other integer types for `scatter_*` operations.

Arguably it's not a bug fix persay, but aligns `pyproject.toml` with the original intention when we wanted to allow scatter operations to use lower precision integer types.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Closes #84 

## Changes Made

<!-- List the key changes made in this PR -->

- Updates `uv.lock`, `pyproject.toml`
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
