### PR TITLE
Refactor hook contexts

### DIFF
--- a/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nvalchemi-dynamics-hooks
-description: How to use and write dynamics hooks — callbacks that observe or modify batch state at specific points during each simulation step.
+description: How to use and write dynamics hooks — callbacks that observe or
+  modify batch state at specific points during each simulation step.
 ---
 
 # nvalchemi Hooks
@@ -10,11 +11,13 @@ description: How to use and write dynamics hooks — callbacks that observe or m
 Hooks are callbacks that fire at specific points during each workflow step.
 They observe or modify batch state without changing the engine itself.
 The hook system is framework-wide: the same `Hook` protocol works for
-dynamics and custom pipelines — only the stage enum changes.
+dynamics and custom pipelines. Dynamics engines pass `DynamicsContext`;
+custom engines can pass `HookContext` or their own context subclass.
 
 ```python
 from nvalchemi.hooks import (
     BiasedPotentialHook,
+    DynamicsContext,
     Hook,
     HookContext,
     HookRegistryMixin,
@@ -48,22 +51,30 @@ class Hook(Protocol):
         ...
 ```
 
-A hook fires when `step_count % hook.frequency == 0` (so all hooks fire at step 0).
+A hook fires when `step_count % hook.frequency == 0` (so all hooks fire at
+step 0).
 
-**HookContext** — unified snapshot of workflow state:
+**HookContext** — base snapshot shared by hook-enabled workflows:
 
 ```python
-@dataclass
+@dataclass(kw_only=True)
 class HookContext:
     batch: Batch              # current batch (all engines)
-    step_count: int           # current step number
     model: BaseModelMixin | None = None
-    converged_mask: Tensor | None = None      # dynamics only
-    global_rank: int = 0                      # distributed rank
-    workflow: Any = None                      # back-reference to the engine
+    global_rank: int = 0      # distributed rank
+    workflow: Any = None      # back-reference to the engine
 ```
 
-Access batch data via `ctx.batch`, step info via `ctx.step_count`, etc.
+**DynamicsContext** — context passed by dynamics engines:
+
+```python
+@dataclass(kw_only=True)
+class DynamicsContext(HookContext):
+    step_count: int = 0
+    converged_mask: torch.Tensor | None = None
+```
+
+Access batch data via `ctx.batch` and dynamics step info via `ctx.step_count`.
 
 ---
 
@@ -141,7 +152,6 @@ NaNDetectorHook(
 MaxForceClampHook(
     max_force=10.0,     # max force norm (eV/A)
     frequency=1,
-    log_clamps=False,   # log a warning when clamping occurs
 )
 ```
 
@@ -170,13 +180,13 @@ BiasedPotentialHook(
 
 ```python
 LoggingHook(
+    backend="csv",                  # "csv", "tensorboard", or "custom"
     frequency=100,
-    backend="loguru",              # "loguru", "csv", "tensorboard", "custom"
-    log_path="md_log.csv",         # for file-based backends
-    custom_scalars={               # additional scalars to log
-        "max_velocity": lambda ctx, stage: ctx.batch.velocities.norm(dim=-1).max().item(),
+    log_path="md_log.csv",          # for file-based backends
+    custom_scalars={                # additional scalars to log
+        "max_velocity": lambda ctx: ctx.batch.velocities.norm(dim=-1).max(),
     },
-    writer_fn=None,                # custom writer for "custom" backend
+    writer_fn=None,                 # custom writer for "custom" backend
 )
 ```
 
@@ -219,10 +229,10 @@ dynamics and custom workflows with appropriate domain annotations.
 
 ```python
 ProfilerHook(
+    profiled_stages="all",                  # "all", "step", or "detailed"
     frequency=1,
-    enable_nvtx=True,                        # NVTX annotation for Nsight Systems
-    enable_timer=True,                       # wall-clock step timing
-    timer_backend="cuda_event",              # or "perf_counter"
+    enable_nvtx=True,                       # NVTX annotation for Nsight Systems
+    timer_backend="auto",                   # "auto", "cuda_event", or "perf_counter"
 )
 ```
 
@@ -236,13 +246,13 @@ Implement the protocol directly — no inheritance needed.
 
 ```python
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 class TemperatureLogger:
     stage = DynamicsStage.AFTER_STEP
     frequency = 50
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         ke = ctx.batch.kinetic_energies.sum()
         n_atoms = ctx.batch.num_nodes
         temp = 2.0 * ke / (3.0 * n_atoms * 8.617e-5)  # kB in eV/K
@@ -256,7 +266,7 @@ Fire at multiple stages by defining `_runs_on_stage(stage) -> bool`:
 ```python
 from enum import Enum
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 class StepTimerHook:
     stage = DynamicsStage.BEFORE_STEP  # primary stage (protocol compliance)
@@ -269,7 +279,7 @@ class StepTimerHook:
     def _runs_on_stage(self, stage: Enum) -> bool:
         return stage in self._stages
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         import time
         if stage == DynamicsStage.BEFORE_STEP:
             self._t0 = time.perf_counter()
@@ -285,15 +295,22 @@ a custom enum), use `plum.dispatch` to overload `__call__` with different
 stage types:
 
 ```python
+from dataclasses import dataclass
 from enum import Enum
 from plum import dispatch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext, HookContext
 
 # Example custom stage enum for a hypothetical pipeline
 class MyPipelineStage(Enum):
     BEFORE_PROCESS = 0
     AFTER_PROCESS = 1
+
+
+@dataclass(kw_only=True)
+class PipelineContext(HookContext):
+    step_count: int = 0
+
 
 class UniversalLoggerHook:
     stage = DynamicsStage.AFTER_STEP
@@ -306,17 +323,17 @@ class UniversalLoggerHook:
         return stage in self._stages
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         fmax = ctx.batch.forces.norm(dim=-1).max().item()
         print(f"[dynamics] step {ctx.step_count}: fmax={fmax:.4f}")
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: MyPipelineStage) -> None:
+    def __call__(self, ctx: PipelineContext, stage: MyPipelineStage) -> None:
         print(f"[pipeline] step {ctx.step_count}: processed")
 
     @dispatch
     def __call__(self, ctx: HookContext, stage: Enum) -> None:
-        print(f"[custom] step {ctx.step_count}: stage={stage.name}")
+        print(f"[custom] stage={stage.name}, graphs={ctx.batch.num_graphs}")
 ```
 
 The built-in `ProfilerHook` uses exactly this pattern to instrument
@@ -356,10 +373,10 @@ dynamics = DemoDynamics(model=model, n_steps=10000, dt=0.5, hooks=hooks)
 ```python
 import torch
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.models.demo import DemoModelWrapper
+from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 from nvalchemi.dynamics.demo import DemoDynamics
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.dynamics.hooks import MaxForceClampHook, NaNDetectorHook
 
 # Custom hook
@@ -367,12 +384,12 @@ class StepPrinter:
     stage = DynamicsStage.AFTER_STEP
     frequency = 10
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         fmax = ctx.batch.forces.norm(dim=-1).max().item()
         print(f"Step {ctx.step_count}: fmax={fmax:.4f}")
 
 # Setup
-model = DemoModelWrapper()
+model = DemoModelWrapper(DemoModel())
 dynamics = DemoDynamics(
     model=model,
     n_steps=100,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@
 ### Breaking Changes
 
 - Split hook context state into `HookContext`, `DynamicsContext`, and
-  `TrainContext` so workflow-specific fields live on the context type that
-  actually provides them.
+  `TrainContext` so each workflow exposes only the fields it owns.
+  Dynamics-specific state such as `step_count`, `converged_mask`, and
+  `global_rank` now lives on `DynamicsContext`, while training state lives on
+  `TrainContext`. Existing hooks that used `HookContext` for dynamics-only
+  fields should update their annotations to `DynamicsContext`.
 - Standardized public `stress` outputs on tensile-positive Cauchy stress
   (`sigma = -W / V`) while keeping low-level virials defined as negative
   strain derivatives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Breaking Changes
 
+- Split hook context state into `HookContext`, `DynamicsContext`, and
+  `TrainContext` so workflow-specific fields live on the context type that
+  actually provides them.
 - Standardized public `stress` outputs on tensile-positive Cauchy stress
   (`sigma = -W / V`) while keeping low-level virials defined as negative
   strain derivatives.

--- a/docs/modules/dynamics/hooks.rst
+++ b/docs/modules/dynamics/hooks.rst
@@ -16,7 +16,7 @@ For the general hook protocol, context, and registry see
    - **User guide**: :ref:`hooks_guide` — conceptual overview, writing
      custom hooks, and composing hook pipelines.
    - **Core framework**: :ref:`hooks-api` — the ``Hook`` protocol,
-     ``HookContext``, and ``HookRegistryMixin``.
+     ``HookContext``/``DynamicsContext``, and ``HookRegistryMixin``.
 
 
 DynamicsStage

--- a/docs/modules/hooks.rst
+++ b/docs/modules/hooks.rst
@@ -9,7 +9,7 @@ Hooks — Core Framework
 
 The :mod:`nvalchemi.hooks` package provides the general-purpose hook
 system used across all nvalchemi workflows (dynamics, training, custom
-pipelines). It defines the protocol, context, registry, and a set of
+pipelines). It defines the protocol, context dataclasses, registry, and a set of
 hooks that are useful regardless of the specific engine type.
 
 .. seealso::
@@ -40,7 +40,7 @@ with no subclassing required:
        frequency: int = 1
 
        def __call__(self, ctx: HookContext, stage: Enum) -> None:
-           print(f"Step {ctx.step_count}: energy = {ctx.batch.energy.mean():.4f}")
+           print(f"graphs={ctx.batch.num_graphs}, stage={stage.name}")
 
 Because ``Hook`` is a ``runtime_checkable`` ``Protocol``, you can also
 use it as a type hint and check membership with ``isinstance``:
@@ -56,13 +56,13 @@ use it as a type hint and check membership with ``isinstance``:
    ``frequency``, ``stage``, and ``__call__`` works as a hook.
 
 
-HookContext
------------
+Context dataclasses
+-------------------
 
-Every hook receives a :class:`~nvalchemi.hooks.HookContext`, a dataclass
-that bundles the current workflow state into a single object. Each engine
-overrides ``_build_context(batch)`` to populate the fields relevant to
-its workflow.
+Every hook receives a :class:`~nvalchemi.hooks.HookContext` or a
+workflow-specific subclass. The base dataclass contains only fields shared by
+all hook-enabled engines; specialized contexts add fields that are meaningful
+only for one workflow category.
 
 .. list-table:: HookContext fields
    :widths: 20 25 55
@@ -74,36 +74,61 @@ its workflow.
    * - ``batch``
      - ``Batch``
      - Current batch being processed (all engines).
-   * - ``step_count``
-     - ``int``
-     - Current step number.
    * - ``model``
      - ``BaseModelMixin | None``
      - Model being used (if applicable).
-   * - ``converged_mask``
-     - ``torch.Tensor | None``
-     - Boolean mask of converged samples (dynamics only).
-   * - ``loss``
-     - ``torch.Tensor | None``
-     - Current loss value (training only).
-   * - ``optimizer``
-     - ``torch.optim.Optimizer | None``
-     - Optimizer being used (training only).
-   * - ``lr_scheduler``
-     - ``object | None``
-     - Learning rate scheduler (training only).
-   * - ``gradients``
-     - ``dict[str, torch.Tensor] | None``
-     - Parameter gradients (training only).
-   * - ``epoch``
-     - ``int | None``
-     - Current epoch number (training only).
    * - ``global_rank``
      - ``int``
      - Distributed rank of this process.
    * - ``workflow``
      - ``Any``
      - Back-reference to the engine running the hooks.
+
+.. list-table:: DynamicsContext fields
+   :widths: 20 25 55
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+   * - ``step_count``
+     - ``int``
+     - Current dynamics step.
+   * - ``converged_mask``
+     - ``torch.Tensor | None``
+     - Boolean mask of samples that converged at the current hook stage.
+
+.. list-table:: TrainContext fields
+   :widths: 20 25 55
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+   * - ``step_count``
+     - ``int``
+     - Current optimizer step.
+   * - ``epoch``
+     - ``int``
+     - Current training epoch.
+   * - ``loss``
+     - ``torch.Tensor | None``
+     - Aggregate loss for the current step.
+   * - ``losses``
+     - ``dict[str, torch.Tensor] | None``
+     - Named loss components.
+   * - ``models``
+     - ``dict[str, BaseModelMixin] | ModuleDict[str, BaseModelMixin] | None``
+     - Models participating in the training step.
+   * - ``optimizers``
+     - ``list[torch.optim.Optimizer] | None``
+     - Optimizers participating in the training step.
+   * - ``lr_schedulers``
+     - ``list[object] | None``
+     - Learning-rate schedulers.
+   * - ``gradients``
+     - ``dict[str, torch.Tensor] | None``
+     - Parameter gradients.
 
 
 Registration and dispatch
@@ -128,8 +153,7 @@ The dispatch logic for each hook is:
 
 1. If the hook defines ``_runs_on_stage(stage) -> bool``, call it.
 2. Otherwise, check ``stage == hook.stage``.
-3. If matched, call ``hook(ctx, stage)`` with a fresh
-   :class:`~nvalchemi.hooks.HookContext`.
+3. If matched, call ``hook(ctx, stage)`` with a fresh context object.
 
 .. note::
 
@@ -195,6 +219,8 @@ Protocol
 
    Hook
    HookContext
+   DynamicsContext
+   TrainContext
    HookRegistryMixin
 
 General-purpose hooks

--- a/docs/userguide/hooks.md
+++ b/docs/userguide/hooks.md
@@ -27,21 +27,21 @@ A hook is any object that satisfies the
 |--------------------|------|---------|
 | `stage` | `Enum` | Which stage of the execution loop this hook fires at (e.g. `DynamicsStage`) |
 | `frequency` | `int` | Execute every *n* steps (1 = every step) |
-| `__call__(ctx, stage)` | `None` | The hook's logic, called with a {py:class}`~nvalchemi.hooks.HookContext` and the current stage |
+| `__call__(ctx, stage)` | `None` | The hook's logic, called with a {py:class}`~nvalchemi.hooks.HookContext` or workflow-specific subclass and the current stage |
 
 The `Hook` protocol lives in {py:mod}`nvalchemi.hooks` and is
 stage-enum agnostic --- the same protocol works for dynamics, training,
 or any custom workflow.
 
 ```python
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.dynamics.base import DynamicsStage
 
 class MyHook:
     stage = DynamicsStage.AFTER_STEP
     frequency = 1
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         print(f"Step {ctx.step_count}: energy = {ctx.batch.energy.mean():.4f}")
 
 assert isinstance(MyHook(), Hook)  # True --- structural subtyping
@@ -76,28 +76,43 @@ custom class contains the same attributes and methods---as long as it
 quacks like a duck.
 ```
 
-## HookContext
+## Context Objects
 
-Every hook receives a {py:class}`~nvalchemi.hooks.HookContext` object that
-provides a unified snapshot of the current workflow state:
+Every hook receives a {py:class}`~nvalchemi.hooks.HookContext` object, or a
+workflow-specific subclass, that provides a snapshot of the current workflow
+state. The base context contains only fields that are meaningful to all
+hook-enabled workflows:
 
 | Field | Type | Populated by |
 |-------|------|-------------|
 | `batch` | `Batch` | All engines |
-| `step_count` | `int` | All engines |
 | `model` | `BaseModelMixin \| None` | All engines |
-| `converged_mask` | `torch.Tensor \| None` | Dynamics only |
-| `loss` | `torch.Tensor \| None` | Training only |
-| `optimizer` | `torch.optim.Optimizer \| None` | Training only |
-| `lr_scheduler` | `object \| None` | Training only |
-| `gradients` | `dict[str, torch.Tensor] \| None` | Training only |
-| `epoch` | `int \| None` | Training only |
 | `global_rank` | `int` | All engines (distributed) |
 | `workflow` | `Any` | Back-reference to the engine |
 
+Dynamics engines pass {py:class}`~nvalchemi.hooks.DynamicsContext`, which adds:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `step_count` | `int` | Current dynamics step |
+| `converged_mask` | `torch.Tensor \| None` | Samples that converged at the current hook stage |
+
+Training loops pass {py:class}`~nvalchemi.hooks.TrainContext`, which adds:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `step_count` | `int` | Current optimizer step |
+| `epoch` | `int` | Current epoch |
+| `loss` | `torch.Tensor \| None` | Aggregate loss |
+| `losses` | `dict[str, torch.Tensor] \| None` | Named loss components |
+| `models` | `dict[str, BaseModelMixin] \| ModuleDict[str, BaseModelMixin] \| None` | Models in the training step |
+| `optimizers` | `list[torch.optim.Optimizer] \| None` | Optimizers in the training step |
+| `lr_schedulers` | `list[object] \| None` | Learning-rate schedulers |
+| `gradients` | `dict[str, torch.Tensor] \| None` | Parameter gradients |
+
 The engine builds this context object at each stage via an overridable
-`_build_context(batch)` method, so each engine type populates the fields
-relevant to its workflow.
+`_build_context(batch)` method. Custom engines should return their own
+`HookContext` subclass when hooks need workflow-specific fields.
 
 ### Optional context manager support
 
@@ -249,18 +264,18 @@ hook = ConvergedSnapshotHook(sink=ZarrData("/path/to/relaxed.zarr"))
 ### Simple dynamics hook
 
 To write your own hook, create a class that implements the three required members
-(`stage`, `frequency`, `__call__`). The `__call__` method receives a
-{py:class}`~nvalchemi.hooks.HookContext` and the current stage:
+(`stage`, `frequency`, `__call__`). Dynamics hooks receive a
+{py:class}`~nvalchemi.hooks.DynamicsContext` and the current stage:
 
 ```python
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 class PrintFmaxHook:
     stage = DynamicsStage.AFTER_STEP
     frequency = 1
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         fmax = ctx.batch.forces.norm(dim=-1).max().item()
         print(f"Step {ctx.step_count}: fmax = {fmax:.4f} eV/A")
 ```
@@ -273,7 +288,7 @@ The registry calls this instead of comparing `stage == hook.stage`:
 ```python
 from enum import Enum
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 class StepTimerHook:
     stage = DynamicsStage.BEFORE_STEP  # primary stage (for protocol compliance)
@@ -286,7 +301,7 @@ class StepTimerHook:
     def _runs_on_stage(self, stage: Enum) -> bool:
         return stage in self._stages
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         import time
         if stage == DynamicsStage.BEFORE_STEP:
             self._t0 = time.perf_counter()
@@ -303,14 +318,19 @@ types. This lets you customize behavior per category:
 
 ```python
 from enum import Enum
+from dataclasses import dataclass
 from plum import dispatch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext, HookContext
 
 # Example custom stage enum for a hypothetical pipeline
 class MyPipelineStage(Enum):
     BEFORE_PROCESS = 0
     AFTER_PROCESS = 1
+
+@dataclass(kw_only=True)
+class PipelineContext(HookContext):
+    step_count: int = 0
 
 class UniversalLoggerHook:
     stage = DynamicsStage.AFTER_STEP  # primary stage
@@ -323,17 +343,17 @@ class UniversalLoggerHook:
         return stage in self._stages
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         fmax = ctx.batch.forces.norm(dim=-1).max().item()
         print(f"[dynamics] step {ctx.step_count}: fmax={fmax:.4f}")
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: MyPipelineStage) -> None:
+    def __call__(self, ctx: PipelineContext, stage: MyPipelineStage) -> None:
         print(f"[pipeline] step {ctx.step_count}: processed")
 
     @dispatch
     def __call__(self, ctx: HookContext, stage: Enum) -> None:
-        print(f"[custom] step {ctx.step_count}: stage={stage.name}")
+        print(f"[custom] stage={stage.name}, graphs={ctx.batch.num_graphs}")
 ```
 
 The built-in {py:class}`~nvalchemi.dynamics.hooks.ProfilerHook` uses this
@@ -347,7 +367,7 @@ If your hook needs setup or teardown (e.g. opening a file), add `__enter__` and
 
 ```python
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 class FileWriterHook:
     stage = DynamicsStage.AFTER_STEP
@@ -361,7 +381,7 @@ class FileWriterHook:
         self._file = open(self.path, "w")
         return self
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         energy = ctx.batch.energy.mean().item()
         self._file.write(f"{ctx.step_count},{energy}\n")
 

--- a/examples/advanced/01_biased_potential.py
+++ b/examples/advanced/01_biased_potential.py
@@ -55,7 +55,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import BiasedPotentialHook, HookContext
+from nvalchemi.hooks import BiasedPotentialHook, DynamicsContext
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -239,7 +239,7 @@ class _COMRecorder:
     def __init__(self, storage: list) -> None:
         self.storage = storage
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         # Accumulate on GPU; defer .cpu() to post-run analysis to avoid
         # a GPU sync every frequency steps.
         self.storage.append(ctx.batch.positions.mean(dim=0).detach())

--- a/examples/advanced/02_custom_hook.py
+++ b/examples/advanced/02_custom_hook.py
@@ -22,7 +22,7 @@ primary extension point.  Any object that has ``stage``, ``frequency``, and
 required.  This duck-typing approach makes hooks easy to write and easy to
 test in isolation.
 
-The hook receives a :class:`~nvalchemi.hooks.HookContext` containing the
+The hook receives a :class:`~nvalchemi.hooks.DynamicsContext` containing the
 current workflow state (batch, step count, model, etc.) and the stage enum
 value that triggered the call.  The same protocol works for dynamics
 and custom workflows — only the stage enum changes.
@@ -58,7 +58,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -77,7 +77,7 @@ logging.basicConfig(level=logging.INFO)
 #     Fire every *N* steps.  ``frequency=1`` fires every step;
 #     ``frequency=10`` fires on steps 0, 10, 20, … (step_count % frequency == 0).
 #
-# ``__call__(ctx: HookContext, stage: Enum) -> None``
+# ``__call__(ctx: DynamicsContext, stage: Enum) -> None``
 #     The hook body.  ``ctx.batch`` gives you the current batch;
 #     ``ctx.step_count`` gives you the step number.  Modify the batch
 #     in-place (post-compute hooks) or read it for observation.
@@ -93,7 +93,7 @@ class _MinimalHook:
     stage = DynamicsStage.AFTER_STEP
     frequency = 1  # fire every step
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         pass  # read ctx.batch or ctx.step_count here
 
 
@@ -161,7 +161,7 @@ class RadialDistributionHook:
         self.n_samples: int = 0
         self._n_atoms: int = 0  # set from first batch
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         """Accumulate pair distances into the histogram."""
         batch = ctx.batch
         # Process each graph (system) in the batch independently.

--- a/examples/advanced/03_custom_convergence.py
+++ b/examples/advanced/03_custom_convergence.py
@@ -45,7 +45,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import FIRE
 from nvalchemi.dynamics.base import ConvergenceHook, DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -238,7 +238,7 @@ class _LogHook:
     stage = DynamicsStage.AFTER_STEP
     frequency = 50
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         batch = ctx.batch
         step = ctx.step_count + 1
         energy = batch.energy.squeeze(-1)

--- a/examples/advanced/05_custom_integrator.py
+++ b/examples/advanced/05_custom_integrator.py
@@ -65,7 +65,7 @@ from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 # KB_EV and kinetic_energy_per_graph are internal helpers used by the built-in
 # integrators.  A stable public re-export may be added in a future release.
 from nvalchemi.dynamics.hooks._utils import KB_EV, kinetic_energy_per_graph
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.lj import LennardJonesModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -258,7 +258,7 @@ class _TempLogger:
         self.storage = storage
         self.frequency = frequency
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         batch = ctx.batch
         ke = kinetic_energy_per_graph(
             batch.velocities, batch.atomic_masses, batch.batch_idx, batch.num_graphs

--- a/examples/advanced/06_ewald_electrostatics.py
+++ b/examples/advanced/06_ewald_electrostatics.py
@@ -65,8 +65,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import NeighborListHook
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks import DynamicsContext, NeighborListHook
 from nvalchemi.models.ewald import EwaldModelWrapper
 
 # %%
@@ -185,8 +184,8 @@ print(
 nl_hook = NeighborListHook(
     model.model_config.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE
 )
-# Create a minimal HookContext for one-time neighbor list build
-ctx = HookContext(
+# Create a minimal DynamicsContext for one-time neighbor list build
+ctx = DynamicsContext(
     batch=batch,
     step_count=0,
     model=model,
@@ -264,8 +263,8 @@ data_pert = AtomicData(
     pbc=torch.tensor([[True, True, True]]),
 )
 batch_pert = Batch.from_data_list([data_pert])
-# Create HookContext for perturbed batch
-ctx_pert = HookContext(
+# Create DynamicsContext for perturbed batch
+ctx_pert = DynamicsContext(
     batch=batch_pert,
     step_count=0,
     model=model,

--- a/examples/distributed/01_distributed_pipeline.py
+++ b/examples/distributed/01_distributed_pipeline.py
@@ -76,7 +76,7 @@ from nvalchemi.dynamics import (
 )
 from nvalchemi.dynamics.base import BufferConfig, DynamicsStage
 from nvalchemi.dynamics.hooks import ConvergedSnapshotHook
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -129,9 +129,7 @@ class DownstreamDoneHook:
     graphs to integrate) and marks the stage as finished once the
     patience limit is reached.
 
-    Because :class:`~nvalchemi.hooks.HookContext` does not carry a
-    reference to the dynamics engine, the ``dynamics`` attribute must
-    be set after the engine is constructed (see ``make_langevin``).
+    The dispatching dynamics engine is available as ``ctx.workflow``.
     """
 
     stage = DynamicsStage.AFTER_STEP
@@ -140,15 +138,14 @@ class DownstreamDoneHook:
     def __init__(self, patience: int = 5) -> None:
         self.patience = patience
         self._idle_steps = 0
-        self.dynamics: object | None = None
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         if ctx.batch.num_graphs == 0:
             self._idle_steps += 1
         else:
             self._idle_steps = 0
-        if self._idle_steps >= self.patience and self.dynamics is not None:
-            self.dynamics.done = True
+        if self._idle_steps >= self.patience and ctx.workflow is not None:
+            ctx.workflow.done = True
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +261,6 @@ def make_langevin(
         ),
         **kwargs,
     )
-    done_hook.dynamics = stage
     return stage
 
 

--- a/examples/distributed/02_distributed_monitoring.py
+++ b/examples/distributed/02_distributed_monitoring.py
@@ -59,7 +59,7 @@ from nvalchemi.dynamics import (
 )
 from nvalchemi.dynamics.base import BufferConfig, DynamicsStage
 from nvalchemi.dynamics.hooks import ConvergedSnapshotHook, LoggingHook, ProfilerHook
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -107,9 +107,7 @@ class InMemoryDataset:
 class DownstreamDoneHook:
     """Set ``stage.done = True`` after *patience* consecutive idle steps.
 
-    Because :class:`~nvalchemi.hooks.HookContext` does not carry a
-    reference to the dynamics engine, the ``dynamics`` attribute must
-    be set after the engine is constructed (see ``make_langevin``).
+    The dispatching dynamics engine is available as ``ctx.workflow``.
     """
 
     stage = DynamicsStage.AFTER_STEP
@@ -118,15 +116,14 @@ class DownstreamDoneHook:
     def __init__(self, patience: int = 5) -> None:
         self.patience = patience
         self._idle_steps = 0
-        self.dynamics: object | None = None
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         if ctx.batch.num_graphs == 0:
             self._idle_steps += 1
         else:
             self._idle_steps = 0
-        if self._idle_steps >= self.patience and self.dynamics is not None:
-            self.dynamics.done = True
+        if self._idle_steps >= self.patience and ctx.workflow is not None:
+            ctx.workflow.done = True
 
 
 def build_dataset() -> list[AtomicData]:
@@ -240,7 +237,6 @@ def make_langevin(
         ),
         **kwargs,
     )
-    done_hook.dynamics = stage
     return stage
 
 

--- a/examples/intermediate/01_multistage_pipeline.py
+++ b/examples/intermediate/01_multistage_pipeline.py
@@ -51,7 +51,7 @@ from nvalchemi.dynamics import FIRE, NVE, NVTLangevin, SizeAwareSampler
 from nvalchemi.dynamics.base import ConvergenceHook, DynamicsStage, FusedStage
 from nvalchemi.dynamics.hooks import LoggingHook
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -131,7 +131,7 @@ class StageTransitionLogger:
         self._t0 = time.monotonic()
         self._n_transitions = 0
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         self._n_transitions += 1
         if self._n_transitions % self.frequency != 0:
             return
@@ -365,7 +365,7 @@ class StatusSnapshotHook:
         self._print_count = 0
         self._max_steps = max_steps
 
-    def __call__(self, ctx: HookContext, stage_: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
         if self._print_count >= self._max_steps:
             return
         if ctx.step_count % self.frequency != 0:

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -68,7 +68,7 @@ from torch import distributed as dist
 
 from nvalchemi._typing import AtomsLike, ModelOutputs
 from nvalchemi.data import Batch
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 from nvalchemi.hooks._protocol import Hook
 from nvalchemi.hooks._registry import HookRegistryMixin
 from nvalchemi.models.base import BaseModelMixin
@@ -1437,8 +1437,8 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         self.current_hook_stage = stage
         super()._call_hooks(stage, batch)
 
-    def _build_context(self, batch: Batch) -> HookContext:
-        """Build a dynamics-specific HookContext."""
+    def _build_context(self, batch: Batch) -> DynamicsContext:
+        """Build a dynamics-specific hook context."""
         if self._last_converged is not None:
             _mask = torch.zeros(
                 batch.num_graphs, dtype=torch.bool, device=batch.positions.device
@@ -1446,7 +1446,7 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
             _mask[self._last_converged] = True
         else:
             _mask = None
-        return HookContext(
+        return DynamicsContext(
             batch=batch,
             step_count=self.step_count,
             model=self.model,
@@ -2436,7 +2436,7 @@ class ConvergenceHook:
             return None
         return torch.where(converged_mask)[0]
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Evaluate convergence and optionally migrate sample status.
 
         When ``source_status`` and ``target_status`` are both set,
@@ -2448,7 +2448,7 @@ class ConvergenceHook:
 
         Parameters
         ----------
-        ctx : HookContext
+        ctx : DynamicsContext
             The hook context containing the current batch.
         stage : Enum
             The stage being dispatched.

--- a/nvalchemi/dynamics/hooks/__init__.py
+++ b/nvalchemi/dynamics/hooks/__init__.py
@@ -42,7 +42,7 @@ Hooks are organized into the following modules:
      - Performance profiling and step timing.
 
 All hooks implement the :class:`~nvalchemi.hooks.Hook` protocol and accept
-a :class:`~nvalchemi.hooks.HookContext` plus a stage enum in their
+a :class:`~nvalchemi.hooks.DynamicsContext` plus a stage enum in their
 ``__call__`` method.
 """
 

--- a/nvalchemi/dynamics/hooks/cell_align.py
+++ b/nvalchemi/dynamics/hooks/cell_align.py
@@ -29,7 +29,7 @@ import torch
 
 from nvalchemi.dynamics._ops.cell_align import align_cell
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 __all__ = ["AlignCellHook"]
 
@@ -74,7 +74,7 @@ class AlignCellHook:
         self.stage = DynamicsStage.BEFORE_STEP
         self.frequency = frequency
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Align the current batch when any periodic cell is not triangular."""
         del stage
         batch = ctx.batch

--- a/nvalchemi/dynamics/hooks/freeze.py
+++ b/nvalchemi/dynamics/hooks/freeze.py
@@ -28,7 +28,7 @@ import torch
 from nvalchemi._typing import AtomCategory
 from nvalchemi.data import Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 __all__ = ["FreezeAtomsHook"]
 
@@ -176,7 +176,7 @@ class FreezeAtomsHook:
             if self.zero_forces:
                 batch.forces.copy_(torch.where(mask, zeros, batch.forces))
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Snapshot or restore frozen atom positions."""
         if stage == DynamicsStage.BEFORE_PRE_UPDATE:
             self._saved_positions = ctx.batch.positions.clone()

--- a/nvalchemi/dynamics/hooks/logging.py
+++ b/nvalchemi/dynamics/hooks/logging.py
@@ -54,7 +54,7 @@ from nvalchemi.dynamics.hooks._utils import (
     scatter_reduce_per_graph,
     temperature_per_graph,
 )
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -89,7 +89,7 @@ class LoggingHook:
 
     Users can extend or replace this set by providing a ``custom_scalars``
     mapping of ``{name: callable}`` pairs, where each callable has
-    signature ``(batch, dynamics) -> Tensor`` of shape ``(B,)`` (one
+    signature ``(ctx) -> Tensor`` of shape ``(B,)`` (one
     value per graph) or a plain ``float`` (broadcast to all graphs).
 
     **Asynchronous I/O.** Scalar computation and the GPU-to-CPU transfer
@@ -124,7 +124,7 @@ class LoggingHook:
         ``"tensorboard"``).  Default ``None``.
     custom_scalars : dict[str, Callable] | None, optional
         Additional named scalars to compute and log.  Each callable
-        receives ``(ctx,)`` — a :class:`HookContext` — and returns
+        receives ``(ctx,)`` — a :class:`DynamicsContext` — and returns
         either a ``(B,)`` tensor (per-graph values) or a ``float``
         (broadcast to all graphs).  Name collisions override defaults.
         Default ``None``.
@@ -166,7 +166,7 @@ class LoggingHook:
         frequency: int = 1,
         log_path: str | Path | None = None,
         custom_scalars: (
-            dict[str, Callable[[HookContext], float | torch.Tensor]] | None
+            dict[str, Callable[[DynamicsContext], float | torch.Tensor]] | None
         ) = None,
         writer_fn: (Callable[[int, list[dict[str, float]]], None] | None) = None,
         stage: Enum = DynamicsStage.AFTER_STEP,
@@ -237,7 +237,7 @@ class LoggingHook:
         self,
         batch: Batch,
         step_count: int,
-        ctx: HookContext,
+        ctx: DynamicsContext,
     ) -> None:
         """Compute per-graph scalars and dispatch to the logging backend.
 
@@ -247,7 +247,7 @@ class LoggingHook:
             The current batch of atomic data.
         step_count : int
             The current step number.
-        ctx : HookContext
+        ctx : DynamicsContext
             The hook context (required for custom_scalars).
         """
         device = batch.device
@@ -270,7 +270,7 @@ class LoggingHook:
         self._executor.submit(self._dispatch, td, step_count)
 
     @torch.compiler.disable
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Log scalar observables for the current step."""
         self._log(ctx.batch, ctx.step_count, ctx)
 
@@ -282,7 +282,7 @@ class LoggingHook:
         self,
         batch: Batch,
         step_count: int,
-        ctx: HookContext,
+        ctx: DynamicsContext,
     ) -> TensorDict:
         """Build a ``TensorDict(batch_size=[B])`` of per-graph scalars.
 
@@ -292,7 +292,7 @@ class LoggingHook:
             The current batch of atomic data.
         step_count : int
             The current step number.
-        ctx : HookContext
+        ctx : DynamicsContext
             The hook context (required for custom_scalars).
         """
         dev = batch.device
@@ -339,7 +339,7 @@ class LoggingHook:
 
         if self.custom_scalars:
             for name, fn in self.custom_scalars.items():
-                # custom_scalars receive (ctx,) — a HookContext
+                # custom_scalars receive (ctx,) — a DynamicsContext
                 val = fn(ctx)
                 if isinstance(val, torch.Tensor):
                     td.set(name, val)

--- a/nvalchemi/dynamics/hooks/monitors.py
+++ b/nvalchemi/dynamics/hooks/monitors.py
@@ -31,7 +31,7 @@ from loguru import logger
 from nvalchemi.data import Batch
 from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.dynamics.hooks._utils import kinetic_energy_per_graph
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 __all__ = ["EnergyDriftMonitorHook"]
 
@@ -216,6 +216,6 @@ class EnergyDriftMonitorHook:
                 # TODO: use a distributed aware logger
                 logger.warning(msg)
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Check energy drift against the configured threshold."""
         self._check_drift(ctx.batch, ctx.step_count, ctx.global_rank or 0)

--- a/nvalchemi/dynamics/hooks/profiling.py
+++ b/nvalchemi/dynamics/hooks/profiling.py
@@ -41,7 +41,7 @@ from plum import dispatch
 
 from nvalchemi.data import Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 try:
     import nvtx
@@ -277,14 +277,14 @@ class ProfilerHook:
             self._step_cpu_timestamps.clear()
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:  # noqa: F811
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:  # noqa: F811
         """Record timing for a dynamics stage."""
         self._record(
             ctx.batch, stage, ctx.step_count, ctx.global_rank or 0, domain="dynamics"
         )
 
     @dispatch
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:  # noqa: F811
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:  # noqa: F811
         """Record timing for a generic stage."""
         self._record(
             ctx.batch, stage, ctx.step_count, ctx.global_rank or 0, domain="custom"

--- a/nvalchemi/dynamics/hooks/safety.py
+++ b/nvalchemi/dynamics/hooks/safety.py
@@ -34,7 +34,7 @@ import torch
 
 from nvalchemi.data import Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 __all__ = ["MaxForceClampHook", "NaNDetectorHook"]
 
@@ -167,7 +167,7 @@ class NaNDetectorHook:
             batch, step_count, present_keys, tensors, all_finite
         )
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Check forces, energy, and extra keys for NaN/Inf values."""
         self._check_finite(ctx.batch, ctx.step_count)
 
@@ -305,7 +305,7 @@ class MaxForceClampHook:
         self.stage = stage
         self.frequency = frequency
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Clamp force vectors exceeding ``max_force`` in-place."""
         self._clamp_forces(ctx.batch)
 

--- a/nvalchemi/dynamics/hooks/snapshot.py
+++ b/nvalchemi/dynamics/hooks/snapshot.py
@@ -29,7 +29,7 @@ import torch
 
 from nvalchemi.data import Batch
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext
 
 if TYPE_CHECKING:
     from nvalchemi.dynamics.sinks import DataSink
@@ -119,7 +119,7 @@ class SnapshotHook:
         """Write the current batch state to the configured sink."""
         self.sink.write(batch)
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Write the current batch state to the configured sink."""
         self._write_snapshot(ctx.batch)
 
@@ -218,6 +218,6 @@ class ConvergedSnapshotHook:
                 pass
         self.sink.write(sub_batch)
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Write converged samples to the configured sink."""
         self._write_converged(ctx.batch, ctx.converged_mask)

--- a/nvalchemi/hooks/__init__.py
+++ b/nvalchemi/hooks/__init__.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks._context import DynamicsContext, HookContext, TrainContext
 from nvalchemi.hooks._protocol import Hook
 from nvalchemi.hooks._registry import HookRegistryMixin
 from nvalchemi.hooks.bias import BiasedPotentialHook
@@ -25,9 +25,11 @@ from nvalchemi.hooks.periodic import WrapPeriodicHook
 
 __all__ = [
     "BiasedPotentialHook",
+    "DynamicsContext",
     "Hook",
     "HookContext",
     "HookRegistryMixin",
     "NeighborListHook",
+    "TrainContext",
     "WrapPeriodicHook",
 ]

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -85,8 +85,13 @@ class TrainContext(HookContext):
         Aggregate loss for the current step.
     losses : dict[str, torch.Tensor] | None
         Named loss components for the current step.
-    models : dict[str, BaseModelMixin] | ModuleDict[str, BaseModelMixin] | None
-        Models participating in the training step.
+    models : dict[str, BaseModelMixin] | ModuleDict | None
+        Models participating in the training step; this differs
+        from the ``model`` attribute which is intended to
+        represent a 'main' model in multi-model workflows. The
+        key/model mapping should be semantic, e.g. 'student' and
+        'teacher' in distillation workflows, with 'student' being
+        the intended 'main' model.
     optimizers : list[torch.optim.Optimizer] | None
         Optimizers participating in the training step.
     lr_schedulers : list[object] | None

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -20,13 +20,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
+from torch.nn import ModuleDict
 
 if TYPE_CHECKING:
     from nvalchemi.data.batch import Batch
     from nvalchemi.models.base import BaseModelMixin
 
 
-@dataclass
+@dataclass(init=False)
 class HookContext:
     """Context object passed to hooks at each stage.
 
@@ -59,13 +60,24 @@ class HookContext:
     """
 
     batch: Batch
-    step_count: int
     model: BaseModelMixin | None = None
-    loss: torch.Tensor | None = None
-    optimizer: torch.optim.Optimizer | None = None
-    lr_scheduler: object | None = None
-    gradients: dict[str, torch.Tensor] | None = None
-    converged_mask: torch.Tensor | None = None
-    epoch: int | None = None
     global_rank: int = 0
     workflow: Any = None
+
+
+@dataclass(init=False)
+class DynamicsContext(HookContext):
+    step_count: int = 0
+    converged_mask: torch.Tensor | None = None
+
+
+@dataclass(init=False)
+class TrainContext(HookContext):
+    step_count: int = 0
+    epoch: int = 0
+    loss: torch.Tensor | None = None
+    losses: dict[str, torch.Tensor] | None = None
+    models: dict[str, BaseModelMixin] | ModuleDict[str, BaseModelMixin] | None = None
+    optimizers: list[torch.optim.Optimizer] | None = None
+    lr_schedulers: list[object] | None = None
+    gradients: dict[str, torch.Tensor] | None = None

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -99,7 +99,7 @@ class TrainContext(HookContext):
     epoch: int = 0
     loss: torch.Tensor | None = None
     losses: dict[str, torch.Tensor] | None = None
-    models: dict[str, BaseModelMixin] | ModuleDict[str, BaseModelMixin] | None = None
+    models: dict[str, BaseModelMixin] | ModuleDict | None = None
     optimizers: list[torch.optim.Optimizer] | None = None
     lr_schedulers: list[object] | None = None
     gradients: dict[str, torch.Tensor] | None = None

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Hook context for passing state to hooks."""
+"""Hook context dataclasses for passing workflow state to hooks."""
 
 from __future__ import annotations
 
@@ -27,36 +27,25 @@ if TYPE_CHECKING:
     from nvalchemi.models.base import BaseModelMixin
 
 
-@dataclass(init=False)
+@dataclass(kw_only=True)
 class HookContext:
-    """Context object passed to hooks at each stage.
+    """Common context object passed to hooks.
+
+    ``HookContext`` contains fields shared by all hook-enabled workflows.
+    Workflow-specific subclasses add state that is only meaningful in that
+    domain, such as dynamics step counts or training losses.
 
     Attributes
     ----------
     batch : Batch
         Current batch being processed.
-    step_count : int
-        Current step number in the workflow.
     model : BaseModelMixin | None
         Model being used (if applicable).
-    loss : torch.Tensor | None
-        Current loss value (training only).
-    optimizer : torch.optim.Optimizer | None
-        Optimizer being used (training only).
-    lr_scheduler : object | None
-        Learning rate scheduler (training only).
-    gradients : dict[str, torch.Tensor] | None
-        Parameter gradients (training only).
-    converged_mask : torch.Tensor | None
-        Boolean mask of converged samples (dynamics only).
-    epoch : int | None
-        Current epoch number (training only).
     global_rank : int
         Distributed rank of this process.
     workflow : Any
-        Back-reference to the engine running the hooks (e.g. a
-        ``BaseDynamics`` instance).  ``None`` when the workflow does
-        not inject itself.
+        Back-reference to the engine running the hooks. ``None`` when
+        the workflow does not inject itself.
     """
 
     batch: Batch
@@ -65,14 +54,47 @@ class HookContext:
     workflow: Any = None
 
 
-@dataclass(init=False)
+@dataclass(kw_only=True)
 class DynamicsContext(HookContext):
+    """Context object passed to dynamics hooks.
+
+    Attributes
+    ----------
+    step_count : int
+        Current dynamics step number.
+    converged_mask : torch.Tensor | None
+        Boolean mask of samples that converged at the current hook stage.
+        ``None`` when convergence has not fired for this dispatch.
+    """
+
     step_count: int = 0
     converged_mask: torch.Tensor | None = None
 
 
-@dataclass(init=False)
+@dataclass(kw_only=True)
 class TrainContext(HookContext):
+    """Context object passed to training hooks.
+
+    Attributes
+    ----------
+    step_count : int
+        Current optimizer step number.
+    epoch : int
+        Current training epoch.
+    loss : torch.Tensor | None
+        Aggregate loss for the current step.
+    losses : dict[str, torch.Tensor] | None
+        Named loss components for the current step.
+    models : dict[str, BaseModelMixin] | ModuleDict[str, BaseModelMixin] | None
+        Models participating in the training step.
+    optimizers : list[torch.optim.Optimizer] | None
+        Optimizers participating in the training step.
+    lr_schedulers : list[object] | None
+        Learning rate schedulers participating in the training step.
+    gradients : dict[str, torch.Tensor] | None
+        Parameter gradients for the current step.
+    """
+
     step_count: int = 0
     epoch: int = 0
     loss: torch.Tensor | None = None

--- a/nvalchemi/hooks/_protocol.py
+++ b/nvalchemi/hooks/_protocol.py
@@ -55,7 +55,8 @@ class Hook(Protocol):
         Parameters
         ----------
         ctx : HookContext
-            Snapshot of the current workflow state.
+            Snapshot of the current workflow state. Workflow engines may pass
+            a :class:`HookContext` subclass with additional fields.
         stage : Enum
             The stage being dispatched.
         """

--- a/nvalchemi/hooks/_registry.py
+++ b/nvalchemi/hooks/_registry.py
@@ -120,9 +120,11 @@ class HookRegistryMixin:
         self.hooks.append(hook)
 
     def _build_context(self, batch: Batch) -> HookContext:
-        """Build a HookContext for the current state.
+        """Build a base HookContext for the current state.
 
-        Override in subclasses to populate workflow-specific fields.
+        Override in subclasses to return a workflow-specific context
+        subclass when hooks need additional fields such as step counts,
+        losses, or convergence masks.
 
         Parameters
         ----------
@@ -134,11 +136,7 @@ class HookRegistryMixin:
         HookContext
             Context object for hooks.
         """
-        return HookContext(
-            batch=batch,
-            step_count=self.step_count,
-            model=getattr(self, "model", None),
-        )
+        return HookContext(batch=batch, model=getattr(self, "model", None))
 
     def _call_hooks(self, stage: Enum, batch: Batch) -> None:
         """Call hooks registered for the given stage, gated by frequency.

--- a/nvalchemi/hooks/_registry.py
+++ b/nvalchemi/hooks/_registry.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from torch import distributed as dist
+
 from nvalchemi.data import Batch
 from nvalchemi.hooks._context import HookContext
 from nvalchemi.hooks._protocol import Hook
@@ -136,7 +138,16 @@ class HookRegistryMixin:
         HookContext
             Context object for hooks.
         """
-        return HookContext(batch=batch, model=getattr(self, "model", None))
+        if dist.is_available() and dist.is_initialized():
+            global_rank = dist.get_rank()
+        else:
+            global_rank = 0
+        return HookContext(
+            batch=batch,
+            model=getattr(self, "model", None),
+            global_rank=global_rank,
+            workflow=self,
+        )
 
     def _call_hooks(self, stage: Enum, batch: Batch) -> None:
         """Call hooks registered for the given stage, gated by frequency.

--- a/test/dynamics/conftest.py
+++ b/test/dynamics/conftest.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from enum import Enum
 
 from nvalchemi.dynamics.base import DynamicsStage
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext
 
 
 class RecordingHook:
@@ -76,13 +76,13 @@ class RecordingHook:
         self.name = name if name is not None else stage.name
         self.record_list = record_list
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """
         Record that this hook was called.
 
         Parameters
         ----------
-        ctx : HookContext
+        ctx : DynamicsContext
             The hook context (unused).
         stage : Enum
             The stage being dispatched (unused).

--- a/test/dynamics/conftest.py
+++ b/test/dynamics/conftest.py
@@ -19,9 +19,53 @@ Shared pytest fixtures and helpers for the dynamics test suite.
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
 
 from nvalchemi.dynamics.base import DynamicsStage
 from nvalchemi.hooks import DynamicsContext
+
+if TYPE_CHECKING:
+    from nvalchemi.data import Batch
+    from nvalchemi.dynamics.base import BaseDynamics
+
+
+def make_dynamics_context(
+    batch: Batch,
+    dynamics: BaseDynamics,
+    converged: torch.Tensor | None = None,
+) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance.
+
+    Parameters
+    ----------
+    batch : Batch
+        Batch to expose through the context.
+    dynamics : BaseDynamics
+        Dynamics instance providing step, model, rank, and convergence state.
+    converged : torch.Tensor | None, optional
+        Explicit converged graph indices. When ``None``, use
+        ``dynamics._last_converged``.
+
+    Returns
+    -------
+    DynamicsContext
+        Context object for direct hook unit tests.
+    """
+    raw = converged if converged is not None else dynamics._last_converged
+    if raw is not None:
+        mask = batch.positions.new_zeros(batch.num_graphs, dtype=torch.bool)
+        mask[raw] = True
+    else:
+        mask = None
+    return DynamicsContext(
+        batch=batch,
+        step_count=dynamics.step_count,
+        model=dynamics.model,
+        converged_mask=mask,
+        global_rank=dynamics.global_rank,
+    )
 
 
 class RecordingHook:

--- a/test/dynamics/test_base.py
+++ b/test/dynamics/test_base.py
@@ -29,8 +29,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, ConvergenceHook, DynamicsStage
 from nvalchemi.dynamics.demo import DemoDynamics
-from nvalchemi.hooks import Hook
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # -----------------------------------------------------------------------------
@@ -355,6 +354,24 @@ class TestBaseDynamics:
         """Verify default convergence_hook is None."""
         dynamics = BaseDynamics(self.model)
         assert dynamics.convergence_hook is None
+
+    def test_build_context_returns_dynamics_context(self) -> None:
+        """Verify BaseDynamics populates dynamics-specific context fields."""
+        dynamics = BaseDynamics(self.model)
+        dynamics.step_count = 7
+        batch = create_simple_batch()
+        dynamics._last_converged = torch.tensor([0], dtype=torch.long)
+
+        ctx = dynamics._build_context(batch)
+
+        assert isinstance(ctx, DynamicsContext)
+        assert ctx.batch is batch
+        assert ctx.step_count == 7
+        assert ctx.model is dynamics.model
+        assert ctx.global_rank == dynamics.global_rank
+        assert ctx.workflow is dynamics
+        assert ctx.converged_mask is not None
+        assert ctx.converged_mask.tolist() == [True, False]
 
     def test_on_converge_hooks_fire(self) -> None:
         """Verify ON_CONVERGE hooks fire when convergence is detected."""
@@ -902,7 +919,7 @@ class TestConvergenceHook:
             target_status=1,
         )
 
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # Sample 0: converged (fmax 0.01 <= 0.05) AND status == source_status (0)
@@ -923,7 +940,7 @@ class TestConvergenceHook:
             target_status=None,
         )
 
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # Status should remain unchanged
@@ -1441,7 +1458,7 @@ class TestHookFrequencyGating:
                 self.frequency = f
                 self._record = r
 
-            def __call__(self, ctx: HookContext, stage: Enum) -> None:
+            def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
                 self._record.append(ctx.step_count)
 
         return _RecHook(stage, record, frequency)

--- a/test/dynamics/test_bias_hook.py
+++ b/test/dynamics/test_bias_hook.py
@@ -24,8 +24,9 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.hooks import BiasedPotentialHook, DynamicsContext, Hook
+from nvalchemi.hooks import BiasedPotentialHook, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,23 +56,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
-    """Build a DynamicsContext from a batch and dynamics instance."""
-    converged = dynamics._last_converged
-    if converged is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[converged] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 # ===========================================================================

--- a/test/dynamics/test_bias_hook.py
+++ b/test/dynamics/test_bias_hook.py
@@ -24,7 +24,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.hooks import BiasedPotentialHook, Hook, HookContext
+from nvalchemi.hooks import BiasedPotentialHook, DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -55,8 +55,8 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
-    """Build a HookContext from a batch and dynamics instance."""
+def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance."""
     converged = dynamics._last_converged
     if converged is not None:
         mask = torch.zeros(
@@ -65,7 +65,7 @@ def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
         mask[converged] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,

--- a/test/dynamics/test_cell_align.py
+++ b/test/dynamics/test_cell_align.py
@@ -32,8 +32,9 @@ from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics._ops.cell_align import align_cell
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks import AlignCellHook
-from nvalchemi.hooks import DynamicsContext, Hook
+from nvalchemi.hooks import Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -132,22 +133,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
-    converged = dynamics._last_converged
-    if converged is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[converged] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 # ===========================================================================

--- a/test/dynamics/test_cell_align.py
+++ b/test/dynamics/test_cell_align.py
@@ -32,7 +32,7 @@ from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics._ops.cell_align import align_cell
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks import AlignCellHook
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -132,7 +132,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
+def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
     converged = dynamics._last_converged
     if converged is not None:
         mask = torch.zeros(
@@ -141,7 +141,7 @@ def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
         mask[converged] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,

--- a/test/dynamics/test_freeze_hook.py
+++ b/test/dynamics/test_freeze_hook.py
@@ -25,8 +25,9 @@ from nvalchemi._typing import AtomCategory
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks import FreezeAtomsHook
-from nvalchemi.hooks import DynamicsContext, Hook
+from nvalchemi.hooks import Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -74,23 +75,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
-    """Build a DynamicsContext from a batch and dynamics instance."""
-    converged = dynamics._last_converged
-    if converged is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[converged] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 def _call_hook_two_stage(

--- a/test/dynamics/test_freeze_hook.py
+++ b/test/dynamics/test_freeze_hook.py
@@ -25,7 +25,7 @@ from nvalchemi._typing import AtomCategory
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks import FreezeAtomsHook
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -74,8 +74,8 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
-    """Build a HookContext from a batch and dynamics instance."""
+def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance."""
     converged = dynamics._last_converged
     if converged is not None:
         mask = torch.zeros(
@@ -84,7 +84,7 @@ def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
         mask[converged] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,

--- a/test/dynamics/test_observer_hooks.py
+++ b/test/dynamics/test_observer_hooks.py
@@ -34,7 +34,7 @@ from nvalchemi.dynamics.hooks import (
     SnapshotHook,
 )
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -77,8 +77,8 @@ def _make_dynamics(device: str = "cpu") -> BaseDynamics:
 
 def _make_ctx(
     batch: Batch, dynamics: BaseDynamics, converged: torch.Tensor | None = None
-) -> HookContext:
-    """Build a HookContext from a batch and dynamics instance."""
+) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance."""
     raw = converged if converged is not None else dynamics._last_converged
     if raw is not None:
         mask = torch.zeros(
@@ -87,7 +87,7 @@ def _make_ctx(
         mask[raw] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,
@@ -702,7 +702,7 @@ class _MockCMHook:
         self.call_count = 0
         self.close_count = 0
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         self.call_count += 1
 
     def __enter__(self) -> "_MockCMHook":
@@ -726,7 +726,7 @@ class _MockCloseOnlyHook:
         self.call_count = 0
         self.close_count = 0
 
-    def __call__(self, ctx: HookContext, stage: Enum) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         self.call_count += 1
 
     def close(self) -> None:

--- a/test/dynamics/test_observer_hooks.py
+++ b/test/dynamics/test_observer_hooks.py
@@ -34,8 +34,9 @@ from nvalchemi.dynamics.hooks import (
     SnapshotHook,
 )
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks import DynamicsContext, Hook
+from nvalchemi.hooks import Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -75,25 +76,7 @@ def _make_dynamics(device: str = "cpu") -> BaseDynamics:
     return BaseDynamics(model, device_type=device)
 
 
-def _make_ctx(
-    batch: Batch, dynamics: BaseDynamics, converged: torch.Tensor | None = None
-) -> DynamicsContext:
-    """Build a DynamicsContext from a batch and dynamics instance."""
-    raw = converged if converged is not None else dynamics._last_converged
-    if raw is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[raw] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 # ---------------------------------------------------------------------------

--- a/test/dynamics/test_periodic_hook.py
+++ b/test/dynamics/test_periodic_hook.py
@@ -23,7 +23,7 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.hooks import Hook, HookContext, WrapPeriodicHook
+from nvalchemi.hooks import DynamicsContext, Hook, WrapPeriodicHook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -64,8 +64,8 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
-    """Build a HookContext from a batch and dynamics instance."""
+def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance."""
     converged = dynamics._last_converged
     if converged is not None:
         mask = torch.zeros(
@@ -74,7 +74,7 @@ def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
         mask[converged] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,

--- a/test/dynamics/test_periodic_hook.py
+++ b/test/dynamics/test_periodic_hook.py
@@ -23,8 +23,9 @@ import torch
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
-from nvalchemi.hooks import DynamicsContext, Hook, WrapPeriodicHook
+from nvalchemi.hooks import Hook, WrapPeriodicHook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -64,23 +65,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(DemoModelWrapper(DemoModel()))
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
-    """Build a DynamicsContext from a batch and dynamics instance."""
-    converged = dynamics._last_converged
-    if converged is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[converged] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 # ===========================================================================

--- a/test/dynamics/test_safety_hooks.py
+++ b/test/dynamics/test_safety_hooks.py
@@ -25,8 +25,9 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks.safety import MaxForceClampHook, NaNDetectorHook
-from nvalchemi.hooks import DynamicsContext, Hook
+from nvalchemi.hooks import Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+from test.dynamics.conftest import make_dynamics_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -76,23 +77,7 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(model)
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
-    """Build a DynamicsContext from a batch and dynamics instance."""
-    converged = dynamics._last_converged
-    if converged is not None:
-        mask = torch.zeros(
-            batch.num_graphs, dtype=torch.bool, device=batch.positions.device
-        )
-        mask[converged] = True
-    else:
-        mask = None
-    return DynamicsContext(
-        batch=batch,
-        step_count=dynamics.step_count,
-        model=dynamics.model,
-        converged_mask=mask,
-        global_rank=dynamics.global_rank,
-    )
+_make_ctx = make_dynamics_context
 
 
 # ===========================================================================

--- a/test/dynamics/test_safety_hooks.py
+++ b/test/dynamics/test_safety_hooks.py
@@ -25,7 +25,7 @@ import torch
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import BaseDynamics, DynamicsStage
 from nvalchemi.dynamics.hooks.safety import MaxForceClampHook, NaNDetectorHook
-from nvalchemi.hooks import Hook, HookContext
+from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -76,8 +76,8 @@ def _make_dynamics() -> BaseDynamics:
     return BaseDynamics(model)
 
 
-def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
-    """Build a HookContext from a batch and dynamics instance."""
+def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> DynamicsContext:
+    """Build a DynamicsContext from a batch and dynamics instance."""
     converged = dynamics._last_converged
     if converged is not None:
         mask = torch.zeros(
@@ -86,7 +86,7 @@ def _make_ctx(batch: Batch, dynamics: BaseDynamics) -> HookContext:
         mask[converged] = True
     else:
         mask = None
-    return HookContext(
+    return DynamicsContext(
         batch=batch,
         step_count=dynamics.step_count,
         model=dynamics.model,

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -40,7 +40,7 @@ from nvalchemi.dynamics.base import (
 )
 from nvalchemi.dynamics.hooks import ConvergedSnapshotHook
 from nvalchemi.dynamics.sinks import HostMemory
-from nvalchemi.hooks._context import HookContext
+from nvalchemi.hooks import DynamicsContext
 from nvalchemi.models.base import BaseModelMixin, ModelConfig
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
@@ -189,7 +189,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([0, 0, 0])
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # All should be migrated to status=1
@@ -203,7 +203,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([2, 2, 2])
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # All should remain at status=2
@@ -217,7 +217,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([0, 0, 0])
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # All should remain at status=0
@@ -236,7 +236,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([0, 2, 0, 2])
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         expected = torch.tensor([1, 2, 0, 2])
@@ -250,7 +250,7 @@ class TestConvergenceHook:
 
         # Use higher threshold - all should converge
         hook = ConvergenceHook.from_fmax(0.2, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         assert (batch.status == 1).all()
@@ -262,7 +262,7 @@ class TestConvergenceHook:
         batch.forces = None  # Clear forces
 
         hook = ConvergenceHook()
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
 
         with pytest.raises(KeyError, match="forces"):
             hook(ctx, DynamicsStage.AFTER_STEP)
@@ -276,7 +276,7 @@ class TestConvergenceHook:
             delattr(batch, "status")
 
         hook = ConvergenceHook()
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
 
         # Should not raise, just no-op
         hook(ctx, DynamicsStage.AFTER_STEP)
@@ -288,7 +288,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([0, 0, 0])  # 1D tensor
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         assert (batch.status == 1).all()
@@ -300,7 +300,7 @@ class TestConvergenceHook:
         batch.status = torch.tensor([[0], [0], [0]])  # (B, 1)
 
         hook = ConvergenceHook.from_fmax(0.05, source_status=0, target_status=1)
-        ctx = HookContext(batch=batch, step_count=0)
+        ctx = DynamicsContext(batch=batch, step_count=0)
         hook(ctx, DynamicsStage.AFTER_STEP)
 
         # Should have updated all to 1 (in-place on the original tensor)
@@ -1368,7 +1368,7 @@ class _TrackingHook:
         self.call_count = 0
         self.call_step_counts: list[int] = []
 
-    def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+    def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
         """Record the call and current step count."""
         self.call_count += 1
         self.call_step_counts.append(ctx.step_count)
@@ -1559,7 +1559,7 @@ class TestFusedStageSubstageHooks:
             def __init__(self) -> None:
                 self.masks: list[torch.Tensor] = []
 
-            def __call__(self, ctx: HookContext, stage: DynamicsStage) -> None:
+            def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
                 self.masks.append(ctx.converged_mask.clone())
 
         dynamics0 = BaseDynamics(

--- a/test/hooks/test_context.py
+++ b/test/hooks/test_context.py
@@ -18,69 +18,125 @@ from unittest.mock import MagicMock
 
 import torch
 
-from nvalchemi.hooks import HookContext
+from nvalchemi.hooks import DynamicsContext, HookContext, TrainContext
 
 
 class TestHookContext:
     def test_create_with_required_fields_only(self):
         mock_batch = MagicMock()
-        ctx = HookContext(batch=mock_batch, step_count=10)
+        ctx = HookContext(batch=mock_batch)
 
         assert ctx.batch is mock_batch
-        assert ctx.step_count == 10
 
-    def test_create_with_all_optional_fields(self):
+    def test_create_with_common_optional_fields(self):
         mock_batch = MagicMock()
         mock_model = MagicMock()
-        mock_loss = torch.tensor(0.5)
-        mock_optimizer = MagicMock()
-        mock_scheduler = MagicMock()
-        mock_gradients = {"param": torch.tensor([1.0, 2.0])}
-        mock_converged = torch.tensor([True, False])
+        mock_workflow = MagicMock()
 
         ctx = HookContext(
             batch=mock_batch,
+            model=mock_model,
+            global_rank=2,
+            workflow=mock_workflow,
+        )
+
+        assert ctx.batch is mock_batch
+        assert ctx.model is mock_model
+        assert ctx.global_rank == 2
+        assert ctx.workflow is mock_workflow
+
+    def test_default_values_for_optional_fields(self):
+        mock_batch = MagicMock()
+        ctx = HookContext(batch=mock_batch)
+
+        assert ctx.model is None
+        assert ctx.global_rank == 0
+        assert ctx.workflow is None
+
+    def test_type_annotations_work_at_runtime(self):
+        mock_batch = MagicMock()
+        ctx = HookContext(batch=mock_batch)
+        assert hasattr(ctx, "__dataclass_fields__")
+        fields = ctx.__dataclass_fields__
+        assert "batch" in fields
+        assert "model" in fields
+        assert "global_rank" in fields
+        assert "workflow" in fields
+
+
+class TestDynamicsContext:
+    def test_create_with_dynamics_fields(self):
+        mock_batch = MagicMock()
+        mock_model = MagicMock()
+        mock_converged = torch.tensor([True, False])
+
+        ctx = DynamicsContext(
+            batch=mock_batch,
             step_count=42,
             model=mock_model,
-            loss=mock_loss,
-            optimizer=mock_optimizer,
-            lr_scheduler=mock_scheduler,
-            gradients=mock_gradients,
             converged_mask=mock_converged,
-            epoch=5,
             global_rank=2,
         )
 
         assert ctx.batch is mock_batch
         assert ctx.step_count == 42
         assert ctx.model is mock_model
-        assert ctx.loss is mock_loss
-        assert ctx.optimizer is mock_optimizer
-        assert ctx.lr_scheduler is mock_scheduler
-        assert ctx.gradients is mock_gradients
         assert ctx.converged_mask is mock_converged
-        assert ctx.epoch == 5
         assert ctx.global_rank == 2
 
-    def test_default_values_for_optional_fields(self):
+    def test_default_values_for_dynamics_fields(self):
         mock_batch = MagicMock()
-        ctx = HookContext(batch=mock_batch, step_count=0)
+        ctx = DynamicsContext(batch=mock_batch)
 
-        assert ctx.model is None
-        assert ctx.loss is None
-        assert ctx.optimizer is None
-        assert ctx.lr_scheduler is None
-        assert ctx.gradients is None
+        assert ctx.step_count == 0
         assert ctx.converged_mask is None
-        assert ctx.epoch is None
+        assert ctx.model is None
         assert ctx.global_rank == 0
 
-    def test_type_annotations_work_at_runtime(self):
+
+class TestTrainContext:
+    def test_create_with_training_fields(self):
         mock_batch = MagicMock()
-        ctx = HookContext(batch=mock_batch, step_count=1)
-        assert hasattr(ctx, "__dataclass_fields__")
-        fields = ctx.__dataclass_fields__
-        assert "batch" in fields
-        assert "step_count" in fields
-        assert "model" in fields
-        assert "global_rank" in fields
+        mock_model = MagicMock()
+        mock_loss = torch.tensor(0.5)
+        mock_losses = {"energy": torch.tensor(0.4), "force": torch.tensor(0.1)}
+        mock_optimizer = MagicMock()
+        mock_scheduler = MagicMock()
+        mock_gradients = {"param": torch.tensor([1.0, 2.0])}
+
+        ctx = TrainContext(
+            batch=mock_batch,
+            step_count=42,
+            epoch=5,
+            loss=mock_loss,
+            losses=mock_losses,
+            models={"main": mock_model},
+            optimizers=[mock_optimizer],
+            lr_schedulers=[mock_scheduler],
+            gradients=mock_gradients,
+            global_rank=2,
+        )
+
+        assert ctx.batch is mock_batch
+        assert ctx.step_count == 42
+        assert ctx.epoch == 5
+        assert ctx.loss is mock_loss
+        assert ctx.losses is mock_losses
+        assert ctx.models == {"main": mock_model}
+        assert ctx.optimizers == [mock_optimizer]
+        assert ctx.lr_schedulers == [mock_scheduler]
+        assert ctx.gradients is mock_gradients
+        assert ctx.global_rank == 2
+
+    def test_default_values_for_training_fields(self):
+        mock_batch = MagicMock()
+        ctx = TrainContext(batch=mock_batch)
+
+        assert ctx.step_count == 0
+        assert ctx.epoch == 0
+        assert ctx.loss is None
+        assert ctx.losses is None
+        assert ctx.models is None
+        assert ctx.optimizers is None
+        assert ctx.lr_schedulers is None
+        assert ctx.gradients is None

--- a/test/hooks/test_neighbor_list_hook.py
+++ b/test/hooks/test_neighbor_list_hook.py
@@ -47,7 +47,7 @@ _STAGE = DynamicsStage.BEFORE_COMPUTE
 
 
 def _ctx(batch: Batch) -> HookContext:
-    return HookContext(batch=batch, step_count=0)
+    return HookContext(batch=batch)
 
 
 def _cfg(

--- a/test/hooks/test_registry.py
+++ b/test/hooks/test_registry.py
@@ -180,11 +180,10 @@ class TestHookRegistryMixin:
         assert len(received) == 1
         ctx, stage = received[0]
         assert isinstance(ctx, HookContext)
-        assert ctx.step_count == 42
         assert ctx.batch is mock_batch
         assert stage == _TestStage.A
 
-    def test_build_context_returns_hook_context(self):
+    def test_build_context_returns_base_hook_context(self):
         engine = _MinimalEngine()
         engine.step_count = 42
 
@@ -193,7 +192,7 @@ class TestHookRegistryMixin:
 
         assert isinstance(ctx, HookContext)
         assert ctx.batch is mock_batch
-        assert ctx.step_count == 42
+        assert not hasattr(ctx, "step_count")
 
     def test_build_context_includes_model_if_present(self):
         engine = _MinimalEngine()

--- a/test/hooks/test_registry.py
+++ b/test/hooks/test_registry.py
@@ -192,6 +192,8 @@ class TestHookRegistryMixin:
 
         assert isinstance(ctx, HookContext)
         assert ctx.batch is mock_batch
+        assert ctx.global_rank == 0
+        assert ctx.workflow is engine
         assert not hasattr(ctx, "step_count")
 
     def test_build_context_includes_model_if_present(self):

--- a/test/hooks/test_shared_hooks.py
+++ b/test/hooks/test_shared_hooks.py
@@ -27,7 +27,7 @@ from nvalchemi.dynamics.hooks.snapshot import SnapshotHook
 from nvalchemi.dynamics.sinks import HostMemory
 from nvalchemi.hooks import (
     BiasedPotentialHook,
-    HookContext,
+    DynamicsContext,
     NeighborListHook,
     WrapPeriodicHook,
 )
@@ -53,9 +53,9 @@ def _make_batch(n_graphs: int = 2, atoms_per_graph: int = 3) -> Batch:
     return batch
 
 
-def _make_ctx(batch: Batch, step_count: int = 0) -> HookContext:
-    """Build a minimal HookContext (no model, no dynamics-specific fields)."""
-    return HookContext(batch=batch, step_count=step_count)
+def _make_ctx(batch: Batch, step_count: int = 0) -> DynamicsContext:
+    """Build a minimal dynamics context for hook tests."""
+    return DynamicsContext(batch=batch, step_count=step_count)
 
 
 # ===========================================================================


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Refactors hook context state into `HookContext`, `DynamicsContext`, and
`TrainContext` so hook data matches the workflow that produced it instead of
living in one catch-all context object.

The intent is to make the hook API clearer, keep dynamics-only state out of
generic hooks, and leave a cleaner extension point for future training and
custom workflow contexts.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Split generic, dynamics, and training hook context state into dedicated data classes.
- Propagated the dynamics context through dynamics hooks and downstream usage.
- Updated examples, tests, documentation, and the hook skill to describe the new API.

## Testing

- [x] Focused hook and dynamics tests pass locally
- [x] Linting passes (`make lint`)
- [x] Docstring coverage passes (`make interrogate`)
- [x] License header check passes (`make license`)
- [x] New tests added for new functionality meets coverage expectations

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

Opened as a draft for review.
