### PR TITLE
Expose Slab Correction in Electrostatics Wrappers

### DIFF
--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -94,6 +94,9 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
     coulomb_constant : float, optional
         Coulomb prefactor :math:`k_e` in eV·Å/e².
         Defaults to ``14.3996`` (standard value for Å/e/eV unit system).
+    slab_correction : bool, optional
+        Whether to enable the two-dimensional slab correction. Defaults to
+        ``False``.
 
 
     Attributes
@@ -116,12 +119,14 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         accuracy: float = 1e-6,
         coulomb_constant: float = 14.3996,
         hybrid_forces: bool = True,
+        slab_correction: bool = False,
     ) -> None:
         super().__init__()
         self.cutoff = cutoff
         self.accuracy = accuracy
         self.coulomb_constant = coulomb_constant
         self.hybrid_forces = hybrid_forces
+        self.slab_correction = slab_correction
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
             active_outputs={"energy", "forces"},
@@ -268,6 +273,15 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
                 "(data.cell must be present)."
             )
 
+        if self.slab_correction:
+            try:
+                input_dict["pbc"] = data.pbc  # (B, 3)
+            except AttributeError:
+                raise ValueError(
+                    "EwaldModelWrapper with slab_correction=True requires "
+                    "periodic boundary condition flags (data.pbc must be present)."
+                )
+
         # neighbor_matrix and num_neighbors are already collected by the
         # input_data() loop above.  In a pipeline, the pipeline adapts them
         # to this model's cutoff/format before calling forward().
@@ -327,8 +341,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             ``-W/V``).
         """
         from nvalchemiops.torch.interactions.electrostatics.ewald import (  # lazy
-            ewald_real_space,
-            ewald_reciprocal_space,
+            ewald_summation,
         )
 
         inp = self.adapt_input(data, **kwargs)
@@ -343,6 +356,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         B: int = inp["num_graphs"]
         neighbor_matrix = inp["neighbor_matrix"].contiguous()
         neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        pbc = inp.get("pbc")
 
         compute_forces = "forces" in self.model_config.active_outputs
         compute_stresses = "stress" in self.model_config.active_outputs
@@ -385,36 +399,32 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
                 self._null_shifts_shape = (N, K)
             neighbor_matrix_shifts = self._null_shifts
 
-        # --- Real-space contribution ---
-        real_result = ewald_real_space(
-            positions=positions,
-            charges=charges,
-            cell=cell,
-            alpha=alpha,
-            neighbor_matrix=neighbor_matrix,
-            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
-            mask_value=fill_value,
-            batch_idx=batch_idx,
-            compute_forces=compute_forces,
-            compute_virial=compute_stresses,
-            hybrid_forces=self.hybrid_forces,
-        )
+        try:
+            result = ewald_summation(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=alpha,
+                k_vectors=k_vectors,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+                mask_value=fill_value,
+                batch_idx=batch_idx,
+                compute_forces=compute_forces,
+                compute_virial=compute_stresses,
+                hybrid_forces=self.hybrid_forces,
+                pbc=pbc,
+                slab_correction=self.slab_correction,
+            )
+        except ValueError as exc:
+            if compute_stresses and "not enough values to unpack" in str(exc):
+                raise RuntimeError(
+                    "stress was requested but the kernel did not return a virial"
+                ) from exc
+            raise
 
-        # --- Reciprocal-space contribution ---
-        recip_result = ewald_reciprocal_space(
-            positions=positions,
-            charges=charges,
-            cell=cell,
-            k_vectors=k_vectors,
-            alpha=alpha,
-            batch_idx=batch_idx,
-            compute_forces=compute_forces,
-            compute_virial=compute_stresses,
-            hybrid_forces=self.hybrid_forces,
-        )
-
-        # Unpack results (energies always first; forces and virial follow
-        # in the order they were requested).
+        # Unpack results (energies always first; forces and virial follow in
+        # the order they were requested).
         def _unpack(result, compute_f: bool, compute_v: bool):
             """Extract (energies, forces_or_None, virial_or_None) from result."""
             if isinstance(result, torch.Tensor):
@@ -431,23 +441,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
                 v = result_list[idx]
             return e, f, v
 
-        e_real, f_real, v_real = _unpack(real_result, compute_forces, compute_stresses)
-        e_recip, f_recip, v_recip = _unpack(
-            recip_result, compute_forces, compute_stresses
+        per_atom_energies, forces, virial = _unpack(
+            result, compute_forces, compute_stresses
         )
-
-        # Sum real + reciprocal contributions.
-        per_atom_energies = (e_real + e_recip).to(
-            positions.dtype
-        )  # (N,) float64->dtype
-
-        forces: torch.Tensor | None = None
-        if compute_forces and f_real is not None and f_recip is not None:
-            forces = f_real + f_recip  # (N, 3)
-
-        virial: torch.Tensor | None = None
-        if compute_stresses and v_real is not None and v_recip is not None:
-            virial = v_real + v_recip  # (B, 3, 3)
+        per_atom_energies = per_atom_energies.to(positions.dtype)
 
         # Scale by Coulomb constant.
         per_atom_energies = per_atom_energies * self.coulomb_constant

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -96,8 +96,11 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         Defaults to ``14.3996`` (standard value for Å/e/eV unit system).
     slab_correction : bool, optional
         Whether to enable the two-dimensional slab correction. Defaults to
-        ``False``.
-
+        ``False``. When enabled, the input batch must provide ``data.pbc`` as
+        a boolean tensor with shape ``(B, 3)``. Rows with exactly one
+        ``False`` entry mark slab systems, for example ``[True, True, False]``
+        for a non-periodic z axis. Fully periodic rows are no-ops, so mixed
+        slab and three-dimensional periodic batches are supported.
 
     Attributes
     ----------
@@ -189,7 +192,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
 
     def input_data(self) -> set[str]:
         """Return required input keys (override to drop ``atomic_numbers``)."""
-        return {"positions", "charges", "neighbor_matrix", "num_neighbors"}
+        keys = {"positions", "charges", "neighbor_matrix", "num_neighbors"}
+        if self.slab_correction:
+            keys.add("pbc")
+        return keys
 
     # ------------------------------------------------------------------
     # Cache management
@@ -256,6 +262,12 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         for key in self.input_data():
             value = getattr(data, key, None)
             if value is None:
+                if key == "pbc" and self.slab_correction:
+                    raise ValueError(
+                        "EwaldModelWrapper with slab_correction=True requires "
+                        "periodic boundary condition flags "
+                        "(data.pbc must be present)."
+                    )
                 raise KeyError(f"'{key}' required but not found in input data.")
             input_dict[key] = value
 
@@ -274,13 +286,13 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             )
 
         if self.slab_correction:
-            try:
-                input_dict["pbc"] = data.pbc  # (B, 3)
-            except AttributeError:
+            pbc = getattr(data, "pbc", None)
+            if pbc is None:
                 raise ValueError(
                     "EwaldModelWrapper with slab_correction=True requires "
                     "periodic boundary condition flags (data.pbc must be present)."
                 )
+            input_dict["pbc"] = pbc  # (B, 3)
 
         # neighbor_matrix and num_neighbors are already collected by the
         # input_data() loop above.  In a pipeline, the pipeline adapts them
@@ -399,29 +411,22 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
                 self._null_shifts_shape = (N, K)
             neighbor_matrix_shifts = self._null_shifts
 
-        try:
-            result = ewald_summation(
-                positions=positions,
-                charges=charges,
-                cell=cell,
-                alpha=alpha,
-                k_vectors=k_vectors,
-                neighbor_matrix=neighbor_matrix,
-                neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
-                mask_value=fill_value,
-                batch_idx=batch_idx,
-                compute_forces=compute_forces,
-                compute_virial=compute_stresses,
-                hybrid_forces=self.hybrid_forces,
-                pbc=pbc,
-                slab_correction=self.slab_correction,
-            )
-        except ValueError as exc:
-            if compute_stresses and "not enough values to unpack" in str(exc):
-                raise RuntimeError(
-                    "stress was requested but the kernel did not return a virial"
-                ) from exc
-            raise
+        result = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=alpha,
+            k_vectors=k_vectors,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts.contiguous(),
+            mask_value=fill_value,
+            batch_idx=batch_idx,
+            compute_forces=compute_forces,
+            compute_virial=compute_stresses,
+            hybrid_forces=self.hybrid_forces,
+            pbc=pbc,
+            slab_correction=self.slab_correction,
+        )
 
         # Unpack results (energies always first; forces and virial follow in
         # the order they were requested).

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -109,6 +109,9 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
     coulomb_constant : float, optional
         Coulomb prefactor :math:`k_e` in eV·Å/e².
         Defaults to ``14.3996`` (standard value for Å/e/eV unit system).
+    slab_correction : bool, optional
+        Whether to enable the two-dimensional slab correction. Defaults to
+        ``False``.
 
     Attributes
     ----------
@@ -134,6 +137,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         accuracy: float = 1e-6,
         coulomb_constant: float = 14.3996,
         hybrid_forces: bool = True,
+        slab_correction: bool = False,
     ) -> None:
         super().__init__()
         self.cutoff = cutoff
@@ -144,6 +148,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         self.accuracy = accuracy
         self.coulomb_constant = coulomb_constant
         self.hybrid_forces = hybrid_forces
+        self.slab_correction = slab_correction
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
             active_outputs={"energy", "forces"},
@@ -304,6 +309,15 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
                 "(data.cell must be present)."
             )
 
+        if self.slab_correction:
+            try:
+                input_dict["pbc"] = data.pbc  # (B, 3)
+            except AttributeError:
+                raise ValueError(
+                    "PMEModelWrapper with slab_correction=True requires periodic "
+                    "boundary condition flags (data.pbc must be present)."
+                )
+
         # neighbor_matrix and num_neighbors are already collected by the
         # input_data() loop above.  In a pipeline, the pipeline adapts them
         # to this model's cutoff/format before calling forward().
@@ -377,6 +391,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         B: int = inp["num_graphs"]
         neighbor_matrix = inp["neighbor_matrix"].contiguous()
         neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
+        pbc = inp.get("pbc")
 
         compute_forces = "forces" in self.model_config.active_outputs
         compute_stresses = "stress" in self.model_config.active_outputs
@@ -450,6 +465,8 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             compute_virial=compute_stresses,
             accuracy=self.accuracy,
             hybrid_forces=self.hybrid_forces,
+            pbc=pbc,
+            slab_correction=self.slab_correction,
         )
 
         # Unpack tuple: (energies, [forces], [virial]).

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -111,7 +111,11 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         Defaults to ``14.3996`` (standard value for Å/e/eV unit system).
     slab_correction : bool, optional
         Whether to enable the two-dimensional slab correction. Defaults to
-        ``False``.
+        ``False``. When enabled, the input batch must provide ``data.pbc`` as
+        a boolean tensor with shape ``(B, 3)``. Rows with exactly one
+        ``False`` entry mark slab systems, for example ``[True, True, False]``
+        for a non-periodic z axis. Fully periodic rows are no-ops, so mixed
+        slab and three-dimensional periodic batches are supported.
 
     Attributes
     ----------
@@ -212,7 +216,10 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
 
     def input_data(self) -> set[str]:
         """Return required input keys (override to drop ``atomic_numbers``)."""
-        return {"positions", "charges", "neighbor_matrix", "num_neighbors"}
+        keys = {"positions", "charges", "neighbor_matrix", "num_neighbors"}
+        if self.slab_correction:
+            keys.add("pbc")
+        return keys
 
     # ------------------------------------------------------------------
     # Cache management
@@ -292,6 +299,11 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         for key in self.input_data():
             value = getattr(data, key, None)
             if value is None:
+                if key == "pbc" and self.slab_correction:
+                    raise ValueError(
+                        "PMEModelWrapper with slab_correction=True requires periodic "
+                        "boundary condition flags (data.pbc must be present)."
+                    )
                 raise KeyError(f"'{key}' required but not found in input data.")
             input_dict[key] = value
 
@@ -310,13 +322,13 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             )
 
         if self.slab_correction:
-            try:
-                input_dict["pbc"] = data.pbc  # (B, 3)
-            except AttributeError:
+            pbc = getattr(data, "pbc", None)
+            if pbc is None:
                 raise ValueError(
                     "PMEModelWrapper with slab_correction=True requires periodic "
                     "boundary condition flags (data.pbc must be present)."
                 )
+            input_dict["pbc"] = pbc  # (B, 3)
 
         # neighbor_matrix and num_neighbors are already collected by the
         # input_data() loop above.  In a pipeline, the pipeline adapts them

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -208,6 +208,11 @@ class TestEwaldInputOutput:
         assert "neighbor_matrix" in keys
         assert "num_neighbors" in keys
 
+    def test_input_data_includes_pbc_for_slab_correction(self):
+        """Slab-enabled Ewald declares pbc as a required input."""
+        w = _make_ewald(slab_correction=True)
+        assert "pbc" in w.input_data()
+
     def test_output_data_with_forces(self):
         w = _make_ewald()
         out = w.output_data()
@@ -514,15 +519,14 @@ class TestEwaldIntegration:
 
     def test_forward_stress_is_negative_virial_over_volume(self):
         """ASE-style stress == -virial / volume (eV/A^3)."""
-        w = _make_ewald()
+        w = _make_ewald(slab_correction=True)
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch(box_size=10.0)
         self._build_nl(batch, w)
 
-        real_virial_value = 2.0
-        recip_virial_value = 3.0
+        virial_value = 5.0
 
-        def fake_real_space(**kw):
+        def fake_ewald_summation(**kw):
             positions = kw["positions"]
             cell = kw["cell"]
             return (
@@ -532,49 +536,30 @@ class TestEwaldIntegration:
                 torch.zeros_like(positions),
                 torch.full(
                     (cell.shape[0], 3, 3),
-                    real_virial_value,
+                    virial_value,
                     dtype=positions.dtype,
                     device=positions.device,
                 ),
             )
 
-        def fake_reciprocal_space(**kw):
-            positions = kw["positions"]
-            cell = kw["cell"]
-            return (
-                torch.zeros(
-                    positions.shape[0], dtype=positions.dtype, device=positions.device
-                ),
-                torch.zeros_like(positions),
-                torch.full(
-                    (cell.shape[0], 3, 3),
-                    recip_virial_value,
-                    dtype=positions.dtype,
-                    device=positions.device,
-                ),
-            )
-
-        with (
-            patch(
-                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_real_space",
-                side_effect=fake_real_space,
-            ),
-            patch(
-                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_reciprocal_space",
-                side_effect=fake_reciprocal_space,
-            ),
-        ):
+        with patch(
+            "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_summation",
+            side_effect=fake_ewald_summation,
+        ) as mock_ewald_summation:
             out = w.forward(batch)
 
+        call_kwargs = mock_ewald_summation.call_args.kwargs
+        torch.testing.assert_close(call_kwargs["pbc"], batch.pbc)
+        assert call_kwargs["slab_correction"] is True
+        assert call_kwargs["compute_virial"] is True
+
         volume = torch.det(batch.cell).abs().view(-1, 1, 1)
-        expected = (
-            -(real_virial_value + recip_virial_value) * w.coulomb_constant / volume
-        )
+        expected = -virial_value * w.coulomb_constant / volume
         torch.testing.assert_close(out["stress"], expected.expand_as(out["stress"]))
 
     def test_forward_raises_when_virial_none(self):
         """RuntimeError when stress is requested but kernels return no virial."""
-        w = _make_ewald()
+        w = _make_ewald(slab_correction=True)
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch()
         self._build_nl(batch, w)
@@ -586,18 +571,17 @@ class TestEwaldIntegration:
             forces = torch.zeros(N, 3, dtype=torch.float64)
             return energies, forces
 
-        with (
-            patch(
-                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_real_space",
-                side_effect=_fake_kernel,
-            ),
-            patch(
-                "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_reciprocal_space",
-                side_effect=_fake_kernel,
-            ),
-        ):
+        with patch(
+            "nvalchemiops.torch.interactions.electrostatics.ewald.ewald_summation",
+            side_effect=_fake_kernel,
+        ) as mock_ewald_summation:
             with pytest.raises(RuntimeError, match="kernel did not return a virial"):
                 w.forward(batch)
+
+        call_kwargs = mock_ewald_summation.call_args.kwargs
+        torch.testing.assert_close(call_kwargs["pbc"], batch.pbc)
+        assert call_kwargs["slab_correction"] is True
+        assert call_kwargs["compute_virial"] is True
 
     def test_cache_populated_after_forward(self):
         w = _make_ewald()

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -242,6 +242,11 @@ class TestPMEInputOutput:
         assert "neighbor_matrix" in keys
         assert "num_neighbors" in keys
 
+    def test_input_data_includes_pbc_for_slab_correction(self):
+        """Slab-enabled PME declares pbc as a required input."""
+        w = _make_pme(slab_correction=True)
+        assert "pbc" in w.input_data()
+
     def test_output_data_with_forces(self):
         w = _make_pme()
         out = w.output_data()

--- a/test/models/test_slab.py
+++ b/test/models/test_slab.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Slab-correction tests for electrostatics model wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import torch
+
+from nvalchemi.data import AtomicData, Batch
+from test.models.test_ewald import (
+    _finite_difference_charge_gradient,
+    _make_charged_batch,
+    _make_ewald,
+)
+from test.models.test_pme import _make_pme
+
+
+def _make_model(method: str, slab_correction: bool) -> Any:
+    """Construct an electrostatics wrapper with stable slab-test defaults."""
+    if method == "ewald":
+        return _make_ewald(cutoff=8.0, slab_correction=slab_correction)
+    if method == "pme":
+        return _make_pme(
+            cutoff=8.0,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            slab_correction=slab_correction,
+        )
+    raise ValueError(f"Unknown electrostatics method: {method}")
+
+
+def _add_empty_matrix_neighbors(batch: Batch, max_neighbors: int = 8) -> None:
+    """Attach placeholder matrix-neighbor fields for adapt_input-only tests."""
+    num_atoms = batch.num_nodes
+    object.__setattr__(
+        batch,
+        "neighbor_matrix",
+        torch.full((num_atoms, max_neighbors), num_atoms, dtype=torch.int32),
+    )
+    object.__setattr__(
+        batch, "num_neighbors", torch.zeros(num_atoms, dtype=torch.int32)
+    )
+    batch._neighbor_list_cutoff = 15.0
+
+
+def _make_cell(
+    pbc: tuple[bool, bool, bool],
+    dtype: torch.dtype = torch.float64,
+    device: str = "cpu",
+) -> torch.Tensor:
+    """Create a diagonal cell with vacuum along non-periodic slab axes."""
+    lengths = torch.tensor(
+        [12.0 if periodic else 36.0 for periodic in pbc],
+        dtype=dtype,
+        device=device,
+    )
+    return torch.diag(lengths).unsqueeze(0)
+
+
+def _make_batch_without_pbc() -> Batch:
+    """Build a charged periodic-cell batch that intentionally omits pbc."""
+    num_atoms = 4
+    positions = torch.rand(num_atoms, 3) * 10.0
+    atomic_numbers = torch.ones(num_atoms, dtype=torch.long)
+    charges = torch.tensor([1.0, -1.0, 1.0, -1.0])
+    data = AtomicData(
+        positions=positions,
+        atomic_numbers=atomic_numbers,
+        charges=charges,
+        forces=torch.zeros_like(positions),
+        energy=torch.zeros(1, 1),
+        cell=torch.eye(3).unsqueeze(0) * 10.0,
+    )
+    return Batch.from_data_list([data])
+
+
+def _make_oriented_slab_batch(
+    pbc: tuple[bool, bool, bool],
+    dtype: torch.dtype = torch.float64,
+    device: str = "cpu",
+) -> Batch:
+    """Build a small neutral slab with a dipole along the non-periodic axis."""
+    nonperiodic_axis = pbc.index(False)
+    positions = torch.tensor(
+        [
+            [2.0, 2.0, 2.0],
+            [4.0, 2.0, 2.0],
+            [2.0, 4.0, 2.0],
+            [4.0, 4.0, 2.0],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    positions[1, nonperiodic_axis] += 5.0
+    positions[3, nonperiodic_axis] += 5.0
+    charges = torch.tensor([1.0, -1.0, 0.5, -0.5], dtype=dtype, device=device)
+    atomic_numbers = torch.ones(positions.shape[0], dtype=torch.long, device=device)
+    data = AtomicData(
+        positions=positions,
+        atomic_numbers=atomic_numbers,
+        charges=charges,
+        forces=torch.zeros_like(positions),
+        energy=torch.zeros(1, 1, dtype=dtype, device=device),
+        cell=_make_cell(pbc, dtype=dtype, device=device),
+        pbc=torch.tensor([pbc], dtype=torch.bool, device=device),
+    )
+    return Batch.from_data_list([data])
+
+
+def _make_mixed_slab_batch(
+    pbc: tuple[bool, bool, bool], dtype: torch.dtype = torch.float64
+) -> Batch:
+    """Build one 2D-periodic slab system and one fully 3D-periodic system."""
+    slab = _make_oriented_slab_batch(pbc, dtype=dtype).get_data(0)
+    torch.manual_seed(123)
+    periodic = _make_charged_batch(n_atoms=4, box_size=12.0, dtype=dtype).get_data(0)
+    return Batch.from_data_list([slab, periodic])
+
+
+def _build_nl(batch: Batch, model: Any) -> None:
+    """Build matrix neighbors for the wrapper under test."""
+    from nvalchemi.neighbors import compute_neighbors
+
+    compute_neighbors(batch, config=model.model_config.neighbor_config)
+
+
+def _run_model(
+    batch: Batch, method: str, slab_correction: bool
+) -> dict[str, torch.Tensor]:
+    """Evaluate an electrostatics wrapper with energy, forces, and stress."""
+    model = _make_model(method, slab_correction=slab_correction)
+    model.model_config.active_outputs = {"energy", "forces", "stress"}
+    _build_nl(batch, model)
+    return model(batch)
+
+
+def _assert_outputs_close(actual: dict, expected: dict) -> None:
+    """Assert model energy, forces, and stress are numerically close."""
+    torch.testing.assert_close(actual["energy"], expected["energy"])
+    torch.testing.assert_close(actual["forces"], expected["forces"])
+    torch.testing.assert_close(actual["stress"], expected["stress"])
+
+
+@pytest.mark.parametrize(
+    "model_factory",
+    [
+        pytest.param(lambda slab: _make_ewald(slab_correction=slab), id="ewald"),
+        pytest.param(lambda slab: _make_pme(slab_correction=slab), id="pme"),
+    ],
+)
+class TestSlabAdaptInput:
+    """Slab-specific input adaptation tests."""
+
+    def test_pbc_is_omitted_when_slab_correction_disabled(
+        self, model_factory: Callable[[bool], object]
+    ) -> None:
+        """Non-slab wrappers preserve the existing input contract."""
+        model = model_factory(False)
+        batch = _make_charged_batch()
+        _add_empty_matrix_neighbors(batch)
+
+        inputs = model.adapt_input(batch)
+
+        assert "pbc" not in inputs
+
+    def test_pbc_is_collected_when_slab_correction_enabled(
+        self, model_factory: Callable[[bool], object]
+    ) -> None:
+        """Slab wrappers pass periodicity flags through to nvalchemiops."""
+        model = model_factory(True)
+        batch = _make_charged_batch()
+        _add_empty_matrix_neighbors(batch)
+
+        inputs = model.adapt_input(batch)
+
+        assert "pbc" in inputs
+        torch.testing.assert_close(inputs["pbc"], batch.pbc)
+
+    def test_slab_correction_requires_pbc_flags(
+        self, model_factory: Callable[[bool], object]
+    ) -> None:
+        """Slab wrappers fail clearly when cell exists but pbc is missing."""
+        model = model_factory(True)
+        batch = _make_batch_without_pbc()
+        _add_empty_matrix_neighbors(batch)
+
+        with pytest.raises(ValueError, match="data.pbc must be present"):
+            model.adapt_input(batch)
+
+
+class TestElectrostaticsSlabCorrection:
+    """End-to-end slab-correction behavior for Ewald and PME wrappers."""
+
+    @pytest.fixture(autouse=True)
+    def _require_ops(self):
+        pytest.importorskip("nvalchemiops")
+
+    @pytest.mark.parametrize("method", ["ewald", "pme"])
+    def test_ttt_slab_correction_is_noop(self, method: str) -> None:
+        """Fully 3D-periodic systems are unchanged by slab_correction=True."""
+        torch.manual_seed(42)
+        batch = _make_charged_batch(dtype=torch.float64)
+
+        slab_off = _run_model(batch, method, slab_correction=False)
+        slab_on = _run_model(batch, method, slab_correction=True)
+
+        _assert_outputs_close(slab_on, slab_off)
+
+    @pytest.mark.parametrize(
+        "pbc",
+        [
+            pytest.param((True, True, False), id="ttf"),
+            pytest.param((True, False, True), id="tft"),
+            pytest.param((False, True, True), id="ftt"),
+        ],
+    )
+    @pytest.mark.parametrize("method", ["ewald", "pme"])
+    def test_2d_slab_correction_changes_energy(
+        self, method: str, pbc: tuple[bool, bool, bool]
+    ) -> None:
+        """Each slab orientation receives a non-zero slab energy correction."""
+        batch = _make_oriented_slab_batch(pbc)
+
+        slab_off = _run_model(batch, method, slab_correction=False)
+        slab_on = _run_model(batch, method, slab_correction=True)
+
+        assert not torch.allclose(slab_on["energy"], slab_off["energy"])
+
+    @pytest.mark.parametrize("method", ["ewald", "pme"])
+    @pytest.mark.parametrize(
+        "pbc",
+        [
+            pytest.param((True, True, False), id="ttf"),
+            pytest.param((True, False, True), id="tft"),
+            pytest.param((False, True, True), id="ftt"),
+        ],
+    )
+    def test_mixed_batch_only_corrects_2d_periodic_system(
+        self, method: str, pbc: tuple[bool, bool, bool]
+    ) -> None:
+        """Mixed batches can combine one slab system and one 3D-periodic system."""
+        batch = _make_mixed_slab_batch(pbc)
+
+        slab_off = _run_model(batch, method, slab_correction=False)
+        slab_on = _run_model(batch, method, slab_correction=True)
+
+        assert not torch.allclose(slab_on["energy"][0], slab_off["energy"][0])
+        torch.testing.assert_close(slab_on["energy"][1], slab_off["energy"][1])
+
+        slab_atoms = batch.batch_idx == 0
+        periodic_atoms = batch.batch_idx == 1
+        assert not torch.allclose(
+            slab_on["forces"][slab_atoms], slab_off["forces"][slab_atoms]
+        )
+        torch.testing.assert_close(
+            slab_on["forces"][periodic_atoms], slab_off["forces"][periodic_atoms]
+        )
+
+    @pytest.mark.parametrize(
+        "pbc",
+        [
+            pytest.param((True, True, False), id="ttf"),
+            pytest.param((True, False, True), id="tft"),
+            pytest.param((False, True, True), id="ftt"),
+        ],
+    )
+    @pytest.mark.parametrize("method", ["ewald", "pme"])
+    def test_slab_charge_gradient_matches_finite_difference(
+        self, method: str, pbc: tuple[bool, bool, bool]
+    ) -> None:
+        """Slab energy backward recovers finite-difference charge gradients."""
+        model = _make_model(method, slab_correction=True)
+        batch = _make_oriented_slab_batch(pbc)
+
+        fd_grad = _finite_difference_charge_gradient(model, batch, _build_nl)
+        batch.charges = batch.charges.detach().requires_grad_(True)
+        out = model(batch)
+        out["energy"].sum().backward()
+
+        assert batch.charges.grad is not None
+        torch.testing.assert_close(batch.charges.grad, fd_grad, atol=5e-5, rtol=5e-4)

--- a/test/models/test_slab.py
+++ b/test/models/test_slab.py
@@ -203,6 +203,18 @@ class TestSlabAdaptInput:
         with pytest.raises(ValueError, match="data.pbc must be present"):
             model.adapt_input(batch)
 
+    def test_slab_correction_rejects_none_pbc(
+        self, model_factory: Callable[[bool], object]
+    ) -> None:
+        """Slab wrappers fail clearly when pbc exists but is None."""
+        model = model_factory(True)
+        batch = _make_charged_batch()
+        _add_empty_matrix_neighbors(batch)
+        batch.pbc = None
+
+        with pytest.raises(ValueError, match="data.pbc must be present"):
+            model.adapt_input(batch)
+
 
 class TestElectrostaticsSlabCorrection:
     """End-to-end slab-correction behavior for Ewald and PME wrappers."""
@@ -241,6 +253,7 @@ class TestElectrostaticsSlabCorrection:
         slab_on = _run_model(batch, method, slab_correction=True)
 
         assert not torch.allclose(slab_on["energy"], slab_off["energy"])
+        assert not torch.allclose(slab_on["stress"], slab_off["stress"])
 
     @pytest.mark.parametrize("method", ["ewald", "pme"])
     @pytest.mark.parametrize(
@@ -262,6 +275,8 @@ class TestElectrostaticsSlabCorrection:
 
         assert not torch.allclose(slab_on["energy"][0], slab_off["energy"][0])
         torch.testing.assert_close(slab_on["energy"][1], slab_off["energy"][1])
+        assert not torch.allclose(slab_on["stress"][0], slab_off["stress"][0])
+        torch.testing.assert_close(slab_on["stress"][1], slab_off["stress"][1])
 
         slab_atoms = batch.batch_idx == 0
         periodic_atoms = batch.batch_idx == 1


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Adds `slab_correction` support to Toolkit Ewald/PME wrappers, passing slab pbc geometry into ops only when requested. Refactors Ewald to use the full `ewald_summation` wrapper so slab composition and hybrid charge-gradient behavior stay consistent with ops.

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Added `slab_correction` constructor arg to Ewald and PME wrappers.
- Passed `data.pbc` through only when slab correction is enabled.
- Routed Ewald through `ewald_summation` and PME through `particle_mesh_ewald` with slab args.
- Preserved existing stress/virial error behavior.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
