### PR TITLE
Avoid autograd leaves for energy-only pipelines

### DIFF
--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -689,8 +689,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         grad_keys: set[str] = set()
         for group in self.groups:
             if group.use_autograd:
-                for step in group.steps:
-                    grad_keys |= step.model.model_config.autograd_inputs
+                if requested_derivatives:
+                    for step in group.steps:
+                        grad_keys |= step.model.model_config.autograd_inputs
             else:
                 for step in group.steps:
                     card = step.model.model_config

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -524,7 +524,8 @@ class TestPipelineAutogradGroup:
         out["energy"].sum().backward()
 
         assert model.scale.grad is not None
-        assert model.positions_requires_grad_seen is False
+        assert model.scale.grad.abs() > 0
+        assert not model.positions_requires_grad_seen
 
     def test_training_preserves_stress_graph_for_backward(self):
         data = AtomicData(

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -121,6 +121,7 @@ class MockTrainableAutogradEnergyModel(nn.Module, BaseModelMixin):
     def __init__(self) -> None:
         super().__init__()
         self.scale = nn.Parameter(torch.tensor(1.0))
+        self.positions_requires_grad_seen: bool | None = None
         self.model_config = ModelConfig(
             outputs=frozenset({"energy"}),
             autograd_outputs=frozenset({"forces"}),
@@ -138,6 +139,7 @@ class MockTrainableAutogradEnergyModel(nn.Module, BaseModelMixin):
 
     def forward(self, data, **kwargs) -> ModelOutputs:
         positions = data.positions
+        self.positions_requires_grad_seen = positions.requires_grad
         B = data.num_graphs if isinstance(data, Batch) else 1
         batch = (
             data.batch_idx
@@ -509,6 +511,20 @@ class TestPipelineAutogradGroup:
         assert out["forces"].requires_grad
         assert model.scale.grad is not None
         assert model.scale.grad.abs() > 0
+
+    def test_energy_only_training_does_not_prepare_autograd_inputs(self, simple_batch):
+        model = MockTrainableAutogradEnergyModel()
+        pipe = PipelineModelWrapper(
+            groups=[PipelineGroup(steps=[model], use_autograd=True)]
+        )
+        pipe.model_config.active_outputs = {"energy"}
+        pipe.train()
+
+        out = pipe(simple_batch)
+        out["energy"].sum().backward()
+
+        assert model.scale.grad is not None
+        assert model.positions_requires_grad_seen is False
 
     def test_training_preserves_stress_graph_for_backward(self):
         data = AtomicData(


### PR DESCRIPTION
## Summary
- avoid preparing autograd leaves for autograd pipeline groups when only energy is requested
- add a regression that keeps energy-only training backpropagating to model parameters without marking positions as requiring gradients

Closes #100.

## Testing
- reproduced the issue snippet before the fix
- `python -m pytest test/models/test_pipeline.py::TestPipelineAutogradGroup -q`
- `python -m py_compile nvalchemi\models\pipeline.py test\models\test_pipeline.py`
- `git diff --check`