### PR TITLE
fix: preserve system IDs during inflight refill

### DIFF
--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -2047,6 +2047,17 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
             device = result.device
             for key, default_fn in self._bookkeeping_keys.items():
                 new_tensor = default_fn(n_total, device)
+                # Preserve values already carried by appended replacements before
+                # restoring the prefix for systems that stayed active.
+                result_vals = getattr(result, key, None)
+                if result_vals is not None:
+                    result_vals = (
+                        result_vals.unsqueeze(-1)
+                        if result_vals.dim() == 1
+                        else result_vals
+                    )
+                    if result_vals.shape == new_tensor.shape:
+                        new_tensor.copy_(result_vals)
                 remaining_vals = getattr(batch, key, None)
                 if remaining_vals is not None and n_remaining > 0:
                     src = remaining_vals[remaining_indices]

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -2058,6 +2058,11 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
                     )
                     if result_vals.shape == new_tensor.shape:
                         new_tensor.copy_(result_vals)
+                    else:
+                        raise RuntimeError(
+                            f"Bookkeeping key '{key}' has shape {result_vals.shape} "
+                            f"after refill, expected {new_tensor.shape}."
+                        )
                 remaining_vals = getattr(batch, key, None)
                 if remaining_vals is not None and n_remaining > 0:
                     src = remaining_vals[remaining_indices]

--- a/test/dynamics/test_inflight.py
+++ b/test/dynamics/test_inflight.py
@@ -651,6 +651,22 @@ class TestRefillCheck:
         assert result.system_id.view(-1).tolist() == [2]
         assert result.status.view(-1).tolist() == [0]
 
+    def test_refill_preserves_mixed_system_ids(self) -> None:
+        """Remaining and replacement systems both keep their system IDs."""
+        dataset = MockDataset([(1, 0)] * 3)
+        sampler = SizeAwareSampler(dataset, max_atoms=2)
+        dynamics = BaseDynamics(model=self.model, sampler=sampler, device_type="cpu")
+
+        batch = sampler.build_initial_batch()
+        assert batch.system_id.view(-1).tolist() == [0, 1]
+
+        batch["status"] = torch.tensor([[1], [0]])
+        result = dynamics.refill_check(batch, exit_status=1)
+
+        assert result is not None
+        assert result.system_id.view(-1).tolist() == [1, 2]
+        assert result.status.view(-1).tolist() == [0, 0]
+
     def test_refill_partial_replacement(self) -> None:
         """When sampler has fewer replacements than graduated, batch shrinks.
 

--- a/test/dynamics/test_inflight.py
+++ b/test/dynamics/test_inflight.py
@@ -667,6 +667,66 @@ class TestRefillCheck:
         assert result.system_id.view(-1).tolist() == [1, 2]
         assert result.status.view(-1).tolist() == [0, 0]
 
+    def test_refill_preserves_system_ids_with_multistage_statuses(self) -> None:
+        """A status-2 system is replaced while lower-status systems remain."""
+        dataset = MockDataset([(1, 0)] * 5)
+        sampler = SizeAwareSampler(dataset, max_atoms=3)
+        dynamics = BaseDynamics(model=self.model, sampler=sampler, device_type="cpu")
+
+        batch = sampler.build_initial_batch()
+        assert batch.system_id.view(-1).tolist() == [0, 1, 2]
+
+        batch["status"] = torch.tensor([[0], [1], [2]])
+        result = dynamics.refill_check(batch, exit_status=2)
+
+        assert result is not None
+        assert result.system_id.view(-1).tolist() == [0, 1, 3]
+        assert result.status.view(-1).tolist() == [0, 1, 0]
+
+    def test_refill_preserves_system_ids_with_multiple_replacements(self) -> None:
+        """Multiple graduated systems are replaced in a single refill."""
+        dataset = MockDataset([(1, 0)] * 5)
+        sampler = SizeAwareSampler(dataset, max_atoms=3)
+        dynamics = BaseDynamics(model=self.model, sampler=sampler, device_type="cpu")
+
+        batch = sampler.build_initial_batch()
+        assert batch.system_id.view(-1).tolist() == [0, 1, 2]
+
+        batch["status"] = torch.tensor([[1], [0], [1]])
+        result = dynamics.refill_check(batch, exit_status=1)
+
+        assert result is not None
+        assert result.system_id.view(-1).tolist() == [1, 3, 4]
+        assert result.status.view(-1).tolist() == [0, 0, 0]
+
+    def test_refill_preserves_replacement_status_from_dataset(self) -> None:
+        """Replacement systems keep nonzero dataset-provided entry status."""
+
+        class StatusDataset(MockDataset):
+            def __getitem__(self, index: int) -> tuple[AtomicData, dict]:
+                data, metadata = super().__getitem__(index)
+                data.add_system_property(
+                    "status", torch.tensor([[1]], dtype=torch.long)
+                )
+                return data, metadata
+
+        dataset = StatusDataset([(1, 0)] * 5)
+        sampler = SizeAwareSampler(dataset, max_atoms=3)
+        dynamics = BaseDynamics(model=self.model, sampler=sampler, device_type="cpu")
+
+        batch = sampler.build_initial_batch()
+        assert batch.system_id.view(-1).tolist() == [0, 1, 2]
+        # Initial batching resets status to zero, but refill preserves
+        # replacement status already carried by the appended batch.
+        assert batch.status.view(-1).tolist() == [0, 0, 0]
+
+        batch["status"] = torch.tensor([[0], [2], [1]])
+        result = dynamics.refill_check(batch, exit_status=2)
+
+        assert result is not None
+        assert result.system_id.view(-1).tolist() == [0, 2, 3]
+        assert result.status.view(-1).tolist() == [0, 1, 1]
+
     def test_refill_partial_replacement(self) -> None:
         """When sampler has fewer replacements than graduated, batch shrinks.
 

--- a/test/dynamics/test_inflight.py
+++ b/test/dynamics/test_inflight.py
@@ -635,6 +635,22 @@ class TestRefillCheck:
 
         assert "status" in result
 
+    def test_refill_preserves_replacement_system_id(self) -> None:
+        """Replacement systems keep sampler-assigned system IDs after refill."""
+        dataset = MockDataset([(1, 0)] * 3)
+        sampler = SizeAwareSampler(dataset, max_atoms=2)
+        dynamics = BaseDynamics(model=self.model, sampler=sampler, device_type="cpu")
+
+        batch = sampler.build_initial_batch()
+        assert batch.system_id.view(-1).tolist() == [0, 1]
+
+        batch["status"] = torch.tensor([[1], [1]])
+        result = dynamics.refill_check(batch, exit_status=1)
+
+        assert result is not None
+        assert result.system_id.view(-1).tolist() == [2]
+        assert result.status.view(-1).tolist() == [0]
+
     def test_refill_partial_replacement(self) -> None:
         """When sampler has fewer replacements than graduated, batch shrinks.
 


### PR DESCRIPTION
## Description

Preserve sampler-assigned `system_id` values for replacement systems during inflight refill. `BaseDynamics.refill_check()` now seeds rebuilt bookkeeping tensors from values already present on the appended result batch before restoring values for systems that stayed active.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #112

## Changes Made

- Preserve system_id values assigned by SizeAwareSampler during `refill_check()` for inflight batching.
- Preserve system_id values for systems already in batch.
- Add test to verify this workflow.

## Testing

- [x] Unit tests pass locally (`uv run pytest test/dynamics/test_inflight.py::TestRefillCheck`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?
- Added regression test for `system_id` preservation during inflight refill.


## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

This is a Python-only toolkit fix. No `nvalchemi-toolkit-ops` changes are required.