### PR TITLE
Fix NVT Nose-Hoover scale reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **NVT Nosé-Hoover velocity collapse** (#104) — reset the NHC
+  `total_scale` scratch accumulator to the multiplicative identity on
+  each chain update, preventing persistent state from zeroing or
+  compounding velocity rescaling.
 - **MTK NPT barostat runaway** (#89, #90) — four bugs in
   `nvalchemi/dynamics/integrators/npt.py` (with matching fixes in
   `nph.py`) that combined to drive unbounded cell-volume drift in long

--- a/nvalchemi/dynamics/_ops/nose_hoover.py
+++ b/nvalchemi/dynamics/_ops/nose_hoover.py
@@ -128,7 +128,15 @@ def nhc_compute_masses(
 
 @torch.library.custom_op(
     "nvalchemi::nhc_chain_update",
-    mutates_args={"velocities", "eta", "eta_dot", "ke2", "total_scale", "step_scale"},
+    mutates_args={
+        "velocities",
+        "eta",
+        "eta_dot",
+        "ke2",
+        "total_scale",
+        "step_scale",
+        "dt_chain",
+    },
 )
 def nhc_chain_update(
     velocities: torch.Tensor,
@@ -173,7 +181,8 @@ def nhc_chain_update(
     ke2 : torch.Tensor
         Scratch buffer ``[M]``, same dtype.  Written by kernel.
     total_scale : torch.Tensor
-        Scratch buffer ``[M]``, same dtype.  Written by kernel.
+        Scratch buffer ``[M]``, same dtype.  Reset to ``1.0`` by this wrapper,
+        then written by kernel.
     step_scale : torch.Tensor
         Scratch buffer ``[M]``, same dtype.  Written by kernel.
     dt_chain : torch.Tensor
@@ -185,6 +194,7 @@ def nhc_chain_update(
     dtype = velocities.dtype
     vec_t = _vec_type(dtype)
     scl_t = _scalar_type(dtype)
+    total_scale.fill_(1.0)
     _nhc_chain_update(
         wp.from_torch(velocities, dtype=vec_t),
         wp.from_torch(masses, dtype=scl_t),

--- a/test/dynamics/test_ops.py
+++ b/test/dynamics/test_ops.py
@@ -438,6 +438,15 @@ class TestNoseHoover:
         Q = nhc_compute_masses(temp, tau, mass, batch, C)
         assert (Q > 0).all()
 
+    def test_chain_update_schema_marks_dt_chain_mutable(self):
+        from nvalchemi.dynamics._ops.nose_hoover import nhc_chain_update
+
+        assert nhc_chain_update is not None
+        schema = torch.ops.nvalchemi.nhc_chain_update.default._schema
+        args = {arg.name: arg for arg in schema.arguments}
+        assert args["dt_chain"].alias_info is not None
+        assert args["dt_chain"].alias_info.is_write
+
     def test_chain_update_mutates_velocities(self, dtype, device):
         from nvalchemi.dynamics._ops.nose_hoover import (
             nhc_chain_update,
@@ -473,6 +482,87 @@ class TestNoseHoover:
         assert vel.shape == vel_orig.shape
         # Velocities should be scaled (modified) by thermostat.
         assert not torch.allclose(vel, vel_orig)
+        assert float(vel.norm()) > 0.0
+        assert torch.all(total_scale > 0.0)
+
+    def test_chain_update_resets_total_scale_each_call(self, dtype, device):
+        from nvalchemi.dynamics._ops.nose_hoover import (
+            nhc_chain_update,
+            nhc_compute_masses,
+        )
+
+        M, N, C = 1, 4, 3
+        vel, mass, eta, eta_dot, temp, tau, dt, batch = self._make_nhc_state(
+            M, N, C, dtype, device
+        )
+        Q = nhc_compute_masses(temp, tau, mass, batch, C)
+        ndof = torch.full((M,), N * 3, dtype=torch.int32, device=device)
+        ke2 = torch.zeros(M, dtype=dtype, device=device)
+        total_scale = torch.ones(M, dtype=dtype, device=device)
+        step_scale = torch.zeros(M, dtype=dtype, device=device)
+        dt_chain = torch.zeros(M, dtype=dtype, device=device)
+
+        nhc_chain_update(
+            vel,
+            mass,
+            eta,
+            eta_dot,
+            Q,
+            temp,
+            dt,
+            ndof,
+            ke2,
+            total_scale,
+            step_scale,
+            dt_chain,
+            batch,
+        )
+
+        vel_stale = vel.clone()
+        eta_stale = eta.clone()
+        eta_dot_stale = eta_dot.clone()
+        total_scale_stale = total_scale.clone()
+        vel_fresh = vel.clone()
+        eta_fresh = eta.clone()
+        eta_dot_fresh = eta_dot.clone()
+        total_scale_fresh = torch.ones(M, dtype=dtype, device=device)
+        total_scale_stale.fill_(0.5)
+
+        nhc_chain_update(
+            vel_stale,
+            mass,
+            eta_stale,
+            eta_dot_stale,
+            Q,
+            temp,
+            dt,
+            ndof,
+            ke2.clone(),
+            total_scale_stale,
+            step_scale.clone(),
+            dt_chain.clone(),
+            batch,
+        )
+        nhc_chain_update(
+            vel_fresh,
+            mass,
+            eta_fresh,
+            eta_dot_fresh,
+            Q,
+            temp,
+            dt,
+            ndof,
+            ke2.clone(),
+            total_scale_fresh,
+            step_scale.clone(),
+            dt_chain.clone(),
+            batch,
+        )
+
+        assert torch.allclose(vel_stale, vel_fresh)
+        assert torch.allclose(eta_stale, eta_fresh)
+        assert torch.allclose(eta_dot_stale, eta_dot_fresh)
+        assert torch.allclose(total_scale_stale, total_scale_fresh)
 
     def test_velocity_half_step_shape(self, dtype, device):
         from nvalchemi.dynamics._ops.nose_hoover import nhc_velocity_half_step


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Fixes the NVT Nosé-Hoover chain scratch accumulator handling so velocity
rescaling starts from the multiplicative identity on each chain update instead
of reusing persistent state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #104

## Changes Made

- Reset `nhc_chain_update`'s `total_scale` scratch buffer to `1.0` before dispatch.
- Mark `dt_chain` mutable in the custom-op schema.
- Add regression coverage for zeroed velocities, stale scale reuse, and schema mutability.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Targeted checks run:

- `uv run pytest test/dynamics/test_ops.py::TestNoseHoover -q`
- `uv run pytest test/dynamics/test_ops.py::TestIntegrators::test_nvt_nhc_step -q`
- `uv run pytest /tmp/test_nhc_cuda_issue_104.py -q` with `uv sync --extra cu12` on NVIDIA L4
- `uv run ruff check nvalchemi/dynamics/_ops/nose_hoover.py test/dynamics/test_ops.py`
- `make license`
- pre-commit hooks during commit

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The CUDA test was run through a temporary CUDA-only pytest because
`test/dynamics/test_ops.py` currently overrides the shared `device` fixture with
CPU-only parametrization.
No full `make pytest` or `make lint` run was performed; targeted tests, Ruff,
license checks, and commit-time pre-commit hooks passed.
