### PR TITLE
fix(neighbors): delegate batched method selection to ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **Batched neighbor-list dispatch alignment** — `compute_neighbors` and
+  `NeighborListHook` now delegate method selection to Toolkit-Ops and avoid
+  forwarding stale algorithm-specific scratch buffers when Toolkit-Ops chooses
+  a geometry-dependent strategy.
 - **MTK NPT barostat runaway** (#89, #90) — four bugs in
   `nvalchemi/dynamics/integrators/npt.py` (with matching fixes in
   `nph.py`) that combined to drive unbounded cell-volume drift in long

--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -32,23 +32,10 @@ The hook maintains *staging buffers* — persistent GPU tensors that are
 refreshed each step via ``Tensor.copy_()`` — to avoid per-step dynamic
 allocation inside the ``neighbor_list`` dispatcher.
 
-``neighbor_list`` selects between ``batch_naive`` (avg < 2000 atoms/system)
-and ``batch_cell_list`` (avg >= 2000), see https://nvidia.github.io/nvalchemi-toolkit-ops/userguide/components/neighborlist.html.
-Both paths normally allocate auxiliary tensors on-demand with CPU-GPU syncs
-(e.g. ``.item()`` calls). :meth:`NeighborListHook._alloc_nl_kwargs`
-computes these **once** when the batch shape is first seen (or changes)
-and caches them in ``NeighborListHook._buf_nl_kwargs``:
-
-* *Naive, no PBC*: no extra kwargs needed.
-* *Naive, PBC*: ``shift_range_per_dimension``, ``num_shifts_per_system``,
-  ``max_shifts_per_system``, and ``max_atoms_per_system``.
-* *Cell list*: seven cell-list scratch tensors via ``allocate_cell_list``.
-
-**NPT note**: geometry-dependent kwargs (shift ranges, cell-list sizes) are
-fixed when the staging buffers are first allocated for a given ``(N, B)``
-shape.  For NPT (variable-cell) simulations the pre-computed values may
-become stale as the cell changes; accuracy is maintained by keeping the
-cutoff + skin well below the shortest cell dimension throughout the run.
+Toolkit delegates neighbor-list method selection to Toolkit-Ops by leaving
+``method=None``.  The hook still pre-allocates the output and staging tensors it
+owns, but it does not pre-allocate algorithm-specific scratch kwargs because
+Toolkit-Ops can now choose among geometry-dependent strategies.
 """
 
 from __future__ import annotations
@@ -58,19 +45,6 @@ from enum import Enum
 import torch
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
 from nvalchemiops.torch.neighbors import neighbor_list
-
-try:
-    from nvalchemiops.torch.neighbors.batch_cell_list import (
-        estimate_batch_cell_list_sizes,
-    )
-    from nvalchemiops.torch.neighbors.neighbor_utils import (
-        allocate_cell_list,
-        compute_naive_num_shifts,
-    )
-except ImportError:
-    allocate_cell_list = None
-    compute_naive_num_shifts = None
-    estimate_batch_cell_list_sizes = None
 
 try:
     from nvalchemiops.torch.neighbors.rebuild_detection import (
@@ -238,14 +212,12 @@ class NeighborListHook:
             self._alloc_output_tensors(N, batch, pbc)
 
         # ------------------------------------------------------------------
-        # (Re)allocate staging buffers and algorithm kwargs on shape change.
+        # (Re)allocate staging buffers and clear algorithm kwargs on shape change.
         # ------------------------------------------------------------------
         if self._alloc_N != N or self._alloc_B != B:
             # Composition changed — check K before staging realloc.
             self._check_and_resize_k(N, batch.device, pbc)
-            self._alloc_staging_buffers(
-                N, B, positions.dtype, batch.device, cell, pbc, batch_ptr
-            )
+            self._alloc_staging_buffers(N, B, positions.dtype, batch.device, cell, pbc)
             self._alloc_N = N
             self._alloc_B = B
 
@@ -488,7 +460,6 @@ class NeighborListHook:
         device: torch.device,
         cell: torch.Tensor | None,
         pbc: torch.Tensor | None,
-        batch_ptr: torch.Tensor | None = None,
     ) -> None:
         """Allocate persistent staging buffers for the current (N, B) shape."""
         self._buf_positions = torch.zeros(N, 3, dtype=dtype, device=device)
@@ -505,12 +476,9 @@ class NeighborListHook:
         # neighbor-list build for every system.  The in-place op zeroes this
         # buffer at the start of each subsequent call before writing fresh values.
         self._rebuild_flags = torch.ones(B, dtype=torch.bool, device=device)
-        # Pre-allocate algorithm-specific kwargs to eliminate on-demand CPU syncs
-        # from the neighbor_list dispatcher.  Use the actual batch_ptr (if provided)
-        # to compute max_atoms_per_system correctly — the staging buffer is still
-        # all-zeros at this point and would give max_atoms = 0.
-        ptr = batch_ptr if batch_ptr is not None else self._buf_batch_ptr
-        self._alloc_nl_kwargs(N, B, self._buf_positions, ptr, cell, pbc, device, dtype)
+        # Keep this call here so shape changes always clear any stale method-specific
+        # kwargs from older hook instances.
+        self._alloc_nl_kwargs()
 
     def _copy_to_staging_buffers(
         self,
@@ -533,115 +501,12 @@ class NeighborListHook:
     # Algorithm-specific pre-allocation
     # ------------------------------------------------------------------
 
-    def _alloc_nl_kwargs(
-        self,
-        N: int,
-        B: int,
-        positions: torch.Tensor,
-        batch_ptr: torch.Tensor,
-        cell: torch.Tensor | None,
-        pbc: torch.Tensor | None,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> None:
-        """Pre-allocate algorithm-specific kwargs to remove CPU-GPU syncs.
+    def _alloc_nl_kwargs(self) -> None:
+        """Reset algorithm-specific kwargs.
 
-        The ``neighbor_list`` dispatcher normally infers geometry-dependent
-        values (shift ranges, cell-list sizes) at call time using ``.item()``
-        synchronisations.  This method computes them **once** when the staging
-        buffers are allocated (or re-allocated after a shape change) and stores
-        the resulting tensors in ``_buf_nl_kwargs`` so they can be forwarded as
-        ``**kwargs`` on every ``neighbor_list`` call.
-
-        Algorithm selection mirrors the dispatcher threshold:
-
-        * ``avg_atoms < 2000`` -> ``batch_naive``
-        * ``avg_atoms >= 2000`` -> ``batch_cell_list``
-
-        Parameters
-        ----------
-        N, B : int
-            Total atom count and number of systems at alloc time.
-        positions : torch.Tensor
-            Staging buffer for positions (used to estimate bounding box for
-            non-PBC cell-list systems).
-        batch_ptr : torch.Tensor
-            Staging buffer for batch_ptr (used to get max_atoms_per_system).
-        cell, pbc : torch.Tensor or None
-            Cell and PBC flag tensors at alloc time.
-        device, dtype : torch.device, torch.dtype
-            Allocation target.
+        Toolkit-Ops owns neighbor-list method selection for ``method=None`` and
+        can choose among geometry-dependent fine-grained strategies.  Toolkit
+        therefore avoids forwarding stale scratch buffers sized for a different
+        algorithm than the dispatcher ultimately selects.
         """
         self._buf_nl_kwargs = {}
-
-        avg_atoms = N // max(B, 1)
-        use_cell_list = avg_atoms >= 2000
-
-        if use_cell_list:
-            if estimate_batch_cell_list_sizes is None or allocate_cell_list is None:
-                return  # nvalchemiops too old; fall back to dynamic allocation
-            if cell is not None and pbc is not None:
-                # PBC: use the actual cell geometry.
-                alloc_cell = cell.to(dtype).contiguous()
-                alloc_pbc = pbc
-            else:
-                # Non-PBC: synthesise a bounding-box cell from current positions
-                # with a 1.5x pad so that position drift during the simulation
-                # doesn't overflow the pre-allocated cell-list arrays.
-                expanded_idx = self._buf_batch_idx.unsqueeze(1).expand_as(positions)
-                pos_min = torch.full((B, 3), float("inf"), dtype=dtype, device=device)
-                pos_min.scatter_reduce_(0, expanded_idx, positions, reduce="amin")
-                pos_max = torch.full((B, 3), float("-inf"), dtype=dtype, device=device)
-                pos_max.scatter_reduce_(0, expanded_idx, positions, reduce="amax")
-                cell_lengths = (pos_max - pos_min) * 1.5 + 0.1 * (
-                    self.config.cutoff + self.skin
-                )
-                alloc_cell = torch.diag_embed(cell_lengths)  # (B, 3, 3)
-                alloc_pbc = torch.zeros(B, 3, dtype=torch.bool, device=device)
-
-            max_total_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
-                alloc_cell, alloc_pbc, self.config.cutoff + self.skin
-            )
-            (
-                cells_per_dimension,
-                neighbor_search_radius,
-                atom_periodic_shifts,
-                atom_to_cell_mapping,
-                atoms_per_cell_count,
-                cell_atom_start_indices,
-                cell_atom_list,
-            ) = allocate_cell_list(
-                N, int(max_total_cells), neighbor_search_radius, device
-            )
-            self._buf_nl_kwargs = {
-                "cells_per_dimension": cells_per_dimension,
-                "neighbor_search_radius": neighbor_search_radius,
-                "atom_periodic_shifts": atom_periodic_shifts,
-                "atom_to_cell_mapping": atom_to_cell_mapping,
-                "atoms_per_cell_count": atoms_per_cell_count,
-                "cell_atom_start_indices": cell_atom_start_indices,
-                "cell_atom_list": cell_atom_list,
-            }
-
-        else:
-            # Naive algorithm.
-            if cell is not None and pbc is not None:
-                # PBC naive: pre-compute shift-range tensors so the dispatcher
-                # does not call compute_naive_num_shifts (which has .item()) on
-                # the hot path.
-                if compute_naive_num_shifts is None:
-                    return
-                shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
-                    cell.to(dtype).contiguous(),
-                    self.config.cutoff + self.skin,
-                    pbc,
-                )
-                max_atoms = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
-                self._buf_nl_kwargs = {
-                    "shift_range_per_dimension": shift_range,
-                    "num_shifts_per_system": num_shifts,
-                    "max_shifts_per_system": max_shifts,
-                    "max_atoms_per_system": max_atoms,
-                }
-            # No-PBC naive: no extra kwargs required — the kernel has no
-            # CPU-sync allocations in this branch.

--- a/test/hooks/test_neighbor_list_hook.py
+++ b/test/hooks/test_neighbor_list_hook.py
@@ -19,7 +19,7 @@ Covers all improvements made to NeighborListHook:
 * In-place rebuild-detection custom op
   (:mod:`nvalchemi.dynamics._ops.neighbor_list_rebuild`)
 * Staging-buffer pre-allocation and copy semantics
-* Algorithm-specific kwarg pre-allocation (``_alloc_nl_kwargs``)
+* Avoiding stale algorithm-specific kwargs with Toolkit-Ops auto-dispatch
 * Shape-change invalidation
 * Verlet skin-check integration
 * Correct MATRIX and COO output written to the batch
@@ -114,6 +114,21 @@ def _is_neighbor(
     """Return True if atom j appears in atom i's neighbor list."""
     n = int(num_neighbors[i].item())
     return j in neighbor_matrix[i, :n].tolist()
+
+
+def _assert_no_cross_graph_neighbors(batch: Batch) -> None:
+    """Assert that every valid neighbor entry stays within its source graph."""
+    nm = batch.neighbor_matrix.cpu()
+    nn = batch.num_neighbors.cpu()
+    graph_idx = batch.batch_idx.cpu()
+
+    for i in range(batch.num_nodes):
+        n = int(nn[i].item())
+        for nb in nm[i, :n].tolist():
+            assert graph_idx[i] == graph_idx[nb], (
+                f"atom {i} (graph {int(graph_idx[i])}) has neighbor {nb} "
+                f"from graph {int(graph_idx[nb])}"
+            )
 
 
 # ===========================================================================
@@ -430,49 +445,57 @@ class TestCopyToStagingBuffers:
 
 
 class TestAllocNlKwargs:
-    """Verify algorithm-specific kwargs are pre-computed correctly."""
+    """Verify Toolkit does not forward stale algorithm-specific kwargs."""
 
     def test_naive_no_pbc_empty_kwargs(self, device: str):
-        """No-PBC naive path requires no extra kwargs."""
+        """No-PBC systems leave method-specific kwargs to Toolkit-Ops."""
         hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=False)
         hook(_ctx(batch), _STAGE)
 
         assert hook._buf_nl_kwargs == {}
 
-    def test_naive_pbc_has_shift_kwargs(self, device: str):
-        """PBC naive path must pre-compute shift-range tensors."""
+    def test_pbc_empty_kwargs(self, device: str):
+        """PBC systems leave method-specific kwargs to Toolkit-Ops."""
         hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
-        expected_keys = {
-            "shift_range_per_dimension",
-            "num_shifts_per_system",
-            "max_shifts_per_system",
-            "max_atoms_per_system",
-        }
-        assert expected_keys.issubset(hook._buf_nl_kwargs.keys()), (
-            f"Missing keys: {expected_keys - set(hook._buf_nl_kwargs.keys())}"
-        )
+        assert hook._buf_nl_kwargs == {}
 
-    def test_cell_list_has_scratch_tensors(self, device: str):
-        """Cell-list path (avg_atoms >= 2000) must pre-allocate seven tensors."""
+    def test_dense_periodic_batch_does_not_pass_stale_kwargs(
+        self, device: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Toolkit delegates method selection without stale scratch kwargs."""
+        import nvalchemi.hooks.neighbor_list as hook_mod
+
         N_per = 2000
-        # Build a large batch to trigger cell-list selection
-        positions = torch.rand(N_per, 3) * 10.0
-        data = AtomicData(
-            positions=positions,
-            atomic_numbers=torch.ones(N_per, dtype=torch.long),
-        )
-        batch = Batch.from_data_list([data]).to(device)
+        data_list = [
+            AtomicData(
+                positions=torch.rand(N_per, 3) * 10.0,
+                atomic_numbers=torch.ones(N_per, dtype=torch.long),
+                cell=torch.eye(3).unsqueeze(0) * 20.0,
+                pbc=torch.tensor([[True, True, True]]),
+            )
+            for _ in range(4)
+        ]
+        batch = Batch.from_data_list(data_list).to(device)
 
+        calls: list[dict] = []
+
+        def fake_neighbor_list(**kwargs):
+            calls.append(kwargs)
+            kwargs["num_neighbors"].zero_()
+
+        monkeypatch.setattr(hook_mod, "neighbor_list", fake_neighbor_list)
         hook = NeighborListHook(
             _cfg(), max_neighbors=64, stage=DynamicsStage.BEFORE_COMPUTE
         )
         hook(_ctx(batch), _STAGE)
 
-        expected_keys = {
+        assert calls
+        assert all(call.get("method") is None for call in calls)
+        stale_keys = {
             "cells_per_dimension",
             "neighbor_search_radius",
             "atom_periodic_shifts",
@@ -480,38 +503,31 @@ class TestAllocNlKwargs:
             "atoms_per_cell_count",
             "cell_atom_start_indices",
             "cell_atom_list",
+            "shift_range_per_dimension",
+            "num_shifts_per_system",
+            "max_shifts_per_system",
+            "max_atoms_per_system",
         }
-        assert expected_keys.issubset(hook._buf_nl_kwargs.keys()), (
-            f"Missing keys: {expected_keys - set(hook._buf_nl_kwargs.keys())}"
-        )
+        assert all(stale_keys.isdisjoint(call.keys()) for call in calls)
 
-    def test_kwargs_are_tensors(self, device: str):
-        """Tensor-valued pre-allocated kwargs must be torch.Tensor objects.
-
-        Some kwargs (e.g. ``max_shifts_per_system``, ``max_atoms_per_system``)
-        are plain Python ``int`` scalars as required by the nvalchemiops API.
-        """
+    def test_no_algorithm_kwargs_after_pbc_build(self, device: str):
+        """PBC builds should not cache method-specific scratch kwargs."""
         hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
-        for key, val in hook._buf_nl_kwargs.items():
-            if isinstance(val, int):
-                continue  # int scalars are valid (e.g. max_shifts_per_system)
-            assert isinstance(val, torch.Tensor), f"{key} must be a Tensor"
+        assert hook._buf_nl_kwargs == {}
 
-    def test_kwargs_on_correct_device(self, device: str):
-        """Tensor-valued pre-allocated kwargs must live on the same device as the batch."""
+    def test_no_algorithm_kwargs_after_shape_realloc(self, device: str):
+        """Shape changes should leave method-specific scratch kwargs empty."""
         hook = NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE)
         batch = _line_batch(device, pbc=True)
         hook(_ctx(batch), _STAGE)
 
-        for key, val in hook._buf_nl_kwargs.items():
-            if not isinstance(val, torch.Tensor):
-                continue  # int scalars have no .device attribute
-            assert str(val.device).startswith(device.split(":")[0]), (
-                f"{key} is on {val.device}, expected {device}"
-            )
+        larger_batch = _line_batch(device, pbc=True, n_graphs=2)
+        hook(_ctx(larger_batch), _STAGE)
+
+        assert hook._buf_nl_kwargs == {}
 
 
 # ===========================================================================
@@ -652,15 +668,7 @@ class TestNeighborListHookMatrix:
         )  # 6 atoms: graph 0 = [0,1,2], graph 1 = [3,4,5]
         hook(_ctx(batch), _STAGE)
 
-        nm = batch.neighbor_matrix.cpu()
-        nn = batch.num_neighbors.cpu()
-
-        # Atoms 0-2 are graph 0; atoms 3-5 are graph 1.
-        # No cross-graph neighbors allowed.
-        for i in range(3):
-            n = int(nn[i].item())
-            for nb in nm[i, :n].tolist():
-                assert nb < 3, f"atom {i} (graph 0) has neighbor {nb} from graph 1"
+        _assert_no_cross_graph_neighbors(batch)
 
     def test_idempotent_second_call(self, device: str):
         """Calling the hook twice should give the same neighbor counts."""
@@ -1004,6 +1012,35 @@ class TestAdaptiveK:
         # Non-PBC cap: K = ceil_16(max_num_nodes) = 16.
         nm = batch.neighbor_matrix
         assert nm.shape[1] <= 16
+
+    def test_compute_neighbors_multi_graph_isolation(self, device: str):
+        """compute_neighbors must not build neighbors across Batch graph boundaries."""
+        from nvalchemi.neighbors import compute_neighbors
+
+        batch = _line_batch(device, n_graphs=4)
+        compute_neighbors(batch, cutoff=_CUTOFF, max_neighbors=16)
+
+        _assert_no_cross_graph_neighbors(batch)
+
+    def test_compute_neighbors_delegates_method_selection(
+        self, device: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Toolkit should rely on Toolkit-Ops auto-dispatch for batches."""
+        from nvalchemi import neighbors as neighbors_mod
+        from nvalchemi.neighbors import compute_neighbors
+
+        methods: list[str | None] = []
+
+        def fake_neighbor_list(**kwargs):
+            methods.append(kwargs.get("method"))
+            kwargs["num_neighbors"].zero_()
+
+        monkeypatch.setattr(neighbors_mod, "neighbor_list", fake_neighbor_list)
+
+        batch = _line_batch(device, n_graphs=4)
+        compute_neighbors(batch, cutoff=_CUTOFF, max_neighbors=16)
+
+        assert methods == [None]
 
 
 # ===========================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Align Toolkit neighbor-list construction with current Toolkit-Ops dispatch:
`compute_neighbors` and `NeighborListHook` now pass batched metadata
(`batch_idx` / `batch_ptr`) without forcing an explicit neighbor-list method.
That lets Toolkit-Ops choose the correct batched strategy via `method=None`.

This pairs with an upstream Toolkit-Ops guard that rejects explicit
single-system methods such as `method="naive"` or `method="cell_list"` when
batched metadata is provided.

The observed failure mode is that forcing `method="naive"` can connect atoms
from different batched systems as neighbors. The model then treats those
cross-system edges like real neighbor interactions/messages.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Relates to neighbor-list batching reports where explicit unbatched Toolkit-Ops
methods can create cross-graph neighbor edges.

## Changes Made

- Removed Toolkit's internal explicit batched-method selector.
- Updated `compute_neighbors` and `NeighborListHook` to leave `method=None` when calling Toolkit-Ops with batched metadata.
- Removed pre-allocation/forwarding of algorithm-specific scratch kwargs from `NeighborListHook`; Toolkit-Ops chooses among geometry-dependent strategies at dispatch time.
- Added graph-boundary regression coverage for `compute_neighbors` and strengthened `NeighborListHook` boundary assertions.
- Added tests that verify Toolkit delegates method selection instead of passing stale explicit methods or scratch kwargs.
- Updated `CHANGELOG.md`.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Ran locally:

```bash
WARP_CACHE_PATH=/tmp/warp-cache \
TRITON_CACHE_DIR=/tmp/triton-cache \
TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor-cache \
TORCH_COMPILE_DISABLE=1 \
python -m pytest test/hooks/test_neighbor_list_hook.py -q
```

Result: `123 passed, 16 warnings`.

```bash
ruff check nvalchemi/neighbors.py nvalchemi/hooks/neighbor_list.py test/hooks/test_neighbor_list_hook.py
```

Result: `All checks passed!`

Coverage added in `test/hooks/test_neighbor_list_hook.py`:

- `test_compute_neighbors_multi_graph_isolation` verifies one-shot neighbor
  construction does not create cross-graph neighbor entries.
- `test_multi_graph_isolation` now checks every valid `NeighborListHook`
  neighbor entry for `src_system == dst_system`.
- `test_compute_neighbors_delegates_method_selection` verifies
  `compute_neighbors` leaves `method=None`.
- `TestAllocNlKwargs` verifies `NeighborListHook` does not forward stale
  algorithm-specific scratch kwargs while Toolkit-Ops owns method selection.

Here "hooks" refers to Toolkit runtime hooks, not Git or CI hooks. CI exercises
them by running pytest; the tests instantiate and call `NeighborListHook`
directly.

Live H2O boundary probe against the patched Toolkit branch:

```text
Toolkit compute_neighbors    total_edges= 16 cross_edges=  0 examples=[]
Toolkit NeighborListHook     total_edges= 16 cross_edges=  0 examples=[]
ops method=batch_naive       total_edges= 16 cross_edges=  0 examples=[]
ops method=naive             raises ValueError with upstream Toolkit-Ops guard
ops method=batch_cell_list   total_edges= 16 cross_edges=  0 examples=[]
ops method=cell_list         raises ValueError with upstream Toolkit-Ops guard
ops method=None              total_edges= 16 cross_edges=  0 examples=[]
```

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

This PR intentionally does not change the Toolkit public API. It updates
Toolkit's own neighbor-list callers to use Toolkit-Ops' official batched
auto-dispatch path.

The paired upstream Toolkit-Ops PR should land first or alongside this one so
direct explicit misuse fails loudly instead of silently treating a concatenated
batch as one system.

The current `CONTRIBUTING.md` says public direct contributions are not accepted
during the initial public beta, and signed-off commits are required.
