### PR TITLE
fix(dynamics): avoid double particle thermostat coupling in NPT

### DIFF
--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -36,7 +36,7 @@ nph_barostat_half_step
 nph_velocity_half_step
     NPH particle velocity half-step coupled to barostat strain rate.
 npt_barostat_half_step
-    NPT cell-velocity half-step with thermostat η̇₁ drag term.
+    NPT cell-velocity half-step (no thermostat drag).
 npt_thermostat_half_step
     NHC thermostat half-step used in NPT (updates chain variables).
 npt_velocity_half_step
@@ -50,6 +50,8 @@ stress_to_cell_force
 """
 
 from __future__ import annotations
+
+import inspect
 
 import torch
 import torch.library
@@ -90,6 +92,41 @@ from nvalchemiops.dynamics.utils.cell_filter import (
 )
 
 from nvalchemi.dynamics._ops._bridge import _mat_type, _scalar_type, _vec_type
+
+# ops v0.3.1 ships ``npt_barostat_half_step`` with an ``eta_dots`` argument
+# and an inline ``-eta_dot[:,0] * h_dot`` drag; post-v0.3.1 dropped both
+# (canonical MTK: NHC drag is *not* inside the barostat half-step).  The
+# Toolkit caller speaks the post-v0.3.1 contract; when the legacy kernel is
+# detected we feed it a zero ``eta_dots`` buffer below to mute the drag.
+# ``inspect`` is required here because ops ``main`` still reports
+# ``__version__ == "0.3.1"`` until the next release bumps it, so
+# ``importlib.metadata.version`` cannot distinguish the two kernels.
+#
+# TODO: drop this flag, the zero-buffer cache, and the call-site ``if`` in
+# ``npt_barostat_half_step`` when the toolkit's minimum ops pin advances
+# above the legacy kernel.
+_NPT_BAROSTAT_LEGACY_API = "eta_dots" in inspect.signature(_npt_baro_half).parameters
+_ZERO_ETA_DOTS_CACHE: dict[tuple[int, torch.dtype, torch.device], torch.Tensor] = {}
+
+
+def _zero_eta_dots_buffer(cell_velocity: torch.Tensor) -> torch.Tensor:
+    """Return a cached zero buffer of shape ``[M, 1]`` for the legacy kernel.
+
+    The legacy ``npt_barostat_half_step`` reads only ``eta_dots[:, 0]``, so a
+    single-link buffer is sufficient.  Cached per ``(num_systems, dtype,
+    device)`` so repeated steps reuse the same tensor.
+    """
+    key = (cell_velocity.shape[0], cell_velocity.dtype, cell_velocity.device)
+    buf = _ZERO_ETA_DOTS_CACHE.get(key)
+    if buf is None:
+        buf = torch.zeros(
+            cell_velocity.shape[0],
+            1,
+            dtype=cell_velocity.dtype,
+            device=cell_velocity.device,
+        )
+        _ZERO_ETA_DOTS_CACHE[key] = buf
+    return buf
 
 
 def _vec9_type(dtype: torch.dtype):
@@ -469,12 +506,13 @@ def npt_barostat_half_step(
     W: torch.Tensor,
     kinetic_energy: torch.Tensor,
     num_atoms_per_system: torch.Tensor,
-    eta_dots: torch.Tensor,
     dt: torch.Tensor,
 ) -> None:
-    """NPT barostat cell-velocity half-step with thermostat drag.
+    """NPT barostat cell-velocity half-step.
 
-    Updates ``ḣ`` via ``ḧ = (V/W)(P_inst - P_ext) - η̇₁·ḣ``.
+    Updates ``ḣ`` via ``ḧ = (V/W)(P_inst - P_ext)``.  Canonical MTK puts no
+    thermostat drag in this half-step; the particle/barostat NHC chains are
+    applied as separate Trotter operators by the caller.
     Modifies *cell_velocity* in-place.
 
     Parameters
@@ -494,9 +532,6 @@ def npt_barostat_half_step(
         Per-system kinetic energy ``[M]``, same dtype.
     num_atoms_per_system : torch.Tensor
         Number of atoms per system ``[M]``, int32.
-    eta_dots : torch.Tensor
-        Full NHC chain velocities ``[M, chain_length]``, same dtype.
-        The kernel reads only ``eta_dots[:, 0]`` (first chain link).
     dt : torch.Tensor
         Per-system timestep ``[M]``, same dtype.
     """
@@ -504,7 +539,7 @@ def npt_barostat_half_step(
     mat_t = _mat_type(dtype)
     scl_t = _scalar_type(dtype)
     vec9_t = _vec9_type(dtype)
-    _npt_baro_half(
+    args = [
         wp.from_torch(cell_velocity, dtype=mat_t),
         wp.from_torch(pressure_tensor, dtype=vec9_t),  # [M, 9] as vec9 [M]
         _target_pressure_wp_array(target_pressure),
@@ -512,9 +547,11 @@ def npt_barostat_half_step(
         wp.from_torch(W, dtype=scl_t),
         wp.from_torch(kinetic_energy, dtype=scl_t),
         wp.from_torch(num_atoms_per_system, dtype=wp.int32),
-        wp.from_torch(eta_dots, dtype=scl_t),
-        wp.from_torch(dt, dtype=scl_t),
-    )
+    ]
+    if _NPT_BAROSTAT_LEGACY_API:
+        args.append(wp.from_torch(_zero_eta_dots_buffer(cell_velocity), dtype=scl_t))
+    args.append(wp.from_torch(dt, dtype=scl_t))
+    _npt_baro_half(*args)
 
 
 @npt_barostat_half_step.register_fake
@@ -526,7 +563,6 @@ def _npt_barostat_half_step_fake(
     W,
     kinetic_energy,
     num_atoms_per_system,
-    eta_dots,
     dt,
 ) -> None:
     pass

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -52,6 +52,7 @@ stress_to_cell_force
 from __future__ import annotations
 
 import inspect
+from functools import lru_cache
 
 import torch
 import torch.library
@@ -102,31 +103,24 @@ from nvalchemi.dynamics._ops._bridge import _mat_type, _scalar_type, _vec_type
 # ``__version__ == "0.3.1"`` until the next release bumps it, so
 # ``importlib.metadata.version`` cannot distinguish the two kernels.
 #
-# TODO: drop this flag, the zero-buffer cache, and the call-site ``if`` in
-# ``npt_barostat_half_step`` when the toolkit's minimum ops pin advances
+# TODO: drop this flag, the bounded zero-buffer cache, and the call-site ``if``
+# in ``npt_barostat_half_step`` when the toolkit's minimum ops pin advances
 # above the legacy kernel.
 _NPT_BAROSTAT_LEGACY_API = "eta_dots" in inspect.signature(_npt_baro_half).parameters
-_ZERO_ETA_DOTS_CACHE: dict[tuple[int, torch.dtype, torch.device], torch.Tensor] = {}
 
 
-def _zero_eta_dots_buffer(cell_velocity: torch.Tensor) -> torch.Tensor:
-    """Return a cached zero buffer of shape ``[M, 1]`` for the legacy kernel.
+@lru_cache(maxsize=1)
+def _zero_eta_dots_buffer(
+    num_systems: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a bounded cached zero buffer for the legacy barostat kernel.
 
     The legacy ``npt_barostat_half_step`` reads only ``eta_dots[:, 0]``, so a
-    single-link buffer is sufficient.  Cached per ``(num_systems, dtype,
-    device)`` so repeated steps reuse the same tensor.
+    single-link buffer is sufficient.
     """
-    key = (cell_velocity.shape[0], cell_velocity.dtype, cell_velocity.device)
-    buf = _ZERO_ETA_DOTS_CACHE.get(key)
-    if buf is None:
-        buf = torch.zeros(
-            cell_velocity.shape[0],
-            1,
-            dtype=cell_velocity.dtype,
-            device=cell_velocity.device,
-        )
-        _ZERO_ETA_DOTS_CACHE[key] = buf
-    return buf
+    return torch.zeros(num_systems, 1, dtype=dtype, device=device)
 
 
 def _vec9_type(dtype: torch.dtype):
@@ -549,7 +543,14 @@ def npt_barostat_half_step(
         wp.from_torch(num_atoms_per_system, dtype=wp.int32),
     ]
     if _NPT_BAROSTAT_LEGACY_API:
-        args.append(wp.from_torch(_zero_eta_dots_buffer(cell_velocity), dtype=scl_t))
+        args.append(
+            wp.from_torch(
+                _zero_eta_dots_buffer(
+                    cell_velocity.shape[0], cell_velocity.dtype, cell_velocity.device
+                ),
+                dtype=scl_t,
+            )
+        )
     args.append(wp.from_torch(dt, dtype=scl_t))
     _npt_baro_half(*args)
 

--- a/nvalchemi/dynamics/_ops/npt_nph.py
+++ b/nvalchemi/dynamics/_ops/npt_nph.py
@@ -52,7 +52,6 @@ stress_to_cell_force
 from __future__ import annotations
 
 import inspect
-from functools import lru_cache
 
 import torch
 import torch.library
@@ -93,34 +92,6 @@ from nvalchemiops.dynamics.utils.cell_filter import (
 )
 
 from nvalchemi.dynamics._ops._bridge import _mat_type, _scalar_type, _vec_type
-
-# ops v0.3.1 ships ``npt_barostat_half_step`` with an ``eta_dots`` argument
-# and an inline ``-eta_dot[:,0] * h_dot`` drag; post-v0.3.1 dropped both
-# (canonical MTK: NHC drag is *not* inside the barostat half-step).  The
-# Toolkit caller speaks the post-v0.3.1 contract; when the legacy kernel is
-# detected we feed it a zero ``eta_dots`` buffer below to mute the drag.
-# ``inspect`` is required here because ops ``main`` still reports
-# ``__version__ == "0.3.1"`` until the next release bumps it, so
-# ``importlib.metadata.version`` cannot distinguish the two kernels.
-#
-# TODO: drop this flag, the bounded zero-buffer cache, and the call-site ``if``
-# in ``npt_barostat_half_step`` when the toolkit's minimum ops pin advances
-# above the legacy kernel.
-_NPT_BAROSTAT_LEGACY_API = "eta_dots" in inspect.signature(_npt_baro_half).parameters
-
-
-@lru_cache(maxsize=1)
-def _zero_eta_dots_buffer(
-    num_systems: int,
-    dtype: torch.dtype,
-    device: torch.device,
-) -> torch.Tensor:
-    """Return a bounded cached zero buffer for the legacy barostat kernel.
-
-    The legacy ``npt_barostat_half_step`` reads only ``eta_dots[:, 0]``, so a
-    single-link buffer is sufficient.
-    """
-    return torch.zeros(num_systems, 1, dtype=dtype, device=device)
 
 
 def _vec9_type(dtype: torch.dtype):
@@ -542,11 +513,21 @@ def npt_barostat_half_step(
         wp.from_torch(kinetic_energy, dtype=scl_t),
         wp.from_torch(num_atoms_per_system, dtype=wp.int32),
     ]
-    if _NPT_BAROSTAT_LEGACY_API:
+    # Legacy ops v0.3.1 ``npt_barostat_half_step`` takes an ``eta_dots`` array
+    # and applies inline ``-eta_dot[:,0] * h_dot`` drag; post-v0.3.1 dropped
+    # the argument (canonical MTK: no NHC drag inside the barostat half-step).
+    # Pass zeros to mute the drag on the legacy kernel.  ``inspect`` is needed
+    # because ops main and ops v0.3.1 both report ``__version__ == "0.3.1"``.
+    # TODO: drop this branch when the toolkit's minimum ops pin advances past
+    # v0.3.1.
+    if "eta_dots" in inspect.signature(_npt_baro_half).parameters:
         args.append(
             wp.from_torch(
-                _zero_eta_dots_buffer(
-                    cell_velocity.shape[0], cell_velocity.dtype, cell_velocity.device
+                torch.zeros(
+                    cell_velocity.shape[0],
+                    1,
+                    dtype=cell_velocity.dtype,
+                    device=cell_velocity.device,
                 ),
                 dtype=scl_t,
             )

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -21,10 +21,10 @@ particle DOFs and one coupled to cell/barostat DOFs.
 
 The step is split around the force/stress evaluation:
 
-* ``pre_update``:  NHC-p half → NHC-b half → baro half → v half
+* ``pre_update``:  NHC-p half → NHC-b half → baro half → force/barostat v half
                    → r full → cell full
 * [model evaluates F and stress at r(t+dt), h(t+dt)]
-* ``post_update``: v half → baro half → NHC-b half → NHC-p half
+* ``post_update``: force/barostat v half → baro half → NHC-b half → NHC-p half
 
 Per-system state: ``dt``, ``temperature``, ``pressure``,
 ``barostat_time``, ``thermostat_time``, barostat inertia ``W``,
@@ -47,11 +47,11 @@ from nvalchemi.dynamics._ops.nose_hoover import nhc_compute_masses
 from nvalchemi.dynamics._ops.npt_nph import (
     compute_barostat_mass,
     compute_pressure_tensor,
+    nph_velocity_half_step,
     npt_barostat_half_step,
     npt_cell_update,
     npt_position_update,
     npt_thermostat_half_step,
-    npt_velocity_half_step,
 )
 from nvalchemi.dynamics._ops.thermostat_utils import compute_kinetic_energy
 from nvalchemi.dynamics._units import fs_to_internal_time
@@ -238,18 +238,6 @@ class NPT(BaseDynamics):
                     M, self.chain_length, dtype=dtype, device=dev
                 ),
                 "nhc_b_Q": Q_b,
-                # Workaround for nvalchemi-toolkit-ops <= 0.3.1: the
-                # ``npt_barostat_half_step`` kernel still applies an inline
-                # ``-eta_dot * h_dot`` drag, but canonical MTK puts no drag
-                # in the barostat half-step (cell damping comes from
-                # ``b_scale`` below).  Pass a permanent zero buffer to
-                # mute the drag.
-                # TODO: drop ``nhc_zero_eta_dot`` and switch to the
-                # eta_dots-free API once nvalchemi-toolkit-ops > 0.3.1
-                # ships (kernel fix in NVIDIA/nvalchemi-toolkit-ops#77).
-                "nhc_zero_eta_dot": torch.zeros(
-                    M, self.chain_length, dtype=dtype, device=dev
-                ),
                 # Pre-allocated scratch tensors; zeroed by kernel each call.
                 "kinetic_tensors": torch.zeros(M, 9, dtype=dtype, device=dev),
                 "pressure_tensors": torch.zeros(M, 9, dtype=dtype, device=dev),
@@ -309,9 +297,6 @@ class NPT(BaseDynamics):
                     n, self.chain_length, dtype=dtype, device=dev
                 ),
                 "nhc_b_Q": Q_b,
-                "nhc_zero_eta_dot": torch.zeros(
-                    n, self.chain_length, dtype=dtype, device=dev
-                ),
                 "kinetic_tensors": torch.zeros(n, 9, dtype=dtype, device=dev),
                 "pressure_tensors": torch.zeros(n, 9, dtype=dtype, device=dev),
                 "volumes": torch.zeros(n, dtype=dtype, device=dev),
@@ -350,7 +335,7 @@ class NPT(BaseDynamics):
         )
 
     def pre_update(self, batch: Batch) -> None:
-        """NHC-p half → NHC-b half → baro half → v half → r full → cell full.
+        """NHC-p half → NHC-b half → baro half → force/barostat v half → r full → cell full.
 
         Parameters
         ----------
@@ -407,11 +392,8 @@ class NPT(BaseDynamics):
 
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
-        # Workaround for nvalchemi-toolkit-ops <= 0.3.1: pass zero ``eta_dots``
-        # to mute the kernel's spurious ``−eta_dot·h_dot`` drag (cell damping
-        # comes from the ``b_scale`` step above).
-        # TODO: switch to eta_dots-free API once toolkit-ops > 0.3.1 ships
-        # (NVIDIA/nvalchemi-toolkit-ops#77).
+        # Cell damping is the explicit ``b_scale`` step above; the barostat
+        # half-step itself carries no thermostat drag.
         npt_barostat_half_step(
             self._state.cell_velocity,
             P_inst,
@@ -420,16 +402,17 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            self._state.nhc_zero_eta_dot,
             self._state.dt,
         )
-        npt_velocity_half_step(
+        # Force + barostat-strain velocity half step.  Particle NHC scaling is
+        # applied as the separate Trotter operator above, so use the no-drag
+        # NPH primitive here.
+        nph_velocity_half_step(
             batch.velocities,
             batch.atomic_masses,
             batch.forces,
             self._state.cell_velocity,
             volumes,
-            self._state.nhc_eta_dot,
             self._state.num_atoms_per_system,
             self._state.dt,
             batch.batch_idx.int(),
@@ -452,7 +435,7 @@ class NPT(BaseDynamics):
         )
 
     def post_update(self, batch: Batch) -> None:
-        """v half → baro half → NHC-b half → NHC-p half (symmetric closure).
+        """Force/barostat v half → baro half → NHC-b half → NHC-p half.
 
         Parameters
         ----------
@@ -464,13 +447,14 @@ class NPT(BaseDynamics):
         cells_inv = torch.linalg.inv_ex(batch.cell)[0].contiguous()
         KE = self._compute_ke(batch)
 
-        npt_velocity_half_step(
+        # Force + barostat-strain velocity half step only; particle NHC scaling
+        # closes the split below.
+        nph_velocity_half_step(
             batch.velocities,
             batch.atomic_masses,
             batch.forces,
             self._state.cell_velocity,
             volumes,
-            self._state.nhc_eta_dot,
             self._state.num_atoms_per_system,
             self._state.dt,
             batch.batch_idx.int(),
@@ -479,7 +463,6 @@ class NPT(BaseDynamics):
         )
         P_inst = self._compute_P(batch, volumes)
         KE = self._compute_ke(batch)
-        # See pre_update for nhc_zero_eta_dot workaround (toolkit-ops <= 0.3.1).
         npt_barostat_half_step(
             self._state.cell_velocity,
             P_inst,
@@ -488,7 +471,6 @@ class NPT(BaseDynamics):
             self._state.W,
             KE,
             self._state.num_atoms_per_system,
-            self._state.nhc_zero_eta_dot,
             self._state.dt,
         )
 

--- a/nvalchemi/dynamics/integrators/npt.py
+++ b/nvalchemi/dynamics/integrators/npt.py
@@ -445,7 +445,6 @@ class NPT(BaseDynamics):
         M = batch.num_graphs
         volumes = self._compute_volumes(batch)
         cells_inv = torch.linalg.inv_ex(batch.cell)[0].contiguous()
-        KE = self._compute_ke(batch)
 
         # Force + barostat-strain velocity half step only; particle NHC scaling
         # closes the split below.

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -453,6 +453,29 @@ class TestNPTIntegrator:
             assert any(v is batch.velocities for v in flat)
             assert npt.pressure_coupling in flat
 
+    def test_zero_eta_dots_buffer_cache_is_bounded(self):
+        """Legacy zero-eta buffer cache cannot grow without bound."""
+        import nvalchemi.dynamics._ops.npt_nph as npt_nph_ops
+
+        npt_nph_ops._zero_eta_dots_buffer.cache_clear()
+        try:
+            cache_info = npt_nph_ops._zero_eta_dots_buffer.cache_info()
+            maxsize = cache_info.maxsize
+            assert maxsize is not None
+
+            for num_systems in range(1, maxsize + 3):
+                buffer = npt_nph_ops._zero_eta_dots_buffer(
+                    num_systems, torch.float64, torch.device("cpu")
+                )
+                assert buffer.shape == (num_systems, 1)
+                assert buffer.dtype == torch.float64
+                assert buffer.device == torch.device("cpu")
+
+            cache_info = npt_nph_ops._zero_eta_dots_buffer.cache_info()
+            assert cache_info.currsize <= maxsize
+        finally:
+            npt_nph_ops._zero_eta_dots_buffer.cache_clear()
+
     # ------------------------------------------------------------------
     # chain_length respected
     # ------------------------------------------------------------------

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -747,29 +747,6 @@ class TestNPTIntegrator:
         velocity_diff = (batch.velocities - ops_velocities).abs().max()
         assert velocity_diff < 1e-3
 
-    def test_zero_eta_dots_buffer_cache_is_bounded(self):
-        """Legacy zero-eta buffer cache cannot grow without bound."""
-        import nvalchemi.dynamics._ops.npt_nph as npt_nph_ops
-
-        npt_nph_ops._zero_eta_dots_buffer.cache_clear()
-        try:
-            cache_info = npt_nph_ops._zero_eta_dots_buffer.cache_info()
-            maxsize = cache_info.maxsize
-            assert maxsize is not None
-
-            for num_systems in range(1, maxsize + 3):
-                buffer = npt_nph_ops._zero_eta_dots_buffer(
-                    num_systems, torch.float64, torch.device("cpu")
-                )
-                assert buffer.shape == (num_systems, 1)
-                assert buffer.dtype == torch.float64
-                assert buffer.device == torch.device("cpu")
-
-            cache_info = npt_nph_ops._zero_eta_dots_buffer.cache_info()
-            assert cache_info.currsize <= maxsize
-        finally:
-            npt_nph_ops._zero_eta_dots_buffer.cache_clear()
-
     # ------------------------------------------------------------------
     # chain_length respected
     # ------------------------------------------------------------------

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -408,6 +408,51 @@ class TestNPTIntegrator:
         npt.pre_update(batch)
         npt.post_update(batch)
 
+    def test_pre_post_update_use_nph_velocity_half_step(
+        self, npt_with_state, monkeypatch
+    ):
+        """NPT split uses no-thermostat velocity primitive for particle half-steps.
+
+        Regression for the particle-thermostat double-coupling bug: when the
+        explicit NHC scaling is applied as a separate Trotter operator, the
+        particle velocity half-step must go through the no-drag NPH primitive
+        rather than ``npt_velocity_half_step`` (which would re-apply
+        ``eta_dot[:,0]`` drag inline).
+        """
+        import nvalchemi.dynamics.integrators.npt as npt_module
+
+        npt, batch = npt_with_state
+        calls = []
+
+        def fake_nph_velocity_half_step(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        def forbidden_npt_velocity_half_step(*args, **kwargs):
+            raise AssertionError("NPT integrator must not call npt_velocity_half_step")
+
+        monkeypatch.setattr(
+            npt_module, "nph_velocity_half_step", fake_nph_velocity_half_step
+        )
+        # ``npt_velocity_half_step`` was deliberately removed from the npt
+        # module's imports as part of the fix; ``raising=False`` lets us add
+        # the name back as a tripwire — if a future regression re-imports it
+        # and calls it, the AssertionError above fires.
+        monkeypatch.setattr(
+            npt_module,
+            "npt_velocity_half_step",
+            forbidden_npt_velocity_half_step,
+            raising=False,
+        )
+
+        npt.pre_update(batch)
+        npt.post_update(batch)
+
+        assert len(calls) == 2, "expected two nph_velocity_half_step calls"
+        for args, kwargs in calls:
+            flat = list(args) + list(kwargs.values())
+            assert any(v is batch.velocities for v in flat)
+            assert npt.pressure_coupling in flat
+
     # ------------------------------------------------------------------
     # chain_length respected
     # ------------------------------------------------------------------

--- a/test/dynamics/test_npt_nph.py
+++ b/test/dynamics/test_npt_nph.py
@@ -30,6 +30,7 @@ from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics._units import fs_to_internal_time
 from nvalchemi.dynamics.integrators.nph import NPH
 from nvalchemi.dynamics.integrators.npt import NPT
+from nvalchemi.models.base import BaseModelMixin, ModelConfig
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 # ---------------------------------------------------------------------------
@@ -70,6 +71,87 @@ def _make_barostat_batch(
     )
     batch["stress"] = torch.zeros(B, 3, 3, dtype=dtype, device=device)
     return batch
+
+
+class _ZeroStressModel(torch.nn.Module, BaseModelMixin):
+    """Minimal model returning zero energy, forces, and stress."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces", "stress"}),
+            supports_pbc=True,
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        """Return no embedding outputs."""
+        return {}
+
+    def compute_embeddings(self, data: Batch, **kwargs: object) -> Batch:
+        """Return the input batch unchanged."""
+        del kwargs
+        return data
+
+    def forward(self, batch: Batch) -> dict[str, torch.Tensor]:
+        """Return zero model outputs matching *batch* shapes."""
+        dtype = batch.positions.dtype
+        device = batch.positions.device
+        M = batch.num_graphs
+        return {
+            "energy": torch.zeros((M, 1), dtype=dtype, device=device),
+            "forces": torch.zeros_like(batch.positions),
+            "stress": torch.zeros((M, 3, 3), dtype=dtype, device=device),
+        }
+
+
+def _make_zero_force_npt_batch(
+    *,
+    num_systems: int,
+    atoms_per_system: int,
+    dtype: torch.dtype,
+    seed: int,
+) -> tuple[Batch, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build matched Toolkit and fused-ops state for zero-force NPT tests."""
+    torch.manual_seed(seed)
+    cell_one = torch.eye(3, dtype=dtype) * 12.0
+    positions_one = torch.rand(atoms_per_system, 3, dtype=dtype) * 10.0 + 1.0
+    masses_one = torch.full((atoms_per_system,), 18.0, dtype=dtype)
+    atomic_numbers = torch.ones(atoms_per_system, dtype=torch.int64)
+    velocities = torch.randn(num_systems * atoms_per_system, 3, dtype=dtype) * 0.01
+
+    data_list = []
+    for sys_idx in range(num_systems):
+        start = sys_idx * atoms_per_system
+        data_list.append(
+            AtomicData(
+                atomic_numbers=atomic_numbers.clone(),
+                positions=positions_one.clone(),
+                atomic_masses=masses_one.clone(),
+                cell=cell_one.clone().unsqueeze(0),
+                pbc=torch.ones(1, 3, dtype=torch.bool),
+                forces=torch.zeros(atoms_per_system, 3, dtype=dtype),
+                stress=torch.zeros(1, 3, 3, dtype=dtype),
+                energy=torch.zeros(1, 1, dtype=dtype),
+                velocities=velocities[start : start + atoms_per_system].clone(),
+            )
+        )
+
+    batch = Batch.from_data_list(data_list, device="cpu")
+    ops_positions = positions_one.repeat(num_systems, 1).contiguous()
+    ops_cells = cell_one.repeat(num_systems, 1, 1).contiguous()
+    ops_masses = masses_one.repeat(num_systems).contiguous()
+    ops_batch_idx = torch.arange(num_systems, dtype=torch.int32).repeat_interleave(
+        atoms_per_system
+    )
+    return (
+        batch,
+        ops_positions,
+        velocities.contiguous(),
+        ops_cells,
+        ops_masses,
+        ops_batch_idx,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -452,6 +534,218 @@ class TestNPTIntegrator:
             flat = list(args) + list(kwargs.values())
             assert any(v is batch.velocities for v in flat)
             assert npt.pressure_coupling in flat
+
+    def test_post_update_particle_nhc_scaling_values(self, monkeypatch):
+        """post_update applies particle NHC scaling exactly once."""
+        import nvalchemi.dynamics.integrators.npt as npt_module
+
+        dtype = torch.float64
+        data = AtomicData(
+            atomic_numbers=torch.tensor([18, 18], dtype=torch.long),
+            positions=torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=dtype),
+        )
+        batch = Batch.from_data_list([data])
+        batch["velocities"] = torch.tensor(
+            [[1.0, -2.0, 0.5], [-0.25, 0.75, -1.5]], dtype=dtype
+        )
+        batch["forces"] = torch.zeros(2, 3, dtype=dtype)
+        batch["atomic_masses"] = torch.ones(2, dtype=dtype)
+        batch["cell"] = torch.eye(3, dtype=dtype).unsqueeze(0).contiguous() * 10.0
+        batch["stress"] = torch.zeros(1, 3, 3, dtype=dtype)
+
+        npt = NPT(
+            model=DemoModelWrapper(DemoModel()),
+            dt=1.0,
+            temperature=300.0,
+            pressure=1.0,
+            barostat_time=100.0,
+            thermostat_time=100.0,
+            pressure_coupling="isotropic",
+            chain_length=3,
+        )
+        npt._init_state(batch)
+        npt._state.cell_velocity.zero_()
+        npt._state.nhc_eta_dot.zero_()
+        npt._state.nhc_eta_dot[:, 0] = 2.0
+        npt._state.nhc_b_eta_dot.zero_()
+
+        def fake_compute_pressure(
+            batch_arg: Batch, volumes: torch.Tensor
+        ) -> torch.Tensor:
+            del volumes
+            return torch.zeros(
+                batch_arg.num_graphs, 9, dtype=dtype, device=batch_arg.device
+            )
+
+        def fake_compute_ke(batch_arg: Batch) -> torch.Tensor:
+            return torch.zeros(
+                batch_arg.num_graphs, dtype=dtype, device=batch_arg.device
+            )
+
+        monkeypatch.setattr(npt, "_compute_P", fake_compute_pressure)
+        monkeypatch.setattr(npt, "_compute_ke", fake_compute_ke)
+        monkeypatch.setattr(npt_module, "npt_barostat_half_step", lambda *args: None)
+        monkeypatch.setattr(npt_module, "npt_thermostat_half_step", lambda *args: None)
+
+        npt.post_update(batch)
+
+        expected = torch.tensor(
+            [
+                [0.9064431653963262, -1.8128863307926524, 0.4532215826981631],
+                [-0.2266107913490815, 0.6798323740472446, -1.3596647480944892],
+            ],
+            dtype=dtype,
+        )
+        torch.testing.assert_close(batch.velocities, expected, rtol=1e-6, atol=1e-6)
+
+    def test_high_level_npt_matches_fused_step_velocity_drift(self):
+        """High-level NPT stays close to fused ops on zero-force dynamics."""
+        import warp as wp
+        from nvalchemiops.dynamics.integrators import compute_barostat_mass
+        from nvalchemiops.dynamics.integrators.npt import run_npt_step, vec9d
+        from nvalchemiops.dynamics.utils.cell_utils import (
+            compute_cell_inverse,
+            compute_cell_volume,
+        )
+        from nvalchemiops.dynamics.utils.thermostat_utils import (
+            compute_kinetic_energy,
+        )
+
+        from nvalchemi.dynamics.hooks._utils import KB_EV
+
+        steps = 100
+        num_systems = 2
+        atoms_per_system = 8
+        dtype = torch.float64
+        temperature = 300.0
+        pressure = 6.324209e-7
+        timestep = 0.5
+        thermostat_time = 100.0
+        barostat_time = 1000.0
+        chain_length = 3
+
+        batch, ops_positions, ops_velocities, ops_cells, ops_masses, ops_batch_idx = (
+            _make_zero_force_npt_batch(
+                num_systems=num_systems,
+                atoms_per_system=atoms_per_system,
+                dtype=dtype,
+                seed=42,
+            )
+        )
+
+        npt = NPT(
+            model=_ZeroStressModel(),
+            dt=timestep,
+            temperature=temperature,
+            pressure=pressure,
+            barostat_time=barostat_time,
+            thermostat_time=thermostat_time,
+            chain_length=chain_length,
+            device_type="cpu",
+        )
+
+        ops_forces = torch.zeros_like(ops_positions)
+        positions_wp = wp.from_torch(ops_positions, dtype=wp.vec3d)
+        velocities_wp = wp.from_torch(ops_velocities, dtype=wp.vec3d)
+        forces_wp = wp.from_torch(ops_forces, dtype=wp.vec3d)
+        masses_wp = wp.from_torch(ops_masses, dtype=wp.float64)
+        cells_wp = wp.from_torch(ops_cells, dtype=wp.mat33d)
+        cell_velocities_wp = wp.zeros(num_systems, dtype=wp.mat33d, device="cpu")
+        virial_wp = wp.zeros(num_systems, dtype=vec9d, device="cpu")
+        eta_wp = wp.zeros((num_systems, chain_length), dtype=wp.float64, device="cpu")
+        eta_dot_wp = wp.zeros(
+            (num_systems, chain_length), dtype=wp.float64, device="cpu"
+        )
+
+        kT = KB_EV * temperature
+        tau_t = fs_to_internal_time(thermostat_time)
+        tau_p = fs_to_internal_time(barostat_time)
+        dt = fs_to_internal_time(timestep)
+
+        thermostat_masses = torch.zeros(num_systems, chain_length, dtype=dtype)
+        thermostat_masses[:, 0] = 3 * atoms_per_system * kT * tau_t**2
+        thermostat_masses[:, 1:] = kT * tau_t**2
+        thermostat_masses_wp = wp.from_torch(
+            thermostat_masses.contiguous(), dtype=wp.float64
+        )
+
+        cell_masses_wp = wp.zeros(num_systems, dtype=wp.float64, device="cpu")
+        target_temperature_wp = wp.from_torch(
+            torch.full((num_systems,), kT, dtype=dtype), dtype=wp.float64
+        )
+        tau_p_wp = wp.from_torch(
+            torch.full((num_systems,), tau_p, dtype=dtype), dtype=wp.float64
+        )
+        num_atoms_per_system = torch.full(
+            (num_systems,), atoms_per_system, dtype=torch.int32
+        )
+        num_atoms_per_system_wp = wp.from_torch(
+            num_atoms_per_system.contiguous(), dtype=wp.int32
+        )
+        compute_barostat_mass(
+            target_temperature_wp,
+            tau_p_wp,
+            num_atoms_per_system_wp,
+            cell_masses_wp,
+            device="cpu",
+        )
+
+        target_pressure_wp = wp.from_torch(
+            torch.full((num_systems,), pressure, dtype=dtype), dtype=wp.float64
+        )
+        dt_wp = wp.from_torch(
+            torch.full((num_systems,), dt, dtype=dtype), dtype=wp.float64
+        )
+        batch_idx_wp = wp.from_torch(ops_batch_idx.contiguous(), dtype=wp.int32)
+        pressure_tensors_wp = wp.zeros(num_systems, dtype=vec9d, device="cpu")
+        volumes_wp = wp.zeros(num_systems, dtype=wp.float64, device="cpu")
+        kinetic_energy_wp = wp.zeros(num_systems, dtype=wp.float64, device="cpu")
+        cells_inv_wp = wp.zeros(num_systems, dtype=wp.mat33d, device="cpu")
+        kinetic_tensors_wp = wp.zeros((num_systems, 9), dtype=wp.float64, device="cpu")
+        num_atoms_wp = wp.array([num_systems * atoms_per_system], dtype=wp.int32)
+
+        compute_kinetic_energy(
+            velocities_wp,
+            masses_wp,
+            kinetic_energy_wp,
+            batch_idx=batch_idx_wp,
+            device="cpu",
+        )
+        compute_cell_volume(cells_wp, volumes_wp, device="cpu")
+        compute_cell_inverse(cells_wp, cells_inv_wp, device="cpu")
+
+        for _ in range(steps):
+            run_npt_step(
+                positions=positions_wp,
+                velocities=velocities_wp,
+                forces=forces_wp,
+                masses=masses_wp,
+                cells=cells_wp,
+                cell_velocities=cell_velocities_wp,
+                virial_tensors=virial_wp,
+                eta=eta_wp,
+                eta_dot=eta_dot_wp,
+                thermostat_masses=thermostat_masses_wp,
+                cell_masses=cell_masses_wp,
+                target_temperature=target_temperature_wp,
+                target_pressure=target_pressure_wp,
+                num_atoms=num_atoms_wp,
+                chain_length=chain_length,
+                dt=dt_wp,
+                pressure_tensors=pressure_tensors_wp,
+                volumes=volumes_wp,
+                kinetic_energy=kinetic_energy_wp,
+                cells_inv=cells_inv_wp,
+                kinetic_tensors=kinetic_tensors_wp,
+                num_atoms_per_system=num_atoms_per_system_wp,
+                compute_forces_fn=None,
+                batch_idx=batch_idx_wp,
+                device="cpu",
+            )
+            npt.step(batch)
+
+        velocity_diff = (batch.velocities - ops_velocities).abs().max()
+        assert velocity_diff < 1e-3
 
     def test_zero_eta_dots_buffer_cache_is_bounded(self):
         """Legacy zero-eta buffer cache cannot grow without bound."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Fix high-level NPT particle velocity half-steps so explicit particle Nose-Hoover scaling is not combined with the NPT velocity primitive's inline thermostat drag. Update the Toolkit NPT barostat bridge to use an eta-free caller contract while zeroing `eta_dots` for legacy ops backends that still require the argument.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes to #95. Relates to #91

## Changes Made

- Route high-level `NPT.pre_update()` and `NPT.post_update()` particle velocity half-steps through `nph_velocity_half_step`.
- Update the `npt_barostat_half_step` bridge documentation and legacy-backend dispatch for eta-free Toolkit callers.
- Add a regression test that asserts high-level NPT uses the no-thermostat velocity primitive.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Staged whitespace/conflict check passed. Targeted high-level NPT/fused ops repro passed with final velocity diff `2.541e-05 < 1.0e-03`.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
