### PR TITLE
fix: preserve inactive cells during masked updates

### DIFF
--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -1327,7 +1327,7 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
     __needs_keys__: set[str] = set()
     __provides_keys__: set[str] = set()
 
-    _mutable_fields: tuple[str, ...] = ("positions", "velocities")
+    _mutable_fields: tuple[str, ...] = ("positions", "velocities", "cell")
 
     _bookkeeping_keys: dict[str, Callable[[int, torch.device], torch.Tensor]] = {
         "status": lambda n, dev: torch.zeros(n, 1, dtype=torch.long, device=dev),

--- a/test/dynamics/test_base.py
+++ b/test/dynamics/test_base.py
@@ -1451,6 +1451,23 @@ class TestMaskedUpdate:
         assert torch.equal(batch.cell[1], unmasked_cell_before)
         assert not torch.equal(batch.cell[0], torch.eye(3))
 
+    def test_masked_post_update_preserves_unmasked_cell(self) -> None:
+        """Inactive systems' cells are restored after masked post-update."""
+
+        class _CellMutatingDynamics(DemoDynamics):
+            def post_update(self, batch: Batch) -> None:
+                batch.cell.add_(1.0)
+
+        dynamics = _CellMutatingDynamics(model=self.model, n_steps=1, dt=1.0)
+        batch = self._make_batch(n_graphs=2, n_atoms_per_graph=2)
+        batch.cell = torch.stack([torch.eye(3), torch.eye(3) * 2.0])
+
+        unmasked_cell_before = batch.cell[1].clone()
+        dynamics._masked_post_update(batch, torch.tensor([True, False]))
+
+        assert torch.equal(batch.cell[1], unmasked_cell_before)
+        assert torch.equal(batch.cell[0], torch.eye(3) + 1.0)
+
     def test_masked_update_preserves_unmasked_cell(self) -> None:
         """Inactive systems' cells are restored after full masked update."""
 

--- a/test/dynamics/test_base.py
+++ b/test/dynamics/test_base.py
@@ -1434,6 +1434,43 @@ class TestMaskedUpdate:
         assert batch.energy[1].item() == pytest.approx(2.0)
         assert batch.energy[2].item() == pytest.approx(3.0)
 
+    def test_masked_pre_update_preserves_unmasked_cell(self) -> None:
+        """Inactive systems' cells are restored after masked pre-update."""
+
+        class _CellMutatingDynamics(DemoDynamics):
+            def pre_update(self, batch: Batch) -> None:
+                batch.cell.add_(1.0)
+
+        dynamics = _CellMutatingDynamics(model=self.model, n_steps=1, dt=1.0)
+        batch = self._make_batch(n_graphs=2, n_atoms_per_graph=2)
+        batch.cell = torch.stack([torch.eye(3), torch.eye(3) * 2.0])
+
+        unmasked_cell_before = batch.cell[1].clone()
+        dynamics._masked_pre_update(batch, torch.tensor([True, False]))
+
+        assert torch.equal(batch.cell[1], unmasked_cell_before)
+        assert not torch.equal(batch.cell[0], torch.eye(3))
+
+    def test_masked_update_preserves_unmasked_cell(self) -> None:
+        """Inactive systems' cells are restored after full masked update."""
+
+        class _CellMutatingDynamics(DemoDynamics):
+            def pre_update(self, batch: Batch) -> None:
+                batch.cell.add_(1.0)
+
+            def post_update(self, batch: Batch) -> None:
+                batch.cell.add_(1.0)
+
+        dynamics = _CellMutatingDynamics(model=self.model, n_steps=1, dt=1.0)
+        batch = self._make_batch(n_graphs=2, n_atoms_per_graph=2)
+        batch.cell = torch.stack([torch.eye(3), torch.eye(3) * 2.0])
+
+        unmasked_cell_before = batch.cell[1].clone()
+        dynamics.masked_update(batch, torch.tensor([True, False]))
+
+        assert torch.equal(batch.cell[1], unmasked_cell_before)
+        assert torch.equal(batch.cell[0], torch.eye(3) + 2.0)
+
 
 # -----------------------------------------------------------------------------
 # Hook frequency gating


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Protect inactive systems' `cell` tensors during masked dynamics updates.

## Description

`FusedStage` runs multiple sub-stages on one shared live `Batch`. In a mixed workflow, one system may be in a fixed-cell stage such as NVE/NVT while another system is in a variable-cell stage such as FIRE/NPT. The masked update helpers already restore inactive systems' `positions` and `velocities`; this change also restores inactive systems' `cell` values so a cell-mutating sub-stage cannot update every system's cell.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #115 

## Changes Made

- Add `cell` to `BaseDynamics._mutable_fields` so masked update restoration protects inactive system cells.
- Add regression coverage for the split `_masked_pre_update()` path used by `FusedStage`.
- Add regression coverage for the full `masked_update()` helper path used outside the split `FusedStage` step flow.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?
Yes. Added regression tests for both masked update paths: `_masked_pre_update()` for the split `FusedStage` flow and `masked_update()` for the full helper flow. Both verify inactive systems' `cell` values are restored.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The two regression tests cover independent masking paths:

- `_masked_pre_update()` is the actual split path used by `FusedStage` before the shared model compute.
- `masked_update()` is the full helper path used outside that split `FusedStage` flow.

This is a Python-only toolkit fix. No `nvalchemi-toolkit-ops` changes are required.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
