### PR TITLE
make PipelineModelWrapper trainable

### DIFF
--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -682,6 +682,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         # Determine what derivatives are requested beyond energies.
         if isinstance(data, AtomicData):
             data = Batch.from_data_list([data])
+        training_with_grad = self.training and torch.is_grad_enabled()
         requested_derivatives = self.model_config.active_outputs - {"energy"}
 
         # Collect all autograd_inputs that need requires_grad
@@ -703,6 +704,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         autograd_groups = [g for g in self.groups if g.use_autograd]
         group_outputs: list[ModelOutputs] = []
         autograd_count = len(autograd_groups)
+        effective_autograd_count = autograd_count + int(training_with_grad)
         autograd_idx = 0
 
         for group in self.groups:
@@ -713,8 +715,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                     context,
                     requested_derivatives,
                     autograd_idx,
-                    autograd_count,
+                    effective_autograd_count,
                     grad_keys,
+                    training=training_with_grad,
                     **kwargs,
                 )
                 autograd_idx += 1
@@ -729,6 +732,8 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
             group_outputs.append(group_out)
 
         result = sum_outputs(*group_outputs, additive_keys=self.additive_keys)
+        if training_with_grad:
+            return result
 
         # Detach all tensors from the computation graph.
         detached: ModelOutputs = OrderedDict()
@@ -786,6 +791,8 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         autograd_idx: int,
         autograd_count: int,
         grad_keys: set[str],
+        *,
+        training: bool,
         **kwargs: Any,
     ) -> ModelOutputs:
         """Run an autograd group: sum energies, then compute derivatives.
@@ -820,6 +827,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                 requested_derivatives,
                 strain,
                 retain_graph=autograd_idx < (autograd_count - 1),
+                training=training,
             )
         finally:
             self._restore_default_stress_strain(data, strain)
@@ -907,6 +915,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         strain: _AutogradStrainState,
         *,
         retain_graph: bool,
+        training: bool,
     ) -> ModelOutputs:
         """Build an autograd group output from step outputs and derivatives."""
         group_energy = None
@@ -934,6 +943,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                         displacement=strain.displacement,
                         orig_cell=strain.cell_for_stress,
                         retain_graph=retain_graph,
+                        training=training,
                     )
                 group_out.update(derivs)
 
@@ -1094,6 +1104,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         displacement: StrainDisplacement | None,
         orig_cell: LatticeVectors | None,
         retain_graph: bool,
+        training: bool = False,
     ) -> dict[str, torch.Tensor]:
         """Built-in derivative computation for autograd groups.
 
@@ -1117,12 +1128,18 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                 displacement,
                 orig_cell,
                 num_graphs,
+                training=training,
                 retain_graph=retain_graph,
             )
             return {"forces": forces, "stress": stress}
 
         if need_forces:
-            forces = autograd_forces(energy, data.positions, retain_graph=retain_graph)
+            forces = autograd_forces(
+                energy,
+                data.positions,
+                training=training,
+                retain_graph=retain_graph,
+            )
             return {"forces": forces}
 
         if need_stresses:
@@ -1136,6 +1153,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                 displacement,
                 orig_cell,
                 num_graphs,
+                training=training,
                 retain_graph=retain_graph,
             )
             return {"stress": stress}

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -683,14 +683,15 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         if isinstance(data, AtomicData):
             data = Batch.from_data_list([data])
         training_with_grad = self.training and torch.is_grad_enabled()
-        requested_derivatives = self.model_config.active_outputs - {"energy"}
+        requested_derivatives = self.model_config.active_outputs & self.model_config.autograd_outputs
 
         # Collect all autograd_inputs that need requires_grad
         grad_keys: set[str] = set()
         for group in self.groups:
             if group.use_autograd:
-                for step in group.steps:
-                    grad_keys |= step.model.model_config.autograd_inputs
+                if requested_derivatives:
+                    for step in group.steps:
+                        grad_keys |= step.model.model_config.autograd_inputs
             else:
                 for step in group.steps:
                     card = step.model.model_config

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -689,9 +689,8 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         grad_keys: set[str] = set()
         for group in self.groups:
             if group.use_autograd:
-                if requested_derivatives:
-                    for step in group.steps:
-                        grad_keys |= step.model.model_config.autograd_inputs
+                for step in group.steps:
+                    grad_keys |= step.model.model_config.autograd_inputs
             else:
                 for step in group.steps:
                     card = step.model.model_config

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -689,8 +689,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         grad_keys: set[str] = set()
         for group in self.groups:
             if group.use_autograd:
-                for step in group.steps:
-                    grad_keys |= step.model.model_config.autograd_inputs
+                if requested_derivatives:
+                    for step in group.steps:
+                        grad_keys |= step.model.model_config.autograd_inputs
             else:
                 for step in group.steps:
                     card = step.model.model_config

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -683,15 +683,14 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         if isinstance(data, AtomicData):
             data = Batch.from_data_list([data])
         training_with_grad = self.training and torch.is_grad_enabled()
-        requested_derivatives = self.model_config.active_outputs & self.model_config.autograd_outputs
+        requested_derivatives = self.model_config.active_outputs - {"energy"}
 
         # Collect all autograd_inputs that need requires_grad
         grad_keys: set[str] = set()
         for group in self.groups:
             if group.use_autograd:
-                if requested_derivatives:
-                    for step in group.steps:
-                        grad_keys |= step.model.model_config.autograd_inputs
+                for step in group.steps:
+                    grad_keys |= step.model.model_config.autograd_inputs
             else:
                 for step in group.steps:
                     card = step.model.model_config

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -510,6 +510,31 @@ class TestPipelineAutogradGroup:
         assert model.scale.grad is not None
         assert model.scale.grad.abs() > 0
 
+    def test_training_preserves_stress_graph_for_backward(self):
+        data = AtomicData(
+            positions=torch.randn(4, 3, dtype=torch.float64),
+            atomic_numbers=torch.tensor([6, 6, 8, 1]),
+            forces=torch.zeros(4, 3, dtype=torch.float64),
+            energy=torch.zeros(1, 1, dtype=torch.float64),
+            cell=torch.eye(3, dtype=torch.float64).unsqueeze(0) * 10.0,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+        model = MockTrainableAutogradEnergyModel().to(dtype=torch.float64)
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "stress"}
+        pipe.train()
+
+        out = pipe(batch)
+        loss = out["stress"].pow(2).sum()
+        loss.backward()
+
+        assert out["stress"].requires_grad
+        assert model.scale.grad is not None
+        assert model.scale.grad.abs() > 0
+
     def test_autograd_disables_sub_model_forces(self, simple_batch):
         """Autograd group strips forces at forward time, not permanently."""
         m = MockAutogradEnergyModel()

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -115,6 +115,41 @@ class MockAutogradEnergyModel(nn.Module, BaseModelMixin):
         return OrderedDict(energy=energies)
 
 
+class MockTrainableAutogradEnergyModel(nn.Module, BaseModelMixin):
+    """Mock autograd model with a trainable energy scale."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.scale = nn.Parameter(torch.tensor(1.0))
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy"}),
+            autograd_outputs=frozenset({"forces"}),
+            autograd_inputs=frozenset({"positions"}),
+            needs_pbc=False,
+            active_outputs={"energy"},
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {}
+
+    def compute_embeddings(self, data, **kwargs):
+        raise NotImplementedError
+
+    def forward(self, data, **kwargs) -> ModelOutputs:
+        positions = data.positions
+        B = data.num_graphs if isinstance(data, Batch) else 1
+        batch = (
+            data.batch_idx
+            if isinstance(data, Batch)
+            else torch.zeros(positions.shape[0], dtype=torch.long)
+        )
+        per_atom = self.scale * (positions**2).sum(dim=-1)
+        energies = torch.zeros(B, 1, dtype=positions.dtype, device=positions.device)
+        energies.scatter_add_(0, batch.unsqueeze(-1), per_atom.unsqueeze(-1))
+        return OrderedDict(energy=energies)
+
+
 class MockChargeEnergyModel(nn.Module, BaseModelMixin):
     """Mock model that outputs charges and energies (position-dependent for autograd)."""
 
@@ -458,6 +493,22 @@ class TestPipelineAutogradGroup:
         out = pipe(simple_batch)
         assert out["forces"].abs().sum() > 0
         assert out["energy"] is not None
+
+    def test_training_preserves_force_graph_for_backward(self, simple_batch):
+        model = MockTrainableAutogradEnergyModel()
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy", "forces"}
+        pipe.train()
+
+        out = pipe(simple_batch)
+        loss = out["forces"].pow(2).sum()
+        loss.backward()
+
+        assert out["forces"].requires_grad
+        assert model.scale.grad is not None
+        assert model.scale.grad.abs() > 0
 
     def test_autograd_disables_sub_model_forces(self, simple_batch):
         """Autograd group strips forces at forward time, not permanently."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Update PipelineModelWrapper so it can be used in training mode.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Update PipelineModelWrapper when self.training=True and grad is enabled.
- Add MockTrainableAutogradEnergyModel and test_training_preserves_force_graph_for_backward for testing.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
