### PR TITLE
fix(models): use tensile-positive stress convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- Standardized public `stress` outputs on tensile-positive Cauchy stress
+  (`sigma = -W / V`) while keeping low-level virials defined as negative
+  strain derivatives.
+
 ## 0.1.0 — 2026-04-16
 
 Initial public-beta release of NVIDIA ALCHEMI Toolkit, a GPU-first Python

--- a/docs/userguide/about/conventions.md
+++ b/docs/userguide/about/conventions.md
@@ -1,0 +1,37 @@
+(conventions)=
+
+# Conventions
+
+This page documents the project-wide sign conventions used by `nvalchemi`.
+
+## Virial
+
+The virial tensor is defined as the negative strain derivative of the energy:
+
+$$W_{ab} = -\frac{\partial E}{\partial \varepsilon_{ab}}$$
+
+where $\varepsilon$ is the symmetric infinitesimal strain tensor.
+
+Low-level interaction kernels in `nvalchemiops` return virials using this
+convention.
+
+## Stress
+
+The public `stress` tensor in `nvalchemi` follows the tensile-positive
+Cauchy stress convention:
+
+$$\sigma = -\frac{W}{V}$$
+
+where $V = |\det(\mathbf{C})|$ is the cell volume.
+
+```{note}
+Some molecular-dynamics codes use the opposite compression-positive, or
+"pressure", convention $\sigma = W / V$. When comparing against external
+references, check which convention they follow.
+```
+
+## Pressure
+
+Scalar pressure is positive for compression:
+
+$$P = -\frac{1}{3}\operatorname{tr}(\sigma)$$

--- a/docs/userguide/about/conventions.md
+++ b/docs/userguide/about/conventions.md
@@ -23,12 +23,8 @@ Cauchy stress convention:
 $$\sigma = -\frac{W}{V}$$
 
 where $V = |\det(\mathbf{C})|$ is the cell volume.
-
-```{note}
-Some molecular-dynamics codes use the opposite compression-positive, or
-"pressure", convention $\sigma = W / V$. When comparing against external
-references, check which convention they follow.
-```
+Cauchy stress is the true stress tensor for the current configuration: it maps
+a surface normal to the traction acting on that surface.
 
 ## Pressure
 
@@ -43,3 +39,12 @@ $$\mathbf{P} = \frac{\mathbf{K} + W}{V}$$
 
 where $\mathbf{K}$ is the kinetic tensor and $W$ is the virial. For a static
 system with $\sigma = -p\mathbf{I}$, this gives $\mathbf{P} = p\mathbf{I}$.
+
+## References
+
+- Malvern, L. E. *Introduction to the Mechanics of a Continuous Medium*.
+  Prentice-Hall, 1969.
+- Thompson, A. P.; Plimpton, S. J.; Mattson, W. "General formulation of
+  pressure and stress tensor for arbitrary many-body interaction potentials
+  under periodic boundary conditions." *J. Chem. Phys.* **131**, 154107
+  (2009). [doi:10.1063/1.3245303](https://doi.org/10.1063/1.3245303)

--- a/docs/userguide/about/conventions.md
+++ b/docs/userguide/about/conventions.md
@@ -32,6 +32,14 @@ references, check which convention they follow.
 
 ## Pressure
 
-Scalar pressure is positive for compression:
+Scalar and tensor pressure are positive for compression. From the
+tensile-positive stress tensor:
 
-$$P = -\frac{1}{3}\operatorname{tr}(\sigma)$$
+$$p = -\frac{1}{3}\operatorname{tr}(\sigma)$$
+
+The NPT/NPH pressure tensor uses the same sign convention:
+
+$$\mathbf{P} = \frac{\mathbf{K} + W}{V}$$
+
+where $\mathbf{K}$ is the kinetic tensor and $W$ is the virial. For a static
+system with $\sigma = -p\mathbf{I}$, this gives $\mathbf{P} = p\mathbf{I}$.

--- a/docs/userguide/data.md
+++ b/docs/userguide/data.md
@@ -27,6 +27,8 @@ as `shifts` (Cartesian displacements) and
 `neighbor_list_shifts` (integer lattice indices) for periodicity.
 - **Optional system-level**: `energy`, `cell`, `pbc`, `stress`, `virial`, etc.
 
+For stress, virial, and pressure sign conventions, see {ref}`conventions`.
+
 All tensor fields use PyTorch tensors, so you can move them to GPU with `.to(device)` or
 use the mixin method {py:meth}`nvalchemi.data.data.DataMixin.to` for device/dtype changes.
 

--- a/docs/userguide/dynamics_simulations.md
+++ b/docs/userguide/dynamics_simulations.md
@@ -58,7 +58,8 @@ with FIREVariableCell(
 ```
 
 The cell degrees of freedom are propagated using an NPH-like scheme at zero target
-pressure. The model must return `stress` (or `virial`) in addition to `forces`.
+pressure. The model must return tensile-positive `stress` in addition
+to `forces`.
 
 ### Choosing between fixed and variable cell
 

--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -26,6 +26,7 @@ $ python -c "import nvalchemi; print(nvalchemi.__version__)"
 
 - [Install](about/install)
 - [Introduction](about/intro)
+- [Conventions](about/conventions)
 
 ## Core Components
 
@@ -47,6 +48,7 @@ $ python -c "import nvalchemi; print(nvalchemi.__version__)"
 
 about/install
 about/intro
+about/conventions
 about/faq
 about/contributing
 

--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -621,7 +621,7 @@ from nvalchemi.models._utils import autograd_forces, autograd_stresses, prepare_
 
 * `autograd_forces(energy, positions)` --- compute forces as `-dE/dr`.
 * `autograd_stresses(energy, displacement, cell, num_graphs)` --- compute
-  stresses as `-1/V * dE/d(strain)`.
+  tensile-positive Cauchy stresses as `1/V * dE/d(strain)`.
 * `prepare_strain(positions, cell, batch_idx)` --- set up the affine strain
   trick for autograd stress computation (see below).
 * `sum_outputs(*outputs)` --- element-wise sum on additive keys (energies,
@@ -704,7 +704,7 @@ def forward(self, data, **kwargs):
             grad_outputs=torch.ones_like(energy),
         )[0]
         volume = torch.det(data.cell).abs().view(-1, 1, 1)
-        result["stress"] = -grad.view(data.num_graphs, 3, 3) / volume
+        result["stress"] = grad.view(data.num_graphs, 3, 3) / volume
 
     return self.adapt_output(result, data)
 ```
@@ -713,6 +713,9 @@ You don't *have* to use ``prepare_strain`` --- it's a convenience.  MACE
 uses its own internal displacement trick via ``compute_displacement=True``.
 The only requirement is that your ``forward()`` returns the requested
 outputs.
+
+See {doc}`about/conventions` for the project-wide virial, stress, and pressure
+sign conventions.
 
 #### Example: Hessians and Jacobians
 

--- a/nvalchemi/data/atomic_data.py
+++ b/nvalchemi/data/atomic_data.py
@@ -227,7 +227,7 @@ class AtomicData(BaseModel, DataMixin):
 
     stress: Annotated[
         t.Stress | None,
-        Field(description="Cauchy stress W/V (eV/A^3) [1, 3, 3]"),
+        Field(description="Tensile-positive Cauchy stress (eV/A^3) [1, 3, 3]"),
         PlainSerializer(_tensor_serialization, when_used="json"),
     ] = None
 

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -783,7 +783,9 @@ def stress_to_cell_force(
     volume: torch.Tensor,
     keep_aligned: bool = True,
 ) -> torch.Tensor:
-    """Convert stress tensor to cell force: ``F_cell = -V * σ * (h⁻¹)ᵀ``.
+    """Convert tensile-positive Cauchy stress to cell force.
+
+    ``F_cell = -V * σ * (h⁻¹)ᵀ``.
 
     Used by variable-cell FIRE/FIRE2 optimizers to obtain the force on
     the cell degrees of freedom from the model's stress output.
@@ -791,7 +793,8 @@ def stress_to_cell_force(
     Parameters
     ----------
     stress : torch.Tensor
-        Per-system stress tensor ``[M, 3, 3]``, float32 or float64.
+        Per-system tensile-positive Cauchy stress tensor ``[M, 3, 3]``,
+        float32 or float64.
     cell : torch.Tensor
         Per-system cell matrix ``[M, 3, 3]``, same dtype.
     volume : torch.Tensor

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -783,9 +783,11 @@ def stress_to_cell_force(
     volume: torch.Tensor,
     keep_aligned: bool = True,
 ) -> torch.Tensor:
-    """Convert tensile-positive Cauchy stress to cell force.
+    r"""Convert tensile-positive Cauchy stress to cell force.
 
-    ``F_cell = -V * σ * (h⁻¹)ᵀ``.
+    .. math::
+
+        F_\mathrm{cell} = -V \sigma (h^{-1})^\mathrm{T}
 
     Used by variable-cell FIRE/FIRE2 optimizers to obtain the force on
     the cell degrees of freedom from the model's stress output.

--- a/nvalchemi/dynamics/integrators/nph.py
+++ b/nvalchemi/dynamics/integrators/nph.py
@@ -194,9 +194,9 @@ class NPH(BaseDynamics):
 
     def _compute_P(self, batch: Batch, volumes: torch.Tensor) -> torch.Tensor:
         """Compute the instantaneous pressure tensor."""
-        # batch.stress is Cauchy stress W/V (eV/A^3).
+        # batch.stress is tensile-positive Cauchy stress -W/V (eV/A^3).
         # compute_pressure_tensor expects virial W (eV).
-        virial = batch.stress * volumes.view(-1, 1, 1)
+        virial = -batch.stress * volumes.view(-1, 1, 1)
         return compute_pressure_tensor(
             batch.velocities,
             batch.atomic_masses,

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -303,9 +303,9 @@ class NPT(BaseDynamics):
 
     def _compute_P(self, batch: Batch, volumes: torch.Tensor) -> torch.Tensor:
         """Compute the instantaneous pressure tensor."""
-        # batch.stress is Cauchy stress W/V (eV/A^3).
+        # batch.stress is tensile-positive Cauchy stress -W/V (eV/A^3).
         # compute_pressure_tensor expects virial W (eV).
-        virial = batch.stress * volumes.view(-1, 1, 1)
+        virial = -batch.stress * volumes.view(-1, 1, 1)
         return compute_pressure_tensor(
             batch.velocities,
             batch.atomic_masses,

--- a/nvalchemi/dynamics/optimizers/fire2.py
+++ b/nvalchemi/dynamics/optimizers/fire2.py
@@ -341,7 +341,7 @@ class FIRE2VariableCell(BaseDynamics):
             updated in-place.
         """
         volumes = torch.linalg.det(batch.cell).abs()
-        # batch.stress is Cauchy stress W/V (eV/A^3).
+        # batch.stress is tensile-positive Cauchy stress -W/V (eV/A^3).
         stress_sigma = batch.stress
         cell_force = stress_to_cell_force(stress_sigma, batch.cell, volumes)
         fire2_step_coord_cell(

--- a/nvalchemi/models/_ops/lj.py
+++ b/nvalchemi/models/_ops/lj.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""PyTorch custom ops wrapping the Warp Lennard-Jones interaction kernels.
+r"""PyTorch custom ops wrapping the Warp Lennard-Jones interaction kernels.
 
 Exposes two ``torch.library`` operators:
 
@@ -30,9 +30,19 @@ virials are computed analytically inside the Warp kernels.
 
 Sign Convention
 ---------------
-The LJ kernels produce the virial ``W = -dE/d(epsilon)`` (energy units, eV).
+The LJ kernels produce the virial
+
+.. math::
+
+    W = -\frac{\partial E}{\partial \epsilon}
+
 The model wrapper converts this to tensile-positive Cauchy stress
-``σ = -W / V`` (eV/Å³) and stores it in ``batch.stress``.
+
+.. math::
+
+    \sigma = -\frac{W}{V}
+
+and stores it in ``batch.stress``.
 
 Notes
 -----

--- a/nvalchemi/models/_ops/lj.py
+++ b/nvalchemi/models/_ops/lj.py
@@ -31,8 +31,8 @@ virials are computed analytically inside the Warp kernels.
 Sign Convention
 ---------------
 The LJ kernels produce the virial ``W = -dE/d(epsilon)`` (energy units, eV).
-The model wrapper divides by cell volume to obtain the Cauchy stress
-``σ = W / V`` (eV/Å³) and stores it in ``batch.stress``.
+The model wrapper converts this to tensile-positive Cauchy stress
+``σ = -W / V`` (eV/Å³) and stores it in ``batch.stress``.
 
 Notes
 -----

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -104,7 +104,7 @@ def prepare_strain(
             energy, displacement, torch.ones_like(energy),
         )[0]
         volume = torch.det(cell).abs().view(-1, 1, 1)
-        stresses = -grad.view(B, 3, 3) / volume
+        stresses = grad.view(B, 3, 3) / volume
 
     This function is used internally by :class:`PipelineModelWrapper`
     for autograd groups, and is available for users who want to
@@ -154,9 +154,9 @@ def autograd_stresses(
     training: bool = False,
     retain_graph: bool = False,
 ) -> Stress:
-    """Compute Cauchy stress as ``W/V = -1/V * dE/d(strain)`` via autograd.
+    """Compute tensile-positive Cauchy stress via autograd.
 
-    Returns the Cauchy stress tensor in eV/Å³.
+    Returns ``1/V * dE/d(strain)`` in eV/Å³.
 
     Parameters
     ----------
@@ -187,7 +187,7 @@ def autograd_stresses(
         retain_graph=effective_retain,
     )[0]
     volume = torch.det(cell).abs().view(-1, 1, 1)
-    return -grad.view(num_graphs, 3, 3) / volume
+    return grad.view(num_graphs, 3, 3) / volume
 
 
 def sum_outputs(

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -206,7 +206,7 @@ def autograd_forces_and_stresses(
     training: bool = False,
     retain_graph: bool = False,
 ) -> tuple[Forces, Stress]:
-    """Compute forces and Cauchy stress in a single autograd call.
+    """Compute forces and tensile-positive Cauchy stress in one autograd call.
 
     Parameters
     ----------
@@ -240,7 +240,7 @@ def autograd_forces_and_stresses(
     )
     forces = -position_grad
     volume = torch.det(cell).abs().view(-1, 1, 1)
-    stress = -displacement_grad.view(num_graphs, 3, 3) / volume
+    stress = displacement_grad.view(num_graphs, 3, 3) / volume
     return forces, stress
 
 

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -622,10 +622,10 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
                     raise ValueError(
                         "stress output requires cell for volume computation"
                     )
-                # Cauchy stress sigma = W/V (eV/A^3).
+                # Tensile-positive Cauchy stress sigma = -W/V (eV/A^3).
                 virial = model_output["virial"]
                 volume = torch.det(data.cell).abs().view(-1, 1, 1)
-                output["stress"] = virial / volume
+                output["stress"] = -virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
             else:
@@ -666,7 +666,7 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
             ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
-            ``W/V``).
+            ``-W/V``).
         """
         from nvalchemiops.torch.interactions.dispersion import (  # lazy
             D3Parameters,

--- a/nvalchemi/models/dftd3.py
+++ b/nvalchemi/models/dftd3.py
@@ -627,6 +627,8 @@ class DFTD3ModelWrapper(nn.Module, BaseModelMixin):
                 volume = torch.det(data.cell).abs().view(-1, 1, 1)
                 output["stress"] = -virial / volume
             elif "stress" in model_output:
+                # Direct stress outputs are expected to already use the
+                # public tensile-positive Cauchy stress convention.
                 output["stress"] = model_output["stress"]
             else:
                 raise RuntimeError(

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -324,7 +324,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
             ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
-            ``W/V``).
+            ``-W/V``).
         """
         from nvalchemiops.torch.interactions.electrostatics.ewald import (  # lazy
             ewald_real_space,
@@ -477,9 +477,9 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:
-            # Cauchy stress sigma = W/V (eV/A^3).
+            # Tensile-positive Cauchy stress sigma = -W/V (eV/A^3).
             volume = torch.det(data.cell).abs().view(-1, 1, 1)
-            model_output["stress"] = virial / volume
+            model_output["stress"] = -virial / volume
         elif compute_stresses:
             raise RuntimeError(
                 "stress was requested but the kernel did not return a virial"

--- a/nvalchemi/models/lj.py
+++ b/nvalchemi/models/lj.py
@@ -46,9 +46,9 @@ Notes
   are scalar parameters shared across all atom pairs.
 * Stress/virial computation (needed for NPT/NPH) is available via
   ``model_config.active_outputs`` including ``"stress"``.  When enabled, the
-  wrapper returns a ``"stress"`` key containing the Cauchy stress
-  ``W/V`` in energy units.  After calling ``Batch.from_data_list``, set the
-  placeholder directly:
+  wrapper returns a ``"stress"`` key containing the tensile-positive Cauchy
+  stress ``-W/V`` in energy units.  After calling ``Batch.from_data_list``, set
+  the placeholder directly:
   ``batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)``.  This is
   required because ``"stress"`` is not a named ``AtomicData`` field and is
   therefore not carried through batching automatically.
@@ -251,10 +251,10 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
                     raise ValueError(
                         "stress output requires cell for volume computation"
                     )
-                # Cauchy stress sigma = W/V (eV/A^3).
+                # Tensile-positive Cauchy stress sigma = -W/V (eV/A^3).
                 virial = model_output["virial"]
                 volume = torch.det(data.cell).abs().view(-1, 1, 1)
-                output["stress"] = virial / volume
+                output["stress"] = -virial / volume
             elif "stress" in model_output:
                 output["stress"] = model_output["stress"]
             else:
@@ -294,7 +294,7 @@ class LennardJonesModelWrapper(nn.Module, BaseModelMixin):
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``),
             ``"forces"`` (shape ``[N, 3]``), and optionally
             ``"stress"`` (shape ``[B, 3, 3]``) — Cauchy stress
-            ``W/V`` in energy units.
+            ``-W/V`` in energy units.
         """
         inp = self.adapt_input(data, **kwargs)
 

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -361,7 +361,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             OrderedDict with keys ``"energy"`` (shape ``[B, 1]``, eV),
             ``"forces"`` (shape ``[N, 3]``, eV/Å), and optionally
             ``"stress"`` (shape ``[B, 3, 3]``, eV/Å³ — Cauchy stress
-            ``W/V``).
+            ``-W/V``).
         """
         from nvalchemiops.torch.interactions.electrostatics.pme import (  # lazy
             particle_mesh_ewald,
@@ -503,9 +503,9 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         if forces is not None:
             model_output["forces"] = forces
         if virial is not None:
-            # Cauchy stress sigma = W/V (eV/A^3).
+            # Tensile-positive Cauchy stress sigma = -W/V (eV/A^3).
             volume = torch.det(data.cell).abs().view(-1, 1, 1)
-            model_output["stress"] = virial / volume
+            model_output["stress"] = -virial / volume
         elif compute_stresses:
             raise RuntimeError(
                 "stress was requested but the kernel did not return a virial"

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -148,6 +148,22 @@ class TestNPHIntegrator:
         assert nph._state.W.shape == (M,)
         assert nph._state.cell_velocity.shape == (M, 3, 3)
 
+    def test_compute_P_uses_ase_stress_convention(self, nph, device):
+        """Hydrostatic ASE stress sigma=-pI gives positive pressure p."""
+        batch = _make_barostat_batch(device=device)
+        nph._init_state(batch)
+        batch.velocities.zero_()
+        pressure = torch.tensor(2.0, dtype=batch.cell.dtype, device=batch.cell.device)
+        identity = torch.eye(3, dtype=batch.cell.dtype, device=batch.cell.device)
+        batch["stress"] = -pressure * identity.unsqueeze(0)
+
+        P = nph._compute_P(batch, nph._compute_volumes(batch)).view(
+            batch.num_graphs, 3, 3
+        )
+
+        expected = pressure * identity.unsqueeze(0)
+        torch.testing.assert_close(P, expected.expand_as(P), atol=1e-5, rtol=1e-5)
+
     # ------------------------------------------------------------------
     # _make_new_state
     # ------------------------------------------------------------------
@@ -342,6 +358,22 @@ class TestNPTIntegrator:
         M = batch.num_graphs
         assert npt._state.nhc_eta.shape == (M, npt.chain_length)
         assert npt._state.nhc_Q.shape == (M, npt.chain_length)
+
+    def test_compute_P_uses_ase_stress_convention(self, npt, device):
+        """Hydrostatic ASE stress sigma=-pI gives positive pressure p."""
+        batch = _make_barostat_batch(device=device)
+        npt._init_state(batch)
+        batch.velocities.zero_()
+        pressure = torch.tensor(2.0, dtype=batch.cell.dtype, device=batch.cell.device)
+        identity = torch.eye(3, dtype=batch.cell.dtype, device=batch.cell.device)
+        batch["stress"] = -pressure * identity.unsqueeze(0)
+
+        P = npt._compute_P(batch, npt._compute_volumes(batch)).view(
+            batch.num_graphs, 3, 3
+        )
+
+        expected = pressure * identity.unsqueeze(0)
+        torch.testing.assert_close(P, expected.expand_as(P), atol=1e-5, rtol=1e-5)
 
     # ------------------------------------------------------------------
     # _make_new_state

--- a/test/dynamics/test_ops.py
+++ b/test/dynamics/test_ops.py
@@ -1011,6 +1011,20 @@ class TestNptNphOps:
         assert cell_force.shape == (M, 3, 3)
         assert cell_force.dtype == dtype
 
+    def test_stress_to_cell_force_tensile_positive_sign(self, dtype, device):
+        from nvalchemi.dynamics._ops.npt_nph import stress_to_cell_force
+
+        pressure = torch.tensor(2.0, dtype=dtype, device=device)
+        identity = torch.eye(3, dtype=dtype, device=device)
+        stress = -pressure * identity.unsqueeze(0)
+        cell = identity.unsqueeze(0).contiguous()
+        volume = torch.linalg.det(cell).abs()
+
+        cell_force = stress_to_cell_force(stress, cell, volume)
+
+        expected = pressure * identity.unsqueeze(0)
+        torch.testing.assert_close(cell_force, expected)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: NVE, NVT (Langevin), NVT (NHC)

--- a/test/models/test_base.py
+++ b/test/models/test_base.py
@@ -619,6 +619,15 @@ class TestAutogradStresses:
         stresses = autograd_stresses(energy, displacement, cell, num_graphs=1)
         assert stresses.shape == (1, 3, 3)
 
+    def test_tensile_positive_sign(self):
+        displacement = torch.zeros(1, 3, 3, requires_grad=True)
+        cell = torch.eye(3).unsqueeze(0)
+        energy = 2.0 * displacement[0, 0, 0]
+        stresses = autograd_stresses(energy, displacement, cell, num_graphs=1)
+        expected = torch.zeros(1, 3, 3)
+        expected[0, 0, 0] = 2.0
+        torch.testing.assert_close(stresses, expected)
+
     def test_multiple_systems(self):
         displacement = torch.randn(3, 3, 3, requires_grad=True)
         cell = torch.eye(3).unsqueeze(0).expand(3, -1, -1) * 10.0

--- a/test/models/test_dftd3.py
+++ b/test/models/test_dftd3.py
@@ -589,8 +589,8 @@ class TestDFTD3ModelWrapper:
         out = wrapper.adapt_output(raw, batch)
         assert "forces" not in out
 
-    def test_adapt_output_stress_is_virial_over_volume(self):
-        """stress == virial / volume (Cauchy stress, eV/A^3)."""
+    def test_adapt_output_stress_is_negative_virial_over_volume(self):
+        """ASE-style stress == -virial / volume (eV/A^3)."""
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
         wrapper.model_config.active_outputs.add("stress")
         batch = _mock_batch()  # identity cell, volume = 1.0
@@ -603,7 +603,7 @@ class TestDFTD3ModelWrapper:
         out = wrapper.adapt_output(raw, batch)
         assert "stress" in out
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        torch.testing.assert_close(out["stress"], virial / volume)
+        torch.testing.assert_close(out["stress"], -virial / volume)
 
     def test_adapt_output_stress_raises_without_cell(self):
         """ValueError when stress+virial is active but data has no cell."""
@@ -806,7 +806,7 @@ class TestDFTD3ModelWrapper:
         )
 
     def test_forward_stress_unit_conversion(self):
-        """Stress output is virial_eV / volume (identity cell => stress == virial_eV)."""
+        """Stress output is -virial_eV / volume."""
         from nvalchemi.models.dftd3 import HARTREE_TO_EV
 
         wrapper = _make_d3_wrapper(a1=0.4, a2=4.4, s8=0.8)
@@ -834,7 +834,7 @@ class TestDFTD3ModelWrapper:
         with patch.object(_d3mod.DFTD3ModelWrapper, "forward", patched_forward):
             out = wrapper.forward(batch)
 
-        expected = virial_ha_value * HARTREE_TO_EV
+        expected = -virial_ha_value * HARTREE_TO_EV
         assert out["stress"].shape == (1, 3, 3)
         torch.testing.assert_close(
             out["stress"],

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -512,32 +512,65 @@ class TestEwaldIntegration:
         assert "stress" in out
         assert out["stress"].shape == (1, 3, 3)
 
-    def test_forward_stress_is_virial_over_volume(self):
-        """Stress == virial / volume (Cauchy stress, eV/A^3)."""
-        import nvalchemi.models.ewald as _emod
-
+    def test_forward_stress_is_negative_virial_over_volume(self):
+        """ASE-style stress == -virial / volume (eV/A^3)."""
         w = _make_ewald()
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch(box_size=10.0)
         self._build_nl(batch, w)
 
-        known_virial = torch.full((1, 3, 3), 5.0)
+        real_virial_value = 2.0
+        recip_virial_value = 3.0
 
-        def patched_forward(self_inner, data, **kw):
-            N = data.num_nodes
-            model_output = {
-                "energy": torch.zeros(1, 1),
-                "forces": torch.zeros(N, 3),
-            }
-            volume = torch.det(data.cell).abs().view(-1, 1, 1)
-            model_output["stress"] = known_virial / volume
-            return self_inner.adapt_output(model_output, data)
+        def fake_real_space(**kw):
+            positions = kw["positions"]
+            cell = kw["cell"]
+            return (
+                torch.zeros(
+                    positions.shape[0], dtype=positions.dtype, device=positions.device
+                ),
+                torch.zeros_like(positions),
+                torch.full(
+                    (cell.shape[0], 3, 3),
+                    real_virial_value,
+                    dtype=positions.dtype,
+                    device=positions.device,
+                ),
+            )
 
-        with patch.object(_emod.EwaldModelWrapper, "forward", patched_forward):
+        def fake_reciprocal_space(**kw):
+            positions = kw["positions"]
+            cell = kw["cell"]
+            return (
+                torch.zeros(
+                    positions.shape[0], dtype=positions.dtype, device=positions.device
+                ),
+                torch.zeros_like(positions),
+                torch.full(
+                    (cell.shape[0], 3, 3),
+                    recip_virial_value,
+                    dtype=positions.dtype,
+                    device=positions.device,
+                ),
+            )
+
+        with (
+            patch(
+                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_real_space",
+                side_effect=fake_real_space,
+            ),
+            patch(
+                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_reciprocal_space",
+                side_effect=fake_reciprocal_space,
+            ),
+        ):
             out = w.forward(batch)
 
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        torch.testing.assert_close(out["stress"], known_virial / volume)
+        expected = (
+            -(real_virial_value + recip_virial_value) * w.coulomb_constant / volume
+        )
+        torch.testing.assert_close(out["stress"], expected.expand_as(out["stress"]))
 
     def test_forward_raises_when_virial_none(self):
         """RuntimeError when stress is requested but kernels return no virial."""
@@ -828,7 +861,7 @@ class TestEwaldHybridForces:
         v_real = real_result[1]
         v_recip = recip_result[1]
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        expected_stress = (v_real + v_recip) * w.coulomb_constant / volume
+        expected_stress = -(v_real + v_recip) * w.coulomb_constant / volume
 
         torch.testing.assert_close(
             out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5

--- a/test/models/test_lj_model.py
+++ b/test/models/test_lj_model.py
@@ -406,7 +406,7 @@ class TestAdaptOutput:
         result = model.adapt_output(self._model_output(include_virials=True), batch)
         assert "stress" not in result
 
-    def test_stresses_equal_virial_over_volume(self):
+    def test_stresses_equal_negative_virial_over_volume(self):
         model = _make_model()
         model.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_lj_batch()
@@ -419,7 +419,7 @@ class TestAdaptOutput:
         result = model.adapt_output(mo, batch)
         assert "stress" in result
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        assert torch.allclose(result["stress"], virials / volume)
+        assert torch.allclose(result["stress"], -virials / volume)
 
     def test_stresses_is_stresses_when_no_virials_key(self):
         model = _make_model()

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -1610,7 +1610,7 @@ class TestPipelineAutogradCorrectness:
 
         expected_forces = -2.0 * positions
         volume = torch.det(cell).abs().view(-1, 1, 1)
-        expected_stress = -(2.0 * positions.T @ positions).unsqueeze(0) / volume
+        expected_stress = (2.0 * positions.T @ positions).unsqueeze(0) / volume
 
         torch.testing.assert_close(out["forces"], expected_forces, atol=1e-10, rtol=0)
         torch.testing.assert_close(out["stress"], expected_stress, atol=1e-10, rtol=0)

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -540,32 +540,40 @@ class TestPMEIntegration:
         assert out["stress"].ndim == 3
         assert out["stress"].shape[-2:] == (3, 3)
 
-    def test_forward_stress_is_virial_over_volume(self):
-        """Stress == virial / volume (Cauchy stress, eV/A^3)."""
-        import nvalchemi.models.pme as _pmod
-
+    def test_forward_stress_is_negative_virial_over_volume(self):
+        """ASE-style stress == -virial / volume (eV/A^3)."""
         w = _make_pme()
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch(box_size=10.0)
         self._build_nl(batch, w)
 
-        known_virial = torch.full((1, 3, 3), 5.0)
+        virial_value = 5.0
 
-        def patched_forward(self_inner, data, **kw):
-            N = data.num_nodes
-            model_output = {
-                "energy": torch.zeros(1, 1),
-                "forces": torch.zeros(N, 3),
-            }
-            volume = torch.det(data.cell).abs().view(-1, 1, 1)
-            model_output["stress"] = known_virial / volume
-            return self_inner.adapt_output(model_output, data)
+        def fake_particle_mesh_ewald(**kw):
+            positions = kw["positions"]
+            cell = kw["cell"]
+            return (
+                torch.zeros(
+                    positions.shape[0], dtype=positions.dtype, device=positions.device
+                ),
+                torch.zeros_like(positions),
+                torch.full(
+                    (cell.shape[0], 3, 3),
+                    virial_value,
+                    dtype=positions.dtype,
+                    device=positions.device,
+                ),
+            )
 
-        with patch.object(_pmod.PMEModelWrapper, "forward", patched_forward):
+        with patch(
+            "nvalchemiops.torch.interactions.electrostatics.pme.particle_mesh_ewald",
+            side_effect=fake_particle_mesh_ewald,
+        ):
             out = w.forward(batch)
 
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        torch.testing.assert_close(out["stress"], known_virial / volume)
+        expected = -virial_value * w.coulomb_constant / volume
+        torch.testing.assert_close(out["stress"], expected.expand_as(out["stress"]))
 
     def test_forward_raises_when_virial_none(self):
         """RuntimeError when stress is requested but kernel returns no virial."""
@@ -800,7 +808,7 @@ class TestPMEIntegration:
             hybrid_forces=False,
         )
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        expected_stress = result[1] * w.coulomb_constant / volume
+        expected_stress = -result[1] * w.coulomb_constant / volume
 
         torch.testing.assert_close(
             out_hybrid["stress"], expected_stress, atol=1e-5, rtol=1e-5


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Update the public `stress` convention to tensile-positive Cauchy stress while keeping low-level virial tensors defined as `W = -dE/dε`. Update model wrappers, autograd stress, and NPT/NPH pressure conversion to use the same convention, and add convention documentation plus regression coverage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Update autograd stress and LJ, Ewald, PME, and DFTD3 wrapper stress outputs to use `-virial / volume`.
- Update NPT/NPH pressure conversion to reconstruct virial as `-stress * volume`.
- Add project convention documentation for virial, stress, and scalar pressure definitions.
- Add regression coverage for stress sign conversion and NPT/NPH hydrostatic stress-to-pressure conversion.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?


## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
