### PR TITLE
fix(dynamics): correct MTK NPT/NPH barostat thermostat coupling and Q_b sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **MTK NPT barostat runaway** (#89, #90) — four bugs in
+  `nvalchemi/dynamics/integrators/npt.py` (with matching fixes in
+  `nph.py`) that combined to drive unbounded cell-volume drift in long
+  NPT runs. Cross-validated against ASE `MTKNPT`/`IsotropicMTKNPT` and
+  TorchSim `npt_nose_hoover_isotropic`. Isotropic users will see their
+  barostat mass `W` shrink by 3× (now matches canonical MTK).
+
 ## 0.1.0 — 2026-04-16
 
 Initial public-beta release of NVIDIA ALCHEMI Toolkit, a GPU-first Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   TorchSim `npt_nose_hoover_isotropic`. Isotropic users will see their
   barostat mass `W` shrink by 3× (now matches canonical MTK).
 
+### Deprecated
+
+- `cells_inv` argument on `_cell_kinetic_energy`. Cell kinetic energy
+  is computed directly from the strain rate `ε̇` and no longer needs
+  the cell inverse. The argument is retained for backwards
+  compatibility (a `DeprecationWarning` is emitted when passed) and
+  will be removed in a future release.
+
 ## 0.1.0 — 2026-04-16
 
 Initial public-beta release of NVIDIA ALCHEMI Toolkit, a GPU-first Python

--- a/nvalchemi/dynamics/integrators/nph.py
+++ b/nvalchemi/dynamics/integrators/nph.py
@@ -139,8 +139,7 @@ class NPH(BaseDynamics):
         kT_est = torch.full((M,), 300.0 * KB_EV, dtype=dtype, device=dev)
         W = torch.zeros(M, dtype=dtype, device=dev)
         compute_barostat_mass(kT_est, barostat_time, num_atoms_per_system, W)
-        if self.pressure_coupling != "isotropic":
-            W = W / 3
+        W = W / 3
         self._state = _make_state_batch(
             {
                 "dt": dt,
@@ -170,8 +169,7 @@ class NPH(BaseDynamics):
         )
         W = torch.zeros(n, dtype=dtype, device=dev)
         compute_barostat_mass(kT_est, barostat_time, num_atoms_per_system, W)
-        if self.pressure_coupling != "isotropic":
-            W = W / 3
+        W = W / 3
         return _make_state_batch(
             {
                 "dt": _to_per_system(self._dt_init, n, dev, dtype),

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -95,7 +95,7 @@ def _cell_kinetic_energy(
     torch.Tensor
         Cell kinetic energy ``[M]``.
     """
-    eps_dot = cell_velocity @ cells_inv
+    eps_dot = cell_velocity
     if pressure_coupling == "triclinic":
         active = eps_dot.reshape(eps_dot.shape[0], -1)
     else:

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -196,8 +196,9 @@ class NPT(BaseDynamics):
         num_atoms_per_system = counts.to(dtype=torch.int32, device=dev)
         W = torch.zeros(M, dtype=dtype, device=dev)
         compute_barostat_mass(kT, tau_p, num_atoms_per_system, W)
-        if self.pressure_coupling != "isotropic":
-            W = W / 3
+        # Kernel emits the full ``(3N+3)·kT·τ_P²``; ``/3`` recovers the canonical
+        # per-DOF MTK barostat mass ``(N+1)·kT·τ_P²``.
+        W = W / 3
         Q = nhc_compute_masses(
             kT, tau_t, batch.atomic_masses, batch.batch_idx.int(), self.chain_length
         )
@@ -208,7 +209,7 @@ class NPT(BaseDynamics):
             M, device=dev, dtype=torch.int32
         ).repeat_interleave(dummy_b_particles)
         Q_b = nhc_compute_masses(
-            kT, tau_t, dummy_b_masses, dummy_b_batch, self.chain_length
+            kT, tau_p, dummy_b_masses, dummy_b_batch, self.chain_length
         )
         self._state = _make_state_batch(
             {
@@ -252,8 +253,7 @@ class NPT(BaseDynamics):
         dummy_batch_idx = torch.zeros(n, dtype=torch.int32, device=dev)
         W = torch.zeros(n, dtype=dtype, device=dev)
         compute_barostat_mass(kT, tau_p, num_atoms_per_system, W)
-        if self.pressure_coupling != "isotropic":
-            W = W / 3
+        W = W / 3
         Q = nhc_compute_masses(
             kT[:1],
             tau_t[:1],
@@ -267,7 +267,7 @@ class NPT(BaseDynamics):
         dummy_b_masses = torch.ones(dummy_b_particles, dtype=dtype, device=dev)
         dummy_b_batch = torch.zeros(dummy_b_particles, dtype=torch.int32, device=dev)
         Q_b_single = nhc_compute_masses(
-            kT[:1], tau_t[:1], dummy_b_masses, dummy_b_batch, self.chain_length
+            kT[:1], tau_p[:1], dummy_b_masses, dummy_b_batch, self.chain_length
         )
         Q_b = Q_b_single.expand(n, -1).contiguous()
         return _make_state_batch(
@@ -362,9 +362,12 @@ class NPT(BaseDynamics):
             cells_inv,
             self.pressure_coupling,
         )
+        # Kernel internally computes ``N_f = 3·input``; pre-divide so the
+        # barostat-thermostat target matches the cell's actual DOF count
+        # (3 for iso/aniso, 9 for triclinic).
         cell_ndof_tensor = torch.full(
             (M,),
-            _cell_dof_count(self.pressure_coupling),
+            _cell_dof_count(self.pressure_coupling) // 3,
             dtype=torch.int32,
             device=batch.device,
         )
@@ -383,6 +386,9 @@ class NPT(BaseDynamics):
 
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
+        # Zero ``eta_dots`` mutes the kernel's ``−eta_dot·h_dot`` drag term;
+        # canonical MTK puts no drag in the barostat half-step (cell damping
+        # comes from the ``b_scale`` step above).
         npt_barostat_half_step(
             self._state.cell_velocity,
             P_inst,
@@ -391,7 +397,7 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            self._state.nhc_eta_dot,
+            torch.zeros_like(self._state.nhc_eta_dot),
             self._state.dt,
         )
         npt_velocity_half_step(
@@ -458,7 +464,7 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            self._state.nhc_eta_dot,
+            torch.zeros_like(self._state.nhc_eta_dot),
             self._state.dt,
         )
 
@@ -470,7 +476,7 @@ class NPT(BaseDynamics):
         )
         cell_ndof_tensor = torch.full(
             (M,),
-            _cell_dof_count(self.pressure_coupling),
+            _cell_dof_count(self.pressure_coupling) // 3,
             dtype=torch.int32,
             device=batch.device,
         )

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -31,12 +31,12 @@ Per-system state: ``dt``, ``temperature``, ``pressure``,
 ``cell_velocity [M,3,3]``, particle NHC state
 ``nhc_eta [M,C]``, ``nhc_eta_dot [M,C]``, ``nhc_Q [M,C]``,
 barostat NHC state ``nhc_b_eta [M,C]``, ``nhc_b_eta_dot [M,C]``,
-``nhc_b_Q [M,C]``, the permanent zero ``eta_dots`` buffer
-``nhc_zero_eta_dot [M,C]``, and pre-allocated scratch tensors.
+``nhc_b_Q [M,C]``, and pre-allocated scratch tensors.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -74,8 +74,8 @@ def _cell_dof_count(pressure_coupling: str) -> int:
 def _cell_kinetic_energy(
     cell_velocity: torch.Tensor,
     W: torch.Tensor,
-    cells_inv: torch.Tensor,
     pressure_coupling: str,
+    cells_inv: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Compute cell kinetic energy ``KE_cell = 0.5 W ||ε̇||²_F``.
 
@@ -85,16 +85,22 @@ def _cell_kinetic_energy(
         Strain-rate tensor ε̇ ``[M, 3, 3]``.
     W : torch.Tensor
         Barostat inertia ``[M]``.
-    cells_inv : torch.Tensor
-        Retained for backward compat; unused.
     pressure_coupling : str
         One of ``"isotropic"``, ``"anisotropic"``, ``"triclinic"``.
+    cells_inv : torch.Tensor, optional
+        Deprecated; ignored.  Emits ``DeprecationWarning`` when passed.
 
     Returns
     -------
     torch.Tensor
         Cell kinetic energy ``[M]``.
     """
+    if cells_inv is not None:
+        warnings.warn(
+            "_cell_kinetic_energy: cells_inv is deprecated and ignored.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     eps_dot = cell_velocity
     if pressure_coupling == "triclinic":
         active = eps_dot.reshape(eps_dot.shape[0], -1)
@@ -232,10 +238,15 @@ class NPT(BaseDynamics):
                     M, self.chain_length, dtype=dtype, device=dev
                 ),
                 "nhc_b_Q": Q_b,
-                # Permanent zero buffer used as ``eta_dots`` argument to
-                # ``npt_barostat_half_step``: canonical MTK has no drag in the
-                # barostat half-step, but the kernel still reads
-                # ``eta_dots[:, 0]``.
+                # Workaround for nvalchemi-toolkit-ops <= 0.3.1: the
+                # ``npt_barostat_half_step`` kernel still applies an inline
+                # ``-eta_dot * h_dot`` drag, but canonical MTK puts no drag
+                # in the barostat half-step (cell damping comes from
+                # ``b_scale`` below).  Pass a permanent zero buffer to
+                # mute the drag.
+                # TODO: drop ``nhc_zero_eta_dot`` and switch to the
+                # eta_dots-free API once nvalchemi-toolkit-ops > 0.3.1
+                # ships (kernel fix in NVIDIA/nvalchemi-toolkit-ops#77).
                 "nhc_zero_eta_dot": torch.zeros(
                     M, self.chain_length, dtype=dtype, device=dev
                 ),
@@ -370,7 +381,6 @@ class NPT(BaseDynamics):
         ke_cell = _cell_kinetic_energy(
             self._state.cell_velocity,
             self._state.W,
-            cells_inv,
             self.pressure_coupling,
         )
         # Kernel internally computes ``N_f = 3·input``; pre-divide so the
@@ -397,9 +407,11 @@ class NPT(BaseDynamics):
 
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
-        # Zero ``eta_dots`` mutes the kernel's ``−eta_dot·h_dot`` drag term;
-        # canonical MTK puts no drag in the barostat half-step (cell damping
+        # Workaround for nvalchemi-toolkit-ops <= 0.3.1: pass zero ``eta_dots``
+        # to mute the kernel's spurious ``−eta_dot·h_dot`` drag (cell damping
         # comes from the ``b_scale`` step above).
+        # TODO: switch to eta_dots-free API once toolkit-ops > 0.3.1 ships
+        # (NVIDIA/nvalchemi-toolkit-ops#77).
         npt_barostat_half_step(
             self._state.cell_velocity,
             P_inst,
@@ -467,6 +479,7 @@ class NPT(BaseDynamics):
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
+        # See pre_update for nhc_zero_eta_dot workaround (toolkit-ops <= 0.3.1).
         npt_barostat_half_step(
             self._state.cell_velocity,
             P_inst,
@@ -482,7 +495,6 @@ class NPT(BaseDynamics):
         ke_cell = _cell_kinetic_energy(
             self._state.cell_velocity,
             self._state.W,
-            cells_inv,
             self.pressure_coupling,
         )
         cell_ndof_tensor = torch.full(

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -31,7 +31,8 @@ Per-system state: ``dt``, ``temperature``, ``pressure``,
 ``cell_velocity [M,3,3]``, particle NHC state
 ``nhc_eta [M,C]``, ``nhc_eta_dot [M,C]``, ``nhc_Q [M,C]``,
 barostat NHC state ``nhc_b_eta [M,C]``, ``nhc_b_eta_dot [M,C]``,
-``nhc_b_Q [M,C]``, and pre-allocated scratch tensors.
+``nhc_b_Q [M,C]``, the permanent zero ``eta_dots`` buffer
+``nhc_zero_eta_dot [M,C]``, and pre-allocated scratch tensors.
 """
 
 from __future__ import annotations
@@ -231,6 +232,13 @@ class NPT(BaseDynamics):
                     M, self.chain_length, dtype=dtype, device=dev
                 ),
                 "nhc_b_Q": Q_b,
+                # Permanent zero buffer used as ``eta_dots`` argument to
+                # ``npt_barostat_half_step``: canonical MTK has no drag in the
+                # barostat half-step, but the kernel still reads
+                # ``eta_dots[:, 0]``.
+                "nhc_zero_eta_dot": torch.zeros(
+                    M, self.chain_length, dtype=dtype, device=dev
+                ),
                 # Pre-allocated scratch tensors; zeroed by kernel each call.
                 "kinetic_tensors": torch.zeros(M, 9, dtype=dtype, device=dev),
                 "pressure_tensors": torch.zeros(M, 9, dtype=dtype, device=dev),
@@ -290,6 +298,9 @@ class NPT(BaseDynamics):
                     n, self.chain_length, dtype=dtype, device=dev
                 ),
                 "nhc_b_Q": Q_b,
+                "nhc_zero_eta_dot": torch.zeros(
+                    n, self.chain_length, dtype=dtype, device=dev
+                ),
                 "kinetic_tensors": torch.zeros(n, 9, dtype=dtype, device=dev),
                 "pressure_tensors": torch.zeros(n, 9, dtype=dtype, device=dev),
                 "volumes": torch.zeros(n, dtype=dtype, device=dev),
@@ -397,7 +408,7 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            torch.zeros_like(self._state.nhc_eta_dot),
+            self._state.nhc_zero_eta_dot,
             self._state.dt,
         )
         npt_velocity_half_step(
@@ -464,7 +475,7 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            torch.zeros_like(self._state.nhc_eta_dot),
+            self._state.nhc_zero_eta_dot,
             self._state.dt,
         )
 

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -77,16 +77,16 @@ def _cell_kinetic_energy(
     cells_inv: torch.Tensor,
     pressure_coupling: str,
 ) -> torch.Tensor:
-    """Compute cell kinetic energy using the strain rate ε̇ = ḣ h⁻¹.
+    """Compute cell kinetic energy ``KE_cell = 0.5 W ||ε̇||²_F``.
 
     Parameters
     ----------
     cell_velocity : torch.Tensor
-        Cell velocity matrix ḣ ``[M, 3, 3]``.
+        Strain-rate tensor ε̇ ``[M, 3, 3]``.
     W : torch.Tensor
         Barostat inertia ``[M]``.
     cells_inv : torch.Tensor
-        Inverse cell matrices h⁻¹ ``[M, 3, 3]``.
+        Retained for backward compat; unused.
     pressure_coupling : str
         One of ``"isotropic"``, ``"anisotropic"``, ``"triclinic"``.
 

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -217,8 +217,12 @@ class TestNPHIntegrator:
             ("triclinic", torch.eye(3).unsqueeze(0)),
         ],
     )
-    def test_W_divided_for_non_isotropic(self, mode, pressure):
-        """Barostat mass W is divided by 3 for non-isotropic modes."""
+    def test_W_normalization_matches_isotropic_across_modes(self, mode, pressure):
+        """Barostat mass W: iso == aniso == triclinic.
+
+        See ``test_npt_nph.TestNPTIntegrator`` for the canonical-MTK
+        derivation of this invariant.
+        """
         nph_iso = NPH(
             model=DemoModelWrapper(DemoModel()),
             dt=0.001,
@@ -226,7 +230,7 @@ class TestNPHIntegrator:
             barostat_time=100.0,
             pressure_coupling="isotropic",
         )
-        nph_aniso = NPH(
+        nph_other = NPH(
             model=DemoModelWrapper(DemoModel()),
             dt=0.001,
             pressure=pressure,
@@ -235,8 +239,8 @@ class TestNPHIntegrator:
         )
         batch = _make_barostat_batch()
         nph_iso._init_state(batch)
-        nph_aniso._init_state(batch)
-        assert torch.allclose(nph_iso._state.W / 3, nph_aniso._state.W, atol=1e-6)
+        nph_other._init_state(batch)
+        assert torch.allclose(nph_other._state.W, nph_iso._state.W, atol=1e-6)
 
     @pytest.mark.parametrize(
         "mode,pressure",
@@ -447,12 +451,17 @@ class TestNPTIntegrator:
     @pytest.mark.parametrize(
         "mode,pressure",
         [
+            # The kernel emits the full ``(3N+3)·kT·τ_P²`` mass regardless of
+            # mode; the toolkit divides by 3 in every mode to recover the
+            # canonical per-DOF MTK barostat mass ``(N+1)·kT·τ_P²`` (matches
+            # ASE ``MTKBarostat`` for triclinic and ``IsotropicMTKBarostat / 3``
+            # for iso/aniso).
             ("anisotropic", torch.tensor([[1.0, 1.0, 1.0]])),
             ("triclinic", torch.eye(3).unsqueeze(0)),
         ],
     )
-    def test_W_divided_for_non_isotropic(self, mode, pressure):
-        """Barostat mass W is divided by 3 for non-isotropic modes."""
+    def test_W_normalization_matches_isotropic_across_modes(self, mode, pressure):
+        """Barostat mass W: iso == aniso == triclinic."""
         npt_iso = NPT(
             model=DemoModelWrapper(DemoModel()),
             dt=0.001,
@@ -462,7 +471,7 @@ class TestNPTIntegrator:
             thermostat_time=100.0,
             pressure_coupling="isotropic",
         )
-        npt_aniso = NPT(
+        npt_other = NPT(
             model=DemoModelWrapper(DemoModel()),
             dt=0.001,
             temperature=300.0,
@@ -473,8 +482,39 @@ class TestNPTIntegrator:
         )
         batch = _make_barostat_batch()
         npt_iso._init_state(batch)
-        npt_aniso._init_state(batch)
-        assert torch.allclose(npt_iso._state.W / 3, npt_aniso._state.W, atol=1e-6)
+        npt_other._init_state(batch)
+        assert torch.allclose(npt_other._state.W, npt_iso._state.W, atol=1e-6)
+
+    def test_Q_b_scales_with_barostat_time_not_thermostat_time(self):
+        """Barostat NHC chain mass ``Q_b`` must be sized with ``τ_P``, not ``τ_T``.
+
+        Per MTK 1996 / ASE ``MTKBarostat`` / TorchSim
+        ``construct_nose_hoover_chain``, ``Q_b ∝ τ_P²``.  Sizing it with
+        ``τ_T`` (default 100 fs vs ``τ_P`` 2 000 fs) makes ``Q_b`` ~400× too
+        small and over-damps the cell's deterministic motion — one of the
+        four bugs behind the cell-volume runaway in long NPT runs.
+        """
+        common = dict(
+            model=DemoModelWrapper(DemoModel()),
+            dt=0.001,
+            temperature=300.0,
+            pressure=1.0,
+            thermostat_time=200.0,
+            pressure_coupling="isotropic",
+        )
+        npt_short = NPT(barostat_time=100.0, **common)
+        npt_long = NPT(barostat_time=400.0, **common)
+        batch = _make_barostat_batch()
+        npt_short._init_state(batch)
+        npt_long._init_state(batch)
+        # Particle chain depends on τ_T (same for both) → identical.
+        assert torch.allclose(npt_short._state.nhc_Q, npt_long._state.nhc_Q, atol=1e-6)
+        # Barostat chain depends on τ_P²; 4× ratio → 16× scaling.
+        assert torch.allclose(
+            npt_long._state.nhc_b_Q,
+            npt_short._state.nhc_b_Q * 16.0,
+            atol=1e-6,
+        )
 
     @pytest.mark.parametrize(
         "mode,pressure",


### PR DESCRIPTION
## Description

Fixes four bugs in the toolkit's MTK NPT integrator (`nvalchemi/dynamics/integrators/npt.py`) that combine to drive unbounded cell-volume drift in long NPT runs (#89). The `W` normalization is also fixed in `nvalchemi/dynamics/integrators/nph.py`. All four are cross-validated against `ase.md.nose_hoover_chain` (`IsotropicMTKNPT`, `MTKNPT`) and `torch_sim.integrators.npt.npt_nose_hoover_isotropic`.

| bug | location | fix |
|---|---|---|
| Barostat mass `W` was only divided by 3 in non-isotropic modes; iso kept the full kernel-emitted `(3N+3)·kT·τ_P²` (3× too large vs canonical) | `npt.py:205, 268`, `nph.py:146, 180` | drop the conditional and always divide `W` by 3 |
| Barostat-thermostat NHC kernel triples its DOF input, so caller passes pre-divided `cell_ndof / 3` | `npt.py:387, 502` | divide `_cell_dof_count(...)` by 3 before the NHC call |
| Cell-velocity update applies a spurious particle-thermostat drag inside the barostat half-step | `npt.py:421, 489` | pass `torch.zeros_like(...)` for the `eta_dots` argument |
| `Q_b` (barostat NHC mass) was sized with `τ_T` (particle-thermostat time) instead of `τ_P` (barostat time) | `npt.py:222` | pass `tau_p` to `nhc_compute_masses` |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #89.

NVIDIA/nvalchemi-toolkit-ops#77 lands the kernel-side fix that lets the `nhc_zero_eta_dot` workaround be removed; once that ships, a small follow-up PR will drop the buffer here.

## Changes Made

- `nvalchemi/dynamics/integrators/npt.py` — four edits matching the table above.
- `nvalchemi/dynamics/integrators/nph.py` — applies the same `W / 3` normalization in `_init_state` and `_make_new_state`.
- `_cell_kinetic_energy` — deprecate `cells_inv` (kept for backward compat, emits `DeprecationWarning`); helper reads `cell_velocity` directly as the strain rate.
- `test/dynamics/test_npt_nph.py` — replaces `test_W_divided_for_non_isotropic` with `test_W_normalization_matches_isotropic_across_modes` (asserts `iso == aniso == triclinic`); adds `test_Q_b_scales_with_barostat_time_not_thermostat_time`.
- `CHANGELOG.md` — `Fixed` and `Deprecated` entries.

## Testing

- [x] Unit tests pass locally (`make pytest`) — 38/38.
- [x] Linting passes (`make lint`).
- [x] Regression tests added: `test_W_normalization_matches_isotropic_across_modes` and `test_Q_b_scales_with_barostat_time_not_thermostat_time` fail against `origin/main` and pass on this branch.

### Empirical validation

NPT comparison on a 100-molecule n-octane box (~2600 atoms, Packmol seed = 42, initial ρ ≈ 0.703 g/cm³, Orb-v3-conservative-inf-omat + DFT-D3(BJ), T = 298 K, P = 1 atm, dt = 0.5 fs, τ_T = 100 fs, τ_P = 5000 fs, NHC chain length 3). Toolkit runs use `pressure_coupling="anisotropic"` with `pressure=[[P, P, P]]`; ASE uses `MTKNPT` (full triclinic, 9-DOF — same `target/Q` ratio as toolkit aniso, giving identical NHC barostat oscillation frequency).

<img width="2880" height="1440" alt="density_comparison_3way_post_codex_fix" src="https://github.com/user-attachments/assets/c6e322f7-b7d7-4b65-8359-fcc2751b062d" />

NIST experimental density at 298 K, 1 atm: 0.703 g/cm³.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes (inline comments at each fixed call site explain the underlying bug + canonical reference)
- [ ] I have updated the documentation (if applicable)
