### PR TITLE
update mace wrapper to enable training

### DIFF
--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -358,7 +358,7 @@ class MACEWrapper(nn.Module, BaseModelMixin):
             # compute_displacement enables the MACE displacement trick required
             # for stress computation via autograd through cell @ neighbor_list_shifts.
             compute_displacement=compute_stresses,
-            training=False,  # Only inference supported right now.
+            training=self.training,
         )
         result = self.adapt_output(raw_output, data)
         return result

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -86,6 +86,7 @@ class MockMACEModel(torch.nn.Module):
 
         # Real parameter so _model_dtype works (next(model.parameters()).dtype).
         self._param = torch.nn.Linear(1, hidden_dim, bias=False)
+        self._param.weight.data.fill_(1.0)
         self._hidden_dim = hidden_dim
 
     def forward(
@@ -102,9 +103,10 @@ class MockMACEModel(torch.nn.Module):
         N = positions.shape[0]
         B = int(batch.max().item()) + 1 if N > 0 else 1
 
-        # Energy = sum of per-atom position norms, grouped by graph.
+        # Energy = sum of per-atom position norms, scaled by a parameter, and then grouped by graph.
         # Avoids zero-norm issues by clamping from below.
         norms = positions.pow(2).sum(dim=-1).clamp(min=1e-8).sqrt()  # [N]
+        norms = norms * self._param.weight[0, 0]
         energy = torch.zeros(B, dtype=positions.dtype, device=positions.device)
         energy.scatter_add_(0, batch, norms)
 

--- a/test/models/test_mace.py
+++ b/test/models/test_mace.py
@@ -523,6 +523,22 @@ class TestForward:
         assert forces.shape == (1, 3)
         assert torch.allclose(forces[0], torch.tensor([-1.0, 0.0, 0.0]), atol=1e-5)
 
+    def test_train_mode_works_with_optimizer(self, wrapper):
+        data = _make_single_atom()
+        batch = Batch.from_data_list([data])
+        optimizer = torch.optim.SGD(wrapper.parameters(), lr=0.1)
+        before = wrapper.model._param.weight.detach().clone()
+
+        wrapper.train()
+        optimizer.zero_grad()
+        out = wrapper.forward(batch)
+        loss = out["forces"].square().sum()
+        loss.backward()
+        optimizer.step()
+
+        after = wrapper.model._param.weight.detach()
+        assert not torch.allclose(after, before)
+
     def test_no_forces_when_disabled(self, wrapper, single_batch):
         wrapper.model_config.active_outputs = {"energy"}
         out = wrapper.forward(single_batch)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Changed training=False to training=self.training in MACEWrapper using the PyTorch's flag to be compatible with the upcoming model training workflow.
- Changed mock model used for MACE in unit test to be dependent on a trainable parameter so train mode test makes sense.
- Added a unit test to make sure that optimization now works when using MACEWrapper.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
