### PR TITLE
fix: 🐛[BUG]: Docs rendering issues in generated API pages

### DIFF
--- a/nvalchemi/data/datapipes/backends/zarr.py
+++ b/nvalchemi/data/datapipes/backends/zarr.py
@@ -274,6 +274,9 @@ class AtomicDataZarrWriter:
     batch writes, appending, custom fields, soft-delete, and defragmentation.
 
     The Zarr store layout is:
+
+    .. code-block:: text
+
         dataset.zarr/
         ├── meta/                       # Pointer arrays + masks
         │   ├── atoms_ptr               # int64 [N+1] — cumulative node counts
@@ -1189,6 +1192,9 @@ class AtomicDataZarrReader(Reader):
     efficient random access using pointer arrays.
 
     The Zarr store layout expected is:
+
+    .. code-block:: text
+
         dataset.zarr/
         ├── meta/                       # Pointer arrays + masks
         │   ├── atoms_ptr               # int64 [N+1] — cumulative node counts


### PR DESCRIPTION
## Summary

Fixes the Sphinx rendering of the Zarr store layout ASCII trees in the `AtomicDataZarrWriter` and `AtomicDataZarrReader` docstrings. The trees now render as literal code blocks in the generated API docs instead of collapsing into a single paragraph.

## Root Cause

The Zarr store layout ASCII tree in the docstrings for `AtomicDataZarrWriter` and `AtomicDataZarrReader` was written as plain indented text directly after a colon. In reStructuredText (used by Sphinx), plain indented text does not preserve whitespace, so it collapses into ordinary paragraph text, breaking the tree structure.

## Change Made

**File:** `nvalchemi/data/datapipes/backends/zarr.py`

Added `.. code-block:: text` directives (with a blank line before and after the directive, and the tree content indented under it) for both affected docstring sections:

- `AtomicDataZarrWriter` docstring (~line 276): wrapped the store layout tree in `.. code-block:: text`
- `AtomicDataZarrReader` docstring (~line 1194): wrapped the store layout tree in `.. code-block:: text`

This ensures Sphinx renders the ASCII tree as a literal/code block, preserving indentation and line structure.

## Issue

Fixes #98

**Issue URL:** https://github.com/NVIDIA/nvalchemi-toolkit/issues/98

## Changes

```
nvalchemi/data/datapipes/backends/zarr.py | 6 ++++++
1 file changed, 6 insertions(+)
```

## Testing

- Agent ran relevant tests during development
- Linting checks passed
- Changes are minimal and focused on the issue

## AI Assistance Disclosure

This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
