### PR TITLE
fix(models): merge force and stress autograd

### DIFF
--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -616,10 +616,18 @@ For total control, write a custom `nn.Module, BaseModelMixin` subclass and
 use the utility functions in {py:mod}`nvalchemi.models._utils`:
 
 ```python
-from nvalchemi.models._utils import autograd_forces, autograd_stresses, prepare_strain, sum_outputs
+from nvalchemi.models._utils import (
+    autograd_forces,
+    autograd_forces_and_stresses,
+    autograd_stresses,
+    prepare_strain,
+    sum_outputs,
+)
 ```
 
 * `autograd_forces(energy, positions)` --- compute forces as `-dE/dr`.
+* `autograd_forces_and_stresses(energy, positions, displacement, cell, num_graphs)`
+  --- compute forces and stresses from one autograd call.
 * `autograd_stresses(energy, displacement, cell, num_graphs)` --- compute
   stresses as `-1/V * dE/d(strain)`.
 * `prepare_strain(positions, cell, batch_idx)` --- set up the affine strain
@@ -674,7 +682,7 @@ displacement tensor.  The
 {py:func}`~nvalchemi.models._utils.prepare_strain` helper handles this:
 
 ```python
-from nvalchemi.models._utils import prepare_strain
+from nvalchemi.models._utils import autograd_forces_and_stresses, prepare_strain
 
 def forward(self, data, **kwargs):
     compute_stresses = "stress" in self.model_config.active_outputs
@@ -690,7 +698,11 @@ def forward(self, data, **kwargs):
 
     result = {"energy": energy.unsqueeze(-1)}
 
-    if "forces" in self.model_config.active_outputs:
+    if "forces" in self.model_config.active_outputs and compute_stresses:
+        result["forces"], result["stress"] = autograd_forces_and_stresses(
+            energy, scaled_pos, displacement, data.cell, data.num_graphs
+        )
+    elif "forces" in self.model_config.active_outputs:
         positions_for_grad = scaled_pos if compute_stresses else data.positions
         result["forces"] = -torch.autograd.grad(
             energy, positions_for_grad,
@@ -698,7 +710,7 @@ def forward(self, data, **kwargs):
             retain_graph=compute_stresses,
         )[0]
 
-    if compute_stresses:
+    if compute_stresses and "stress" not in result:
         grad = torch.autograd.grad(
             energy, displacement,
             grad_outputs=torch.ones_like(energy),

--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -703,11 +703,9 @@ def forward(self, data, **kwargs):
             energy, scaled_pos, displacement, data.cell, data.num_graphs
         )
     elif "forces" in self.model_config.active_outputs:
-        positions_for_grad = scaled_pos if compute_stresses else data.positions
         result["forces"] = -torch.autograd.grad(
-            energy, positions_for_grad,
+            energy, data.positions,
             grad_outputs=torch.ones_like(energy),
-            retain_graph=compute_stresses,
         )[0]
 
     if compute_stresses and "stress" not in result:

--- a/nvalchemi/_typing.py
+++ b/nvalchemi/_typing.py
@@ -81,6 +81,7 @@ PeriodicShifts: TypeAlias = Float[torch.Tensor, "E 3"]  # noqa: F722
 # Integer lattice image indices; stored as int or float depending on source
 NeighborListShifts: TypeAlias = Num[torch.Tensor, "E 3"]  # noqa: F722
 LatticeVectors: TypeAlias = Float[torch.Tensor, "B 3 3"]  # noqa: F722
+StrainDisplacement: TypeAlias = Float[torch.Tensor, "B 3 3"]  # noqa: F722
 Periodicity: TypeAlias = Bool[torch.Tensor, "B 3"]  # noqa: F722
 Forces: TypeAlias = Float[torch.Tensor, "V 3"]  # noqa: F722
 Hessian: TypeAlias = Float[torch.Tensor, "V 3 3"]  # noqa: F722

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -32,6 +32,7 @@ from nvalchemi._typing import (
     LatticeVectors,
     ModelOutputs,
     NodePositions,
+    StrainDisplacement,
     Stress,
 )
 
@@ -86,7 +87,7 @@ def prepare_strain(
     positions: NodePositions,
     cell: LatticeVectors,
     batch_idx: BatchIndices,
-) -> tuple[NodePositions, LatticeVectors, torch.Tensor]:
+) -> tuple[NodePositions, LatticeVectors, StrainDisplacement]:
     """Set up the affine strain trick for autograd stress computation.
 
     Creates a per-system 3x3 displacement tensor with
@@ -154,7 +155,7 @@ def prepare_strain(
 
 def autograd_stresses(
     energy: Energy,
-    displacement: torch.Tensor,
+    displacement: StrainDisplacement,
     cell: LatticeVectors,
     num_graphs: int,
     training: bool = False,
@@ -199,7 +200,7 @@ def autograd_stresses(
 def autograd_forces_and_stresses(
     energy: Energy,
     positions: NodePositions,
-    displacement: torch.Tensor,
+    displacement: StrainDisplacement,
     cell: LatticeVectors,
     num_graphs: int,
     training: bool = False,

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -35,7 +35,13 @@ from nvalchemi._typing import (
     Stress,
 )
 
-__all__ = ["autograd_forces", "autograd_stresses", "prepare_strain", "sum_outputs"]
+__all__ = [
+    "autograd_forces",
+    "autograd_forces_and_stresses",
+    "autograd_stresses",
+    "prepare_strain",
+    "sum_outputs",
+]
 
 
 def autograd_forces(
@@ -188,6 +194,53 @@ def autograd_stresses(
     )[0]
     volume = torch.det(cell).abs().view(-1, 1, 1)
     return -grad.view(num_graphs, 3, 3) / volume
+
+
+def autograd_forces_and_stresses(
+    energy: Energy,
+    positions: NodePositions,
+    displacement: torch.Tensor,
+    cell: LatticeVectors,
+    num_graphs: int,
+    training: bool = False,
+    retain_graph: bool = False,
+) -> tuple[Forces, Stress]:
+    """Compute forces and Cauchy stress in a single autograd call.
+
+    Parameters
+    ----------
+    energy : torch.Tensor
+        Total energy tensor.
+    positions : torch.Tensor
+        Atomic positions with ``requires_grad=True``.
+    displacement : torch.Tensor
+        Displacement tensor from :func:`prepare_strain`.
+    cell : torch.Tensor
+        Original unit cell tensor of shape ``[B, 3, 3]``.
+    num_graphs : int
+        Number of graphs (systems) in the batch.
+    training : bool, optional
+        If ``True``, create the computation graph for higher-order gradients.
+    retain_graph : bool, optional
+        If ``True``, retain the computation graph.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        ``(forces, stress)`` with shapes ``[N, 3]`` and ``[B, 3, 3]``.
+    """
+    effective_retain = retain_graph or training
+    position_grad, displacement_grad = torch.autograd.grad(
+        energy,
+        (positions, displacement),
+        grad_outputs=torch.ones_like(energy),
+        create_graph=training,
+        retain_graph=effective_retain,
+    )
+    forces = -position_grad
+    volume = torch.det(cell).abs().view(-1, 1, 1)
+    stress = -displacement_grad.view(num_graphs, 3, 3) / volume
+    return forces, stress
 
 
 def sum_outputs(

--- a/nvalchemi/models/aimnet2.py
+++ b/nvalchemi/models/aimnet2.py
@@ -64,7 +64,11 @@ from torch import nn
 from nvalchemi._optional import OptionalDependency
 from nvalchemi._typing import ModelOutputs
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.models._utils import prepare_strain
+from nvalchemi.models._utils import (
+    autograd_forces_and_stresses,
+    autograd_stresses,
+    prepare_strain,
+)
 from nvalchemi.models.base import (
     BaseModelMixin,
     ModelConfig,
@@ -468,8 +472,23 @@ class AIMNet2Wrapper(nn.Module, BaseModelMixin):
         if "spin_charges" in self.model_config.active_outputs:
             result["spin_charges"] = raw_output.get("spin_charges")
 
-        # Autograd-derived forces.
-        if compute_forces:
+        # Autograd-derived forces/stresses.
+        if compute_forces and compute_stresses and displacement is not None:
+            if orig_cell is None:
+                raise RuntimeError(
+                    "orig_cell is required when computing autograd stresses."
+                )
+            energy = result["energy"]
+            forces, stress = autograd_forces_and_stresses(
+                energy,
+                data.positions,
+                displacement,
+                orig_cell,
+                data.num_graphs,
+            )
+            result["forces"] = forces
+            result["stress"] = stress
+        elif compute_forces:
             energy = result["energy"]
             forces = -torch.autograd.grad(
                 energy,
@@ -479,11 +498,11 @@ class AIMNet2Wrapper(nn.Module, BaseModelMixin):
                 retain_graph=compute_stresses,
             )[0]
             result["forces"] = forces
-
-        # Autograd-derived stresses via the affine strain trick.
-        if compute_stresses and displacement is not None:
-            from nvalchemi.models._utils import autograd_stresses
-
+        elif compute_stresses and displacement is not None:
+            if orig_cell is None:
+                raise RuntimeError(
+                    "orig_cell is required when computing autograd stresses."
+                )
             result["stress"] = autograd_stresses(
                 result["energy"],
                 displacement,

--- a/nvalchemi/models/aimnet2.py
+++ b/nvalchemi/models/aimnet2.py
@@ -474,10 +474,6 @@ class AIMNet2Wrapper(nn.Module, BaseModelMixin):
 
         # Autograd-derived forces/stresses.
         if compute_forces and compute_stresses and displacement is not None:
-            if orig_cell is None:
-                raise RuntimeError(
-                    "orig_cell is required when computing autograd stresses."
-                )
             energy = result["energy"]
             forces, stress = autograd_forces_and_stresses(
                 energy,
@@ -499,10 +495,6 @@ class AIMNet2Wrapper(nn.Module, BaseModelMixin):
             )[0]
             result["forces"] = forces
         elif compute_stresses and displacement is not None:
-            if orig_cell is None:
-                raise RuntimeError(
-                    "orig_cell is required when computing autograd stresses."
-                )
             result["stress"] = autograd_stresses(
                 result["energy"],
                 displacement,

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -748,10 +748,13 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                     if isinstance(value, torch.Tensor):
                         group[key] = value.detach()
         else:
+            # AtomicData.model_dump() defaults to Python mode, so tensor fields
+            # remain tensors; only JSON serialization converts them to lists.
             for key, value in list(data.model_dump(exclude_none=True).items()):
                 if isinstance(value, torch.Tensor):
                     data[key] = value.detach()
 
+        # Detach runtime attributes stored directly on the object.
         for key, value in list(vars(data).items()):
             if key.startswith("_") or key in {"device", "keys"}:
                 continue

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -55,6 +55,7 @@ from nvalchemi.hooks import NeighborListHook
 from nvalchemi.models._ops.neighbor_filter import prepare_neighbors_for_model
 from nvalchemi.models._utils import (
     autograd_forces,
+    autograd_forces_and_stresses,
     autograd_stresses,
     prepare_strain,
     sum_outputs,
@@ -738,6 +739,25 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
             context[step] = out
         return sum_outputs(*step_outputs, additive_keys=self.additive_keys)
 
+    @staticmethod
+    def _detach_data_tensors(data: AtomicData | Batch) -> None:
+        """Detach tensor fields currently attached to a graph data object."""
+        if isinstance(data, Batch):
+            for group in data._storage.groups.values():
+                for key, value in list(group.items()):
+                    if isinstance(value, torch.Tensor):
+                        group[key] = value.detach()
+        else:
+            for key, value in list(data.model_dump(exclude_none=True).items()):
+                if isinstance(value, torch.Tensor):
+                    data[key] = value.detach()
+
+        for key, value in list(vars(data).items()):
+            if key.startswith("_") or key in {"device", "keys"}:
+                continue
+            if isinstance(value, torch.Tensor):
+                object.__setattr__(data, key, value.detach())
+
     def _run_autograd_group(
         self,
         group: PipelineGroup,
@@ -766,28 +786,30 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         )
 
         # Enable requires_grad on positions for force computation.
-        # We detach + clone first to ensure a fresh leaf tensor.  Without
-        # this, positions from a previous step may still carry graph
-        # references (e.g. from in-place updates by the integrator),
-        # causing "backward through the graph a second time" errors.
+        # We detach first to ensure a fresh leaf tensor.  Without this,
+        # positions from a previous step may still carry graph references
+        # (e.g. from in-place updates by the integrator), causing "backward
+        # through the graph a second time" errors.
         # NOTE: This must happen BEFORE strain preparation so that
         # prepare_strain can build a graph through the fresh leaves.
         for key in grad_keys:
             tensor = getattr(data, key, None)
             if tensor is not None and isinstance(tensor, torch.Tensor):
-                fresh = tensor.detach().clone().requires_grad_(True)
+                fresh = tensor.detach().requires_grad_(True)
                 data[key] = fresh
 
-        # Set up strain AFTER detach+clone (if stresses needed in default
-        # path).  This scales positions and cell through a displacement
-        # tensor so dE/d(displacement) gives the stress.  The fresh leaf
-        # tensors created above ensure the strain graph is not severed.
+        # Set up strain AFTER detaching (if stresses needed in default path).
+        # This scales positions and cell through a displacement tensor so
+        # dE/d(displacement) gives the stress.  The fresh leaf tensors created
+        # above ensure the strain graph is not severed.
         displacement = None
-        orig_positions = None
-        orig_cell = None
+        unstrained_positions = None
+        unstrained_cell = None
+        cell_for_stress = None
         if need_stresses:
-            orig_positions = data.positions
-            orig_cell = data.cell
+            unstrained_positions = data.positions
+            unstrained_cell = data.cell
+            cell_for_stress = data.cell
             scaled_pos, scaled_cell, displacement = prepare_strain(
                 data.positions,
                 data.cell,
@@ -796,78 +818,83 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
             data["positions"] = scaled_pos
             data["cell"] = scaled_cell
 
-        # Run all models in the group.
-        step_outputs: list[ModelOutputs] = []
-        for step in group.steps:
-            self._resolve_inputs(step, context, data)
-            out = self._call_step(step, data, **kwargs)
-            step_outputs.append(out)
-            context[step] = out
+        try:
+            # Run all models in the group.
+            step_outputs: list[ModelOutputs] = []
+            for step in group.steps:
+                self._resolve_inputs(step, context, data)
+                out = self._call_step(step, data, **kwargs)
+                step_outputs.append(out)
+                context[step] = out
 
-        # Sum energies across all steps in the group.
-        group_energy = None
-        for o in step_outputs:
-            e = o.get("energy")
-            if e is not None:
-                group_energy = e if group_energy is None else group_energy + e
+            # Sum energies across all steps in the group.
+            group_energy = None
+            for o in step_outputs:
+                e = o.get("energy")
+                if e is not None:
+                    group_energy = e if group_energy is None else group_energy + e
 
-        needs_retain = autograd_idx < (autograd_count - 1)
-        group_out: ModelOutputs = OrderedDict()
-        if group_energy is not None:
-            group_out["energy"] = group_energy
+            needs_retain = autograd_idx < (autograd_count - 1)
+            group_out: ModelOutputs = OrderedDict()
+            if group_energy is not None:
+                group_out["energy"] = group_energy
 
-        # Compute derivatives from the summed energy.
-        if group_energy is not None and requested_derivatives:
-            already_produced = set(group_out.keys())
-            needed = requested_derivatives - already_produced
+            # Compute derivatives from the summed energy.
+            if group_energy is not None and requested_derivatives:
+                already_produced = set(group_out.keys())
+                needed = requested_derivatives - already_produced
 
-            if needed:
-                if group.derivative_fn is not None:
-                    # User override — full control.
-                    derivs = group.derivative_fn(group_energy, data, needed)
-                else:
-                    # Default: forces + stresses.
-                    derivs = self._default_derivatives(
-                        group_energy,
-                        data,
-                        needed,
-                        displacement=displacement,
-                        orig_cell=orig_cell,
-                        retain_graph=needs_retain,
-                    )
-                group_out.update(derivs)
-
-        # Sum direct additive outputs from step outputs (e.g. hybrid-force
-        # models that return detached kernel forces and virial/stress)
-        # alongside the autograd derivatives computed above.  For hybrid
-        # electrostatic models the kernel returns dE/dR|_q (forces) and
-        # dE/d(strain)|_q (stress) while autograd provides the charge
-        # chain-rule terms (dE/dq)(dq/dR) and (dE/dq)(dq/d(strain)).
-        for o in step_outputs:
-            for key, val in o.items():
-                if val is not None and key in self.additive_keys and key != "energy":
-                    if key in group_out and group_out[key] is not None:
-                        group_out[key] = group_out[key] + val
+                if needed:
+                    if group.derivative_fn is not None:
+                        # User override — full control.
+                        derivs = group.derivative_fn(group_energy, data, needed)
                     else:
+                        # Default: forces + stresses.
+                        derivs = self._default_derivatives(
+                            group_energy,
+                            data,
+                            needed,
+                            displacement=displacement,
+                            orig_cell=cell_for_stress,
+                            retain_graph=needs_retain,
+                        )
+                    group_out.update(derivs)
+
+            # Sum direct additive outputs from step outputs (e.g. hybrid-force
+            # models that return detached kernel forces and virial/stress)
+            # alongside the autograd derivatives computed above.  For hybrid
+            # electrostatic models the kernel returns dE/dR|_q (forces) and
+            # dE/d(strain)|_q (stress) while autograd provides the charge
+            # chain-rule terms (dE/dq)(dq/dR) and (dE/dq)(dq/d(strain)).
+            for o in step_outputs:
+                for key, val in o.items():
+                    if (
+                        val is not None
+                        and key in self.additive_keys
+                        and key != "energy"
+                    ):
+                        if key in group_out and group_out[key] is not None:
+                            group_out[key] = group_out[key] + val
+                        else:
+                            group_out[key] = val
+
+            # Carry through non-additive keys from step outputs.
+            for o in step_outputs:
+                for key, val in o.items():
+                    if (
+                        val is not None
+                        and key not in self.additive_keys
+                        and key not in group_out
+                    ):
                         group_out[key] = val
 
-        # Carry through non-additive keys from step outputs.
-        for o in step_outputs:
-            for key, val in o.items():
-                if (
-                    val is not None
-                    and key not in self.additive_keys
-                    and key not in group_out
-                ):
-                    group_out[key] = val
-
-        # Restore original positions/cell if strain was applied.
-        if orig_positions is not None:
-            data["positions"] = orig_positions
-        if orig_cell is not None:
-            data["cell"] = orig_cell
-
-        return group_out
+            return group_out
+        finally:
+            if unstrained_positions is not None:
+                data["positions"] = unstrained_positions
+            if unstrained_cell is not None:
+                data["cell"] = unstrained_cell
+            self._detach_data_tensors(data)
 
     # ------------------------------------------------------------------
     # Serialization
@@ -1015,21 +1042,42 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         stresses are requested, returns an empty dict.
         """
         result: dict[str, torch.Tensor] = {}
+        need_forces = "forces" in requested
         need_stresses = displacement is not None and "stress" in requested
 
-        if "forces" in requested:
-            result["forces"] = autograd_forces(
+        if need_forces and need_stresses:
+            if orig_cell is None:
+                raise RuntimeError(
+                    "orig_cell is required when computing autograd stresses."
+                )
+            num_graphs = data.num_graphs if isinstance(data, Batch) else 1
+            forces, stress = autograd_forces_and_stresses(
                 energy,
                 data.positions,
-                retain_graph=retain_graph or need_stresses,
+                displacement,
+                orig_cell,
+                num_graphs,
+                retain_graph=retain_graph,
             )
+            return {"forces": forces, "stress": stress}
+
+        if need_forces:
+            forces = autograd_forces(energy, data.positions, retain_graph=retain_graph)
+            return {"forces": forces}
+
         if need_stresses:
+            if orig_cell is None:
+                raise RuntimeError(
+                    "orig_cell is required when computing autograd stresses."
+                )
             num_graphs = data.num_graphs if isinstance(data, Batch) else 1
-            result["stress"] = autograd_stresses(
+            stress = autograd_stresses(
                 energy,
                 displacement,
                 orig_cell,
                 num_graphs,
                 retain_graph=retain_graph,
             )
+            return {"stress": stress}
+
         return result

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -795,6 +795,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         for key in grad_keys:
             tensor = getattr(data, key, None)
             if tensor is not None and isinstance(tensor, torch.Tensor):
+                # Intentionally do not clone: pipeline steps must treat input
+                # tensors as read-only. Boundary cleanup detaches graph state
+                # but does not roll back in-place value mutations.
                 fresh = tensor.detach().requires_grad_(True)
                 data[key] = fresh
 

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -91,6 +91,16 @@ DerivativeFn = Callable[
 ]
 
 
+@dataclass
+class _AutogradStrainState:
+    """Temporary affine-strain state for default stress derivatives."""
+
+    displacement: torch.Tensor | None = None
+    cell_for_stress: LatticeVectors | None = None
+    unstrained_positions: torch.Tensor | None = None
+    unstrained_cell: LatticeVectors | None = None
+
+
 @dataclass(eq=False)
 class PipelineStep:
     """Wraps a model with an output rename mapping.
@@ -778,129 +788,167 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         derivative computation (forces + stresses via affine strain).
         When ``derivative_fn`` is provided, the user's function receives
         the summed energy, the batch, and the set of requested keys.
+
+        Before running group steps, tensors listed in ``grad_keys`` are
+        detached into fresh autograd leaves without cloning.  Pipeline steps
+        must therefore treat input tensors as read-only: boundary cleanup
+        detaches graph state but does not roll back in-place value mutations.
+        Stress strain is applied after fresh leaf creation so the strain graph
+        remains connected.  The ``finally`` block restores unstrained fields
+        and detaches tensors left on the graph data object.
+
+        Direct additive derivative outputs from hybrid models are added to the
+        autograd derivatives from the summed energy.  Non-additive outputs are
+        carried through with last-write-wins behavior.
         """
-        use_default_derivs = group.derivative_fn is None
-        need_stresses = (
-            use_default_derivs
+        need_stresses = self._needs_default_stresses(group, data, requested_derivatives)
+        self._prepare_autograd_leaves(data, grad_keys)
+        strain = self._apply_default_stress_strain(data, need_stresses)
+
+        try:
+            step_outputs = self._run_autograd_steps(group, data, context, **kwargs)
+            return self._build_autograd_group_output(
+                group,
+                data,
+                step_outputs,
+                requested_derivatives,
+                strain,
+                retain_graph=autograd_idx < (autograd_count - 1),
+            )
+        finally:
+            self._restore_default_stress_strain(data, strain)
+            self._detach_data_tensors(data)
+
+    @staticmethod
+    def _needs_default_stresses(
+        group: PipelineGroup,
+        data: AtomicData | Batch,
+        requested_derivatives: set[str],
+    ) -> bool:
+        """Return whether the default derivative path needs affine strain."""
+        return (
+            group.derivative_fn is None
             and "stress" in requested_derivatives
             and isinstance(data, Batch)
             and hasattr(data, "cell")
             and data.cell is not None
         )
 
-        # Enable requires_grad on positions for force computation.
-        # We detach first to ensure a fresh leaf tensor.  Without this,
-        # positions from a previous step may still carry graph references
-        # (e.g. from in-place updates by the integrator), causing "backward
-        # through the graph a second time" errors.
-        # NOTE: This must happen BEFORE strain preparation so that
-        # prepare_strain can build a graph through the fresh leaves.
+    @staticmethod
+    def _prepare_autograd_leaves(data: AtomicData | Batch, grad_keys: set[str]) -> None:
+        """Replace requested gradient tensors with fresh autograd leaves."""
         for key in grad_keys:
             tensor = getattr(data, key, None)
             if tensor is not None and isinstance(tensor, torch.Tensor):
-                # Intentionally do not clone: pipeline steps must treat input
-                # tensors as read-only. Boundary cleanup detaches graph state
-                # but does not roll back in-place value mutations.
                 fresh = tensor.detach().requires_grad_(True)
                 data[key] = fresh
 
-        # Set up strain AFTER detaching (if stresses needed in default path).
-        # This scales positions and cell through a displacement tensor so
-        # dE/d(displacement) gives the stress.  The fresh leaf tensors created
-        # above ensure the strain graph is not severed.
-        displacement = None
-        unstrained_positions = None
-        unstrained_cell = None
-        cell_for_stress = None
-        if need_stresses:
-            unstrained_positions = data.positions
-            unstrained_cell = data.cell
-            cell_for_stress = data.cell
-            scaled_pos, scaled_cell, displacement = prepare_strain(
-                data.positions,
-                data.cell,
-                data.batch_idx,
-            )
-            data["positions"] = scaled_pos
-            data["cell"] = scaled_cell
+    @staticmethod
+    def _apply_default_stress_strain(
+        data: AtomicData | Batch,
+        need_stresses: bool,
+    ) -> _AutogradStrainState:
+        """Apply affine strain for default stress derivatives when needed."""
+        strain = _AutogradStrainState()
+        if not need_stresses:
+            return strain
 
-        try:
-            # Run all models in the group.
-            step_outputs: list[ModelOutputs] = []
-            for step in group.steps:
-                self._resolve_inputs(step, context, data)
-                out = self._call_step(step, data, **kwargs)
-                step_outputs.append(out)
-                context[step] = out
+        strain.unstrained_positions = data.positions
+        strain.unstrained_cell = data.cell
+        strain.cell_for_stress = data.cell
+        scaled_pos, scaled_cell, strain.displacement = prepare_strain(
+            data.positions,
+            data.cell,
+            data.batch_idx,
+        )
+        data["positions"] = scaled_pos
+        data["cell"] = scaled_cell
+        return strain
 
-            # Sum energies across all steps in the group.
-            group_energy = None
-            for o in step_outputs:
-                e = o.get("energy")
-                if e is not None:
-                    group_energy = e if group_energy is None else group_energy + e
+    @staticmethod
+    def _restore_default_stress_strain(
+        data: AtomicData | Batch,
+        strain: _AutogradStrainState,
+    ) -> None:
+        """Restore unstrained tensors after default stress derivative setup."""
+        if strain.unstrained_positions is not None:
+            data["positions"] = strain.unstrained_positions
+        if strain.unstrained_cell is not None:
+            data["cell"] = strain.unstrained_cell
 
-            needs_retain = autograd_idx < (autograd_count - 1)
-            group_out: ModelOutputs = OrderedDict()
-            if group_energy is not None:
-                group_out["energy"] = group_energy
+    def _run_autograd_steps(
+        self,
+        group: PipelineGroup,
+        data: AtomicData | Batch,
+        context: dict[PipelineStep, ModelOutputs],
+        **kwargs: Any,
+    ) -> list[ModelOutputs]:
+        """Run all steps in an autograd group and record their outputs."""
+        step_outputs: list[ModelOutputs] = []
+        for step in group.steps:
+            self._resolve_inputs(step, context, data)
+            out = self._call_step(step, data, **kwargs)
+            step_outputs.append(out)
+            context[step] = out
+        return step_outputs
 
-            # Compute derivatives from the summed energy.
-            if group_energy is not None and requested_derivatives:
-                already_produced = set(group_out.keys())
-                needed = requested_derivatives - already_produced
+    def _build_autograd_group_output(
+        self,
+        group: PipelineGroup,
+        data: AtomicData | Batch,
+        step_outputs: list[ModelOutputs],
+        requested_derivatives: set[str],
+        strain: _AutogradStrainState,
+        *,
+        retain_graph: bool,
+    ) -> ModelOutputs:
+        """Build an autograd group output from step outputs and derivatives."""
+        group_energy = None
+        for output in step_outputs:
+            energy = output.get("energy")
+            if energy is not None:
+                group_energy = energy if group_energy is None else group_energy + energy
 
-                if needed:
-                    if group.derivative_fn is not None:
-                        # User override — full control.
-                        derivs = group.derivative_fn(group_energy, data, needed)
+        group_out: ModelOutputs = OrderedDict()
+        if group_energy is not None:
+            group_out["energy"] = group_energy
+
+        if group_energy is not None and requested_derivatives:
+            already_produced = set(group_out.keys())
+            needed = requested_derivatives - already_produced
+
+            if needed:
+                if group.derivative_fn is not None:
+                    derivs = group.derivative_fn(group_energy, data, needed)
+                else:
+                    derivs = self._default_derivatives(
+                        group_energy,
+                        data,
+                        needed,
+                        displacement=strain.displacement,
+                        orig_cell=strain.cell_for_stress,
+                        retain_graph=retain_graph,
+                    )
+                group_out.update(derivs)
+
+        for output in step_outputs:
+            for key, value in output.items():
+                if value is not None and key in self.additive_keys and key != "energy":
+                    if key in group_out and group_out[key] is not None:
+                        group_out[key] = group_out[key] + value
                     else:
-                        # Default: forces + stresses.
-                        derivs = self._default_derivatives(
-                            group_energy,
-                            data,
-                            needed,
-                            displacement=displacement,
-                            orig_cell=cell_for_stress,
-                            retain_graph=needs_retain,
-                        )
-                    group_out.update(derivs)
+                        group_out[key] = value
 
-            # Sum direct additive outputs from step outputs (e.g. hybrid-force
-            # models that return detached kernel forces and virial/stress)
-            # alongside the autograd derivatives computed above.  For hybrid
-            # electrostatic models the kernel returns dE/dR|_q (forces) and
-            # dE/d(strain)|_q (stress) while autograd provides the charge
-            # chain-rule terms (dE/dq)(dq/dR) and (dE/dq)(dq/d(strain)).
-            for o in step_outputs:
-                for key, val in o.items():
-                    if (
-                        val is not None
-                        and key in self.additive_keys
-                        and key != "energy"
-                    ):
-                        if key in group_out and group_out[key] is not None:
-                            group_out[key] = group_out[key] + val
-                        else:
-                            group_out[key] = val
+        for output in step_outputs:
+            for key, value in output.items():
+                if (
+                    value is not None
+                    and key not in self.additive_keys
+                    and key not in group_out
+                ):
+                    group_out[key] = value
 
-            # Carry through non-additive keys from step outputs.
-            for o in step_outputs:
-                for key, val in o.items():
-                    if (
-                        val is not None
-                        and key not in self.additive_keys
-                        and key not in group_out
-                    ):
-                        group_out[key] = val
-
-            return group_out
-        finally:
-            if unstrained_positions is not None:
-                data["positions"] = unstrained_positions
-            if unstrained_cell is not None:
-                data["cell"] = unstrained_cell
-            self._detach_data_tensors(data)
+        return group_out
 
     # ------------------------------------------------------------------
     # Serialization

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -49,7 +49,13 @@ from typing import Any
 import torch
 from torch import nn
 
-from nvalchemi._typing import Energy, LatticeVectors, ModelOutputs
+from nvalchemi._typing import (
+    Energy,
+    LatticeVectors,
+    ModelOutputs,
+    NodePositions,
+    StrainDisplacement,
+)
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.hooks import NeighborListHook
 from nvalchemi.models._ops.neighbor_filter import prepare_neighbors_for_model
@@ -95,9 +101,9 @@ DerivativeFn = Callable[
 class _AutogradStrainState:
     """Temporary affine-strain state for default stress derivatives."""
 
-    displacement: torch.Tensor | None = None
+    displacement: StrainDisplacement | None = None
     cell_for_stress: LatticeVectors | None = None
-    unstrained_positions: torch.Tensor | None = None
+    unstrained_positions: NodePositions | None = None
     unstrained_cell: LatticeVectors | None = None
 
 
@@ -1085,7 +1091,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         data: Batch | AtomicData,
         requested: set[str],
         *,
-        displacement: torch.Tensor | None,
+        displacement: StrainDisplacement | None,
         orig_cell: LatticeVectors | None,
         retain_graph: bool,
     ) -> dict[str, torch.Tensor]:

--- a/test/models/test_aimnet2.py
+++ b/test/models/test_aimnet2.py
@@ -69,6 +69,7 @@ class _MockAIMNet2Calculator:
         self.model = model if model is not None else _MockAIMNet2Model()
         self.device = device
         self.keys_out = ["energy", "charges"]
+        self.atom_feature_keys = ["charges"]
 
     def mol_flatten(self, data: dict) -> dict:
         """Pass through — already flat for single-system batches."""
@@ -298,6 +299,38 @@ def _build_nl(batch, model):
     from nvalchemi.neighbors import compute_neighbors
 
     compute_neighbors(batch, model.model_config.neighbor_config.cutoff)
+
+
+class TestAIMNet2WrapperMockForward:
+    """CPU forward tests using the mock AIMNet2 calculator."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_model):
+        self.wrapper = _make_wrapper(mock_model)
+
+    def test_forward_forces_and_stress_use_merged_helper(self, monkeypatch):
+        """Forces and stress requested together use the merged autograd helper."""
+        import nvalchemi.models.aimnet2 as aimnet2_module
+
+        real_helper = aimnet2_module.autograd_forces_and_stresses
+        calls = []
+
+        def wrapped_helper(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_helper(*args, **kwargs)
+
+        monkeypatch.setattr(
+            aimnet2_module, "autograd_forces_and_stresses", wrapped_helper
+        )
+
+        batch = _make_water_batch(device="cpu", pbc=True)
+        self.wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
+
+        out = self.wrapper(batch)
+
+        assert len(calls) == 1
+        assert out["forces"].shape == (3, 3)
+        assert out["stress"].shape == (1, 3, 3)
 
 
 @pytest.mark.skipif(

--- a/test/models/test_base.py
+++ b/test/models/test_base.py
@@ -26,7 +26,13 @@ import torch
 from pydantic import ValidationError
 
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.models._utils import autograd_forces, autograd_stresses, sum_outputs
+from nvalchemi.models._utils import (
+    autograd_forces,
+    autograd_forces_and_stresses,
+    autograd_stresses,
+    prepare_strain,
+    sum_outputs,
+)
 from nvalchemi.models.base import (
     BaseModelMixin,
     ModelConfig,
@@ -625,6 +631,88 @@ class TestAutogradStresses:
         energy = (displacement**2).sum()
         stresses = autograd_stresses(energy, displacement, cell, num_graphs=3)
         assert stresses.shape == (3, 3, 3)
+
+
+class TestAutogradForcesAndStresses:
+    """Tests for merged force and stress autograd utility."""
+
+    def test_matches_separate_autograd_calls(self):
+        positions = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
+        cell = torch.stack(
+            [
+                torch.eye(3, dtype=torch.float64) * 5.0,
+                torch.eye(3, dtype=torch.float64) * 8.0,
+            ]
+        )
+        batch_idx = torch.tensor([0, 0, 1, 1])
+        scaled_pos, _, displacement = prepare_strain(positions, cell, batch_idx)
+        energy = (scaled_pos**2).sum()
+
+        forces, stresses = autograd_forces_and_stresses(
+            energy,
+            scaled_pos,
+            displacement,
+            cell,
+            num_graphs=2,
+        )
+
+        positions_ref = positions.detach().clone().requires_grad_(True)
+        scaled_ref, _, displacement_ref = prepare_strain(positions_ref, cell, batch_idx)
+        energy_ref = (scaled_ref**2).sum()
+        expected_forces = autograd_forces(energy_ref, scaled_ref, retain_graph=True)
+        expected_stresses = autograd_stresses(
+            energy_ref, displacement_ref, cell, num_graphs=2
+        )
+
+        torch.testing.assert_close(forces, expected_forces)
+        torch.testing.assert_close(stresses, expected_stresses)
+
+    def test_uses_one_autograd_call(self, monkeypatch):
+        real_grad = torch.autograd.grad
+        calls = []
+
+        def wrapped_grad(outputs, inputs, *args, **kwargs):
+            calls.append(inputs)
+            return real_grad(outputs, inputs, *args, **kwargs)
+
+        monkeypatch.setattr(torch.autograd, "grad", wrapped_grad)
+
+        positions = torch.randn(3, 3, requires_grad=True)
+        cell = torch.eye(3).unsqueeze(0) * 10.0
+        batch_idx = torch.zeros(3, dtype=torch.long)
+        scaled_pos, _, displacement = prepare_strain(positions, cell, batch_idx)
+        energy = (scaled_pos**2).sum()
+
+        autograd_forces_and_stresses(
+            energy,
+            scaled_pos,
+            displacement,
+            cell,
+            num_graphs=1,
+        )
+
+        assert len(calls) == 1
+        assert calls[0][0] is scaled_pos
+        assert calls[0][1] is displacement
+
+    def test_retain_graph_allows_later_autograd_call(self):
+        positions = torch.randn(3, 3, requires_grad=True)
+        cell = torch.eye(3).unsqueeze(0) * 10.0
+        batch_idx = torch.zeros(3, dtype=torch.long)
+        scaled_pos, _, displacement = prepare_strain(positions, cell, batch_idx)
+        energy = (scaled_pos**2).sum()
+
+        autograd_forces_and_stresses(
+            energy,
+            scaled_pos,
+            displacement,
+            cell,
+            num_graphs=1,
+            retain_graph=True,
+        )
+        forces = autograd_forces(energy, scaled_pos)
+
+        assert forces.shape == scaled_pos.shape
 
 
 class TestSumOutputs:

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -1580,6 +1580,133 @@ class TestPipelineAutogradCorrectness:
         expected_forces = -2.0 * single_system_batch.positions
         torch.testing.assert_close(out["forces"], expected_forces, atol=1e-10, rtol=0)
 
+    def test_single_model_forces_and_stress_match_analytical(self):
+        """Pipeline computes forces and stress from the same strained energy."""
+        positions = torch.tensor(
+            [
+                [1.0, 2.0, 0.5],
+                [-0.5, 1.5, 2.0],
+                [0.25, -1.0, 1.0],
+            ],
+            dtype=torch.float64,
+        )
+        cell = torch.eye(3, dtype=torch.float64).unsqueeze(0) * 4.0
+        data = AtomicData(
+            positions=positions,
+            atomic_numbers=torch.tensor([6, 6, 8]),
+            forces=torch.zeros(3, 3, dtype=torch.float64),
+            energy=torch.zeros(1, 1, dtype=torch.float64),
+            cell=cell,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+
+        model = _QuadraticEnergyModel(scale=1.0)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces", "stress"}
+        out = pipe(batch)
+
+        expected_forces = -2.0 * positions
+        volume = torch.det(cell).abs().view(-1, 1, 1)
+        expected_stress = -(2.0 * positions.T @ positions).unsqueeze(0) / volume
+
+        torch.testing.assert_close(out["forces"], expected_forces, atol=1e-10, rtol=0)
+        torch.testing.assert_close(out["stress"], expected_stress, atol=1e-10, rtol=0)
+
+    def test_forces_and_stress_use_merged_autograd_helper(self, monkeypatch):
+        """Requesting forces and stress together should use one helper call."""
+        import nvalchemi.models.pipeline as pipeline_module
+
+        real_helper = pipeline_module.autograd_forces_and_stresses
+        calls = []
+
+        def wrapped_helper(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_helper(*args, **kwargs)
+
+        monkeypatch.setattr(
+            pipeline_module, "autograd_forces_and_stresses", wrapped_helper
+        )
+
+        data = AtomicData(
+            positions=torch.randn(4, 3, dtype=torch.float64),
+            atomic_numbers=torch.tensor([6, 6, 8, 1]),
+            forces=torch.zeros(4, 3, dtype=torch.float64),
+            energy=torch.zeros(1, 1, dtype=torch.float64),
+            cell=torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+        model = _QuadraticEnergyModel(scale=1.0)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces", "stress"}
+
+        out = pipe(batch)
+
+        assert len(calls) == 1
+        assert "forces" in out
+        assert "stress" in out
+
+    def test_autograd_group_detaches_batch_tensors_after_forces_and_stress(self):
+        """Autograd group cleanup should leave batch tensors detached."""
+        data = AtomicData(
+            positions=torch.randn(4, 3, dtype=torch.float64),
+            atomic_numbers=torch.tensor([6, 6, 8, 1]),
+            forces=torch.zeros(4, 3, dtype=torch.float64),
+            energy=torch.zeros(1, 1, dtype=torch.float64),
+            cell=torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+        model = _QuadraticEnergyModel(scale=1.0)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces", "stress"}
+
+        out = pipe(batch)
+
+        assert "forces" in out
+        assert "stress" in out
+        for _, value in batch:
+            if isinstance(value, torch.Tensor):
+                assert not value.requires_grad
+                assert value.grad_fn is None
+
+    def test_autograd_group_detaches_batch_tensors_after_exception(self):
+        """Autograd group cleanup should run even when a step raises."""
+
+        class _RaisingEnergyModel(_QuadraticEnergyModel):
+            def forward(self, data, **kwargs) -> ModelOutputs:
+                raise RuntimeError("intentional failure")
+
+        data = AtomicData(
+            positions=torch.randn(4, 3, dtype=torch.float64),
+            atomic_numbers=torch.tensor([6, 6, 8, 1]),
+            forces=torch.zeros(4, 3, dtype=torch.float64),
+            energy=torch.zeros(1, 1, dtype=torch.float64),
+            cell=torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+        model = _RaisingEnergyModel(scale=1.0)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces", "stress"}
+
+        with pytest.raises(RuntimeError, match="intentional failure"):
+            pipe(batch)
+
+        for _, value in batch:
+            if isinstance(value, torch.Tensor):
+                assert not value.requires_grad
+                assert value.grad_fn is None
+
     def test_two_model_sum_forces_match_analytical(self, single_system_batch):
         """Forces from E_total = 1*sum(pos^2) + 3*sum(pos^2) = 4*sum(pos^2).
 

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -1677,6 +1677,24 @@ class TestPipelineAutogradCorrectness:
                 assert not value.requires_grad
                 assert value.grad_fn is None
 
+    def test_detach_data_tensors_handles_atomic_data_python_model_dump(self):
+        """AtomicData cleanup should detach tensors returned by model_dump."""
+        source = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
+        data = AtomicData(
+            positions=source * 2.0,
+            atomic_numbers=torch.tensor([6, 6, 8, 1]),
+        )
+        data.extra_tensor = source.sum() * torch.ones(1, dtype=torch.float64)
+
+        assert isinstance(data.model_dump(exclude_none=True)["positions"], torch.Tensor)
+
+        PipelineModelWrapper._detach_data_tensors(data)
+
+        assert not data.positions.requires_grad
+        assert data.positions.grad_fn is None
+        assert not data.extra_tensor.requires_grad
+        assert data.extra_tensor.grad_fn is None
+
     def test_autograd_group_detaches_batch_tensors_after_exception(self):
         """Autograd group cleanup should run even when a step raises."""
 


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Fix compiled MACE stress computation in `PipelineModelWrapper` by computing forces and stresses from a single autograd call when both outputs are requested. Update AIMNet2 to use the same merged helper for force+stress requests, detach pipeline autograd tensors at the boundary, and document the merged utility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #86

## Changes Made

- Add `autograd_forces_and_stresses(...)` to compute force and stress gradients together from one `torch.autograd.grad` call.
- Update `PipelineModelWrapper` and `AIMNet2Wrapper` to use the merged helper for force+stress requests while keeping forces-only and stress-only paths separate.
- Detach tensors at the pipeline autograd boundary so temporary graph-attached tensors do not remain on the input batch after normal returns or exceptions.
- Add unit coverage for merged helper equivalence, single-call behavior, pipeline force+stress correctness, boundary detach cleanup, and AIMNet2 mock forward force+stress behavior.
- Update model user-guide documentation to show the merged force+stress helper.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?


Manual Issue #86 confirmation passed on the original 9900-atom SiO2 MWE with compiled-vs-uncompiled max stress difference `3.129244e-07`.

Benchmark setup:

- System: alpha-quartz SiO2.
- Model: MACE `medium-mpa-0`.
- Runtime: CUDA `float32`.
- GPU: NVIDIA RTX 6000 Ada Generation, driver `570.211.01`.
- Correctness supercell: `(5, 5, 5)`, 1125 atoms.
- Timing supercell: `(10, 10, 11)`, 9900 atoms.

Benchmark timing:

- Legacy two-autograd diagnostic: median `404.6125 ms`.
- Merged-autograd compiled: median `309.6663 ms`.
- Forces-only compiled baseline: median `207.9354 ms`.
- Legacy diagnostic stress cost: `196.6771 ms`.
- Merged-autograd stress cost: `101.7309 ms`.
- Median improvement versus legacy diagnostic: `94.9462 ms`.
- Stress-phase reduction: `48.3%`.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The AIMNet2 mock now defines `atom_feature_keys = ["charges"]` because the mock full-forward force+stress test reaches `_strip_padding`, which iterates calculator atom feature keys.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
