### PR TITLE
Pin Toolkit-Ops version to 0.4.0

### DIFF
--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -178,7 +178,8 @@ class NeighborListHook:
         self._buf_pbc: torch.Tensor | None = None  # PBC only
 
         # Algorithm-specific pre-allocated kwargs forwarded to neighbor_list.
-        self._buf_nl_kwargs: dict[str, torch.Tensor] = {}
+        self._buf_nl_kwargs: dict[str, torch.Tensor | int] = {}
+        self._neighbor_list_method: str | None = None
 
         # Adaptive K-dimension state.
         self._actual_max_k: torch.Tensor | None = None  # GPU scalar from last build
@@ -306,6 +307,7 @@ class NeighborListHook:
             num_neighbors=self._num_neighbors,
             neighbor_matrix_shifts=self._neighbor_matrix_shifts,
             rebuild_flags=self._rebuild_flags,
+            method=self._neighbor_list_method,
             **self._buf_nl_kwargs,
         )
 
@@ -334,6 +336,7 @@ class NeighborListHook:
                     num_neighbors=self._num_neighbors,
                     neighbor_matrix_shifts=self._neighbor_matrix_shifts,
                     rebuild_flags=None,  # Force full rebuild
+                    method=self._neighbor_list_method,
                     **self._buf_nl_kwargs,
                 )
 
@@ -576,6 +579,7 @@ class NeighborListHook:
 
         avg_atoms = N // max(B, 1)
         use_cell_list = avg_atoms >= 2000
+        self._neighbor_list_method = "cell_list" if use_cell_list else "naive"
 
         if use_cell_list:
             if estimate_batch_cell_list_sizes is None or allocate_cell_list is None:

--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -68,20 +68,26 @@ try:
     from nvalchemiops.torch.neighbors.batch_cell_list import (
         estimate_batch_cell_list_sizes,
     )
+except ImportError:
+    estimate_batch_cell_list_sizes = None
+
+try:
     from nvalchemiops.torch.neighbors.batch_cluster_tile import (
-        _batch_max_tiles_per_group,
         allocate_batch_cluster_tile_list,
+        estimate_batch_max_tiles_per_group,
     )
+except ImportError:
+    allocate_batch_cluster_tile_list = None
+    estimate_batch_max_tiles_per_group = None
+
+try:
     from nvalchemiops.torch.neighbors.neighbor_utils import (
         allocate_cell_list,
         compute_naive_num_shifts,
     )
 except ImportError:
     allocate_cell_list = None
-    allocate_batch_cluster_tile_list = None
     compute_naive_num_shifts = None
-    estimate_batch_cell_list_sizes = None
-    _batch_max_tiles_per_group = None
 
 try:
     from nvalchemiops.torch.neighbors.rebuild_detection import (
@@ -591,12 +597,12 @@ class NeighborListHook:
         if base_method.endswith("cluster_tile"):
             if (
                 allocate_batch_cluster_tile_list is None
-                or _batch_max_tiles_per_group is None
+                or estimate_batch_max_tiles_per_group is None
                 or cell is None
             ):
                 return
             alloc_cell = cell.to(dtype).contiguous()
-            max_tiles_per_group = _batch_max_tiles_per_group(
+            max_tiles_per_group = estimate_batch_max_tiles_per_group(
                 batch_ptr, self.config.cutoff + self.skin, alloc_cell
             )
             (

--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -32,17 +32,21 @@ The hook maintains *staging buffers* — persistent GPU tensors that are
 refreshed each step via ``Tensor.copy_()`` — to avoid per-step dynamic
 allocation inside the ``neighbor_list`` dispatcher.
 
-``neighbor_list`` selects between ``batch_naive`` (avg < 2000 atoms/system)
-and ``batch_cell_list`` (avg >= 2000), see https://nvidia.github.io/nvalchemi-toolkit-ops/userguide/components/neighborlist.html.
-Both paths normally allocate auxiliary tensors on-demand with CPU-GPU syncs
-(e.g. ``.item()`` calls). :meth:`NeighborListHook._alloc_nl_kwargs`
-computes these **once** when the batch shape is first seen (or changes)
-and caches them in ``NeighborListHook._buf_nl_kwargs``:
+For PBC systems, ``NeighborListHook`` runs the ``nvalchemiops`` selector
+once per batch shape and caches the resulting explicit strategy name (for
+example ``batch_cell_list_pair_centric`` or ``batch_cluster_tile``). For
+non-PBC systems it keeps the legacy size threshold between naive and cell-list
+methods. The selected paths normally allocate auxiliary tensors on demand with
+CPU-GPU syncs (e.g. ``.item()`` calls), so
+:meth:`NeighborListHook._alloc_nl_kwargs` computes these **once** when the batch
+shape is first seen (or changes) and caches them in
+``NeighborListHook._buf_nl_kwargs``:
 
 * *Naive, no PBC*: no extra kwargs needed.
 * *Naive, PBC*: ``shift_range_per_dimension``, ``num_shifts_per_system``,
   ``max_shifts_per_system``, and ``max_atoms_per_system``.
 * *Cell list*: seven cell-list scratch tensors via ``allocate_cell_list``.
+* *Cluster tile*: batch cluster-tile sort/group/tile scratch tensors.
 
 **NPT note**: geometry-dependent kwargs (shift ranges, cell-list sizes) are
 fixed when the staging buffers are first allocated for a given ``(N, B)``
@@ -56,12 +60,17 @@ from __future__ import annotations
 from enum import Enum
 
 import torch
+from nvalchemiops.neighbors.base_dispatch import neighbor_list_strategy_run_args
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
-from nvalchemiops.torch.neighbors import neighbor_list
+from nvalchemiops.torch.neighbors import neighbor_list, suggest_neighbor_list_method
 
 try:
     from nvalchemiops.torch.neighbors.batch_cell_list import (
         estimate_batch_cell_list_sizes,
+    )
+    from nvalchemiops.torch.neighbors.batch_cluster_tile import (
+        _batch_max_tiles_per_group,
+        allocate_batch_cluster_tile_list,
     )
     from nvalchemiops.torch.neighbors.neighbor_utils import (
         allocate_cell_list,
@@ -69,8 +78,10 @@ try:
     )
 except ImportError:
     allocate_cell_list = None
+    allocate_batch_cluster_tile_list = None
     compute_naive_num_shifts = None
     estimate_batch_cell_list_sizes = None
+    _batch_max_tiles_per_group = None
 
 try:
     from nvalchemiops.torch.neighbors.rebuild_detection import (
@@ -245,7 +256,15 @@ class NeighborListHook:
             # Composition changed — check K before staging realloc.
             self._check_and_resize_k(N, batch.device, pbc)
             self._alloc_staging_buffers(
-                N, B, positions.dtype, batch.device, cell, pbc, batch_ptr
+                N,
+                B,
+                positions.dtype,
+                batch.device,
+                cell,
+                pbc,
+                batch_ptr,
+                positions=positions,
+                batch_idx=batch.batch_idx,
             )
             self._alloc_N = N
             self._alloc_B = B
@@ -492,6 +511,8 @@ class NeighborListHook:
         cell: torch.Tensor | None,
         pbc: torch.Tensor | None,
         batch_ptr: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        batch_idx: torch.Tensor | None = None,
     ) -> None:
         """Allocate persistent staging buffers for the current (N, B) shape."""
         self._buf_positions = torch.zeros(N, 3, dtype=dtype, device=device)
@@ -513,7 +534,11 @@ class NeighborListHook:
         # to compute max_atoms_per_system correctly — the staging buffer is still
         # all-zeros at this point and would give max_atoms = 0.
         ptr = batch_ptr if batch_ptr is not None else self._buf_batch_ptr
-        self._alloc_nl_kwargs(N, B, self._buf_positions, ptr, cell, pbc, device, dtype)
+        alloc_positions = positions if positions is not None else self._buf_positions
+        alloc_batch_idx = batch_idx if batch_idx is not None else self._buf_batch_idx
+        self._alloc_nl_kwargs(
+            N, B, alloc_positions, alloc_batch_idx, ptr, cell, pbc, device, dtype
+        )
 
     def _copy_to_staging_buffers(
         self,
@@ -541,6 +566,7 @@ class NeighborListHook:
         N: int,
         B: int,
         positions: torch.Tensor,
+        batch_idx: torch.Tensor,
         batch_ptr: torch.Tensor,
         cell: torch.Tensor | None,
         pbc: torch.Tensor | None,
@@ -549,50 +575,88 @@ class NeighborListHook:
     ) -> None:
         """Pre-allocate algorithm-specific kwargs to remove CPU-GPU syncs.
 
-        The ``neighbor_list`` dispatcher normally infers geometry-dependent
-        values (shift ranges, cell-list sizes) at call time using ``.item()``
-        synchronisations.  This method computes them **once** when the staging
-        buffers are allocated (or re-allocated after a shape change) and stores
-        the resulting tensors in ``_buf_nl_kwargs`` so they can be forwarded as
-        ``**kwargs`` on every ``neighbor_list`` call.
-
-        Algorithm selection mirrors the dispatcher threshold:
-
-        * ``avg_atoms < 2000`` -> ``batch_naive``
-        * ``avg_atoms >= 2000`` -> ``batch_cell_list``
-
-        Parameters
-        ----------
-        N, B : int
-            Total atom count and number of systems at alloc time.
-        positions : torch.Tensor
-            Staging buffer for positions (used to estimate bounding box for
-            non-PBC cell-list systems).
-        batch_ptr : torch.Tensor
-            Staging buffer for batch_ptr (used to get max_atoms_per_system).
-        cell, pbc : torch.Tensor or None
-            Cell and PBC flag tensors at alloc time.
-        device, dtype : torch.device, torch.dtype
-            Allocation target.
+        The ops dispatcher exposes a host-only cost model that can select
+        fine-grained strategies such as ``batch_cell_list_pair_centric`` and
+        ``batch_cluster_tile``.  Run that selector once when staging buffers are
+        allocated, cache the chosen method, and pre-allocate scratch tensors for
+        the selected base algorithm.
         """
         self._buf_nl_kwargs = {}
+        batch_ptr = batch_ptr.detach().to(dtype=torch.int32).contiguous()
+        self._neighbor_list_method = self._select_neighbor_list_method(
+            N, B, batch_ptr, cell, pbc, dtype
+        )
+        base_method = self._base_neighbor_list_method(self._neighbor_list_method)
 
-        avg_atoms = N // max(B, 1)
-        use_cell_list = avg_atoms >= 2000
-        self._neighbor_list_method = "cell_list" if use_cell_list else "naive"
+        if base_method.endswith("cluster_tile"):
+            if (
+                allocate_batch_cluster_tile_list is None
+                or _batch_max_tiles_per_group is None
+                or cell is None
+            ):
+                return
+            alloc_cell = cell.to(dtype).contiguous()
+            max_tiles_per_group = _batch_max_tiles_per_group(
+                batch_ptr, self.config.cutoff + self.skin, alloc_cell
+            )
+            (
+                sorted_atom_index,
+                sort_inv,
+                sorted_pos_x,
+                sorted_pos_y,
+                sorted_pos_z,
+                batch_idx_sorted,
+                batch_ptr_padded,
+                group_system,
+                group_ptr,
+                group_ctr_x,
+                group_ctr_y,
+                group_ctr_z,
+                group_ext_x,
+                group_ext_y,
+                group_ext_z,
+                num_tiles,
+                tile_row_group,
+                tile_col_group,
+                tile_system,
+            ) = allocate_batch_cluster_tile_list(
+                batch_ptr,
+                device,
+                dtype=dtype,
+                max_tiles_per_group=max_tiles_per_group,
+            )
+            self._buf_nl_kwargs = {
+                "max_tiles_per_group": max_tiles_per_group,
+                "sorted_atom_index": sorted_atom_index,
+                "sort_inv": sort_inv,
+                "sorted_pos_x": sorted_pos_x,
+                "sorted_pos_y": sorted_pos_y,
+                "sorted_pos_z": sorted_pos_z,
+                "batch_idx_sorted": batch_idx_sorted,
+                "batch_ptr_padded": batch_ptr_padded,
+                "group_system": group_system,
+                "group_ptr": group_ptr,
+                "group_ctr_x": group_ctr_x,
+                "group_ctr_y": group_ctr_y,
+                "group_ctr_z": group_ctr_z,
+                "group_ext_x": group_ext_x,
+                "group_ext_y": group_ext_y,
+                "group_ext_z": group_ext_z,
+                "num_tiles": num_tiles,
+                "tile_row_group": tile_row_group,
+                "tile_col_group": tile_col_group,
+                "tile_system": tile_system,
+            }
+            return
 
-        if use_cell_list:
+        if base_method.endswith("cell_list"):
             if estimate_batch_cell_list_sizes is None or allocate_cell_list is None:
-                return  # nvalchemiops too old; fall back to dynamic allocation
+                return
             if cell is not None and pbc is not None:
-                # PBC: use the actual cell geometry.
                 alloc_cell = cell.to(dtype).contiguous()
                 alloc_pbc = pbc
             else:
-                # Non-PBC: synthesise a bounding-box cell from current positions
-                # with a 1.5x pad so that position drift during the simulation
-                # doesn't overflow the pre-allocated cell-list arrays.
-                expanded_idx = self._buf_batch_idx.unsqueeze(1).expand_as(positions)
+                expanded_idx = batch_idx.unsqueeze(1).expand_as(positions)
                 pos_min = torch.full((B, 3), float("inf"), dtype=dtype, device=device)
                 pos_min.scatter_reduce_(0, expanded_idx, positions, reduce="amin")
                 pos_max = torch.full((B, 3), float("-inf"), dtype=dtype, device=device)
@@ -600,7 +664,7 @@ class NeighborListHook:
                 cell_lengths = (pos_max - pos_min) * 1.5 + 0.1 * (
                     self.config.cutoff + self.skin
                 )
-                alloc_cell = torch.diag_embed(cell_lengths)  # (B, 3, 3)
+                alloc_cell = torch.diag_embed(cell_lengths)
                 alloc_pbc = torch.zeros(B, 3, dtype=torch.bool, device=device)
 
             max_total_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
@@ -626,26 +690,56 @@ class NeighborListHook:
                 "cell_atom_start_indices": cell_atom_start_indices,
                 "cell_atom_list": cell_atom_list,
             }
+            return
 
-        else:
-            # Naive algorithm.
-            if cell is not None and pbc is not None:
-                # PBC naive: pre-compute shift-range tensors so the dispatcher
-                # does not call compute_naive_num_shifts (which has .item()) on
-                # the hot path.
-                if compute_naive_num_shifts is None:
-                    return
-                shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
-                    cell.to(dtype).contiguous(),
-                    self.config.cutoff + self.skin,
-                    pbc,
-                )
-                max_atoms = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
-                self._buf_nl_kwargs = {
-                    "shift_range_per_dimension": shift_range,
-                    "num_shifts_per_system": num_shifts,
-                    "max_shifts_per_system": max_shifts,
-                    "max_atoms_per_system": max_atoms,
-                }
-            # No-PBC naive: no extra kwargs required — the kernel has no
-            # CPU-sync allocations in this branch.
+        if cell is not None and pbc is not None:
+            if compute_naive_num_shifts is None:
+                return
+            shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+                cell.to(dtype).contiguous(),
+                self.config.cutoff + self.skin,
+                pbc,
+            )
+            max_atoms = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
+            self._buf_nl_kwargs = {
+                "shift_range_per_dimension": shift_range,
+                "num_shifts_per_system": num_shifts,
+                "max_shifts_per_system": max_shifts,
+                "max_atoms_per_system": max_atoms,
+            }
+
+    def _select_neighbor_list_method(
+        self,
+        N: int,
+        B: int,
+        batch_ptr: torch.Tensor,
+        cell: torch.Tensor | None,
+        pbc: torch.Tensor | None,
+        dtype: torch.dtype,
+    ) -> str:
+        """Choose the explicit method to use inside the compiled hot path."""
+        fallback = "cell_list" if N // max(B, 1) >= 2000 else "naive"
+        if cell is None or pbc is None:
+            return fallback
+        try:
+            return suggest_neighbor_list_method(
+                batch_ptr,
+                cell.to(dtype).contiguous(),
+                pbc,
+                self.config.cutoff + self.skin,
+                half_fill=self.config.half_list,
+                return_neighbor_list=False,
+                positions_dtype=dtype,
+            )
+        except (RuntimeError, NotImplementedError, ValueError):
+            return fallback
+
+    @staticmethod
+    def _base_neighbor_list_method(method: str | None) -> str:
+        """Return the dispatcher base method for a fine-grained strategy name."""
+        if method is None:
+            return "naive"
+        try:
+            return neighbor_list_strategy_run_args(method)[0]
+        except ValueError:
+            return method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ cu12 = [
     "nvidia-physicsnemo[cu12]>=2.0.0; sys_platform != 'darwin'",
     "cuml-cu12>=25.6.0; sys_platform != 'darwin'",
     "torch; sys_platform != 'darwin'",
+    "torchvision; sys_platform != 'darwin'",
     "cuequivariance-ops-torch-cu12>=0.8.0; sys_platform != 'darwin'",
 ]
 cu13 = [
@@ -75,6 +76,7 @@ cu13 = [
     "nvidia-physicsnemo[cu13]>=2.0.0; sys_platform != 'darwin'",
     "cuml-cu13>=25.6.0; sys_platform != 'darwin'",
     "torch; sys_platform != 'darwin'",
+    "torchvision; sys_platform != 'darwin'",
     "cuequivariance-ops-torch-cu13>=0.8.0; sys_platform != 'darwin'",
 ]
 pymatgen = [
@@ -116,6 +118,10 @@ dependency-metadata = [
 [tool.uv.sources]
 nvalchemi-toolkit-ops = { git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git", rev = "7a73c012b7fd5bc649701d2aec802b4b9511a355" }
 torch = [
+  { index = "pytorch-cu126", extra = "cu12", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cu130", extra = "cu13", marker = "sys_platform != 'darwin'" },
+]
+torchvision = [
   { index = "pytorch-cu126", extra = "cu12", marker = "sys_platform != 'darwin'" },
   { index = "pytorch-cu130", extra = "cu13", marker = "sys_platform != 'darwin'" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,17 +106,17 @@ override-dependencies = [
   "python-hostlist; sys_platform == 'never'"
 ]
 dependency-metadata = [
-  { name = "nvalchemi-toolkit-ops", version = "0.3.1", requires-dist = [
-    "warp-lang >= 1.10.0",
+  { name = "nvalchemi-toolkit-ops", version = "0.4.0", requires-dist = [
+    "warp-lang >= 1.13.0",
     "numpy",
-    "torch>=2.11.0 ; extra == 'torch'",
-    "torch>=2.11.0 ; extra == 'torch-cu12'",
-    "torch>=2.11.0 ; extra == 'torch-cu13'",
+    "torch>=2.8.0 ; extra == 'torch'",
+    "torch>=2.8.0 ; extra == 'torch-cu12'",
+    "torch>=2.8.0 ; extra == 'torch-cu13'",
   ], provides-extra = ["torch", "torch-cu12", "torch-cu13"] },
 ]
 
 [tool.uv.sources]
-nvalchemi-toolkit-ops = { git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git", rev = "7a73c012b7fd5bc649701d2aec802b4b9511a355" }
+nvalchemi-toolkit-ops = { git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git", rev = "0.4.0-rc" }
 torch = [
   { index = "pytorch-cu126", extra = "cu12", marker = "sys_platform != 'darwin'" },
   { index = "pytorch-cu130", extra = "cu13", marker = "sys_platform != 'darwin'" },

--- a/uv.lock
+++ b/uv.lock
@@ -103,8 +103,8 @@ overrides = [{ name = "python-hostlist", marker = "sys_platform == 'never'" }]
 
 [[manifest.dependency-metadata]]
 name = "nvalchemi-toolkit-ops"
-version = "0.3.1"
-requires-dist = ["warp-lang>=1.10.0", "numpy", "torch>=2.11.0 ; extra == 'torch'", "torch>=2.11.0 ; extra == 'torch-cu12'", "torch>=2.11.0 ; extra == 'torch-cu13'"]
+version = "0.4.0"
+requires-dist = ["warp-lang>=1.13.0", "numpy", "torch>=2.8.0 ; extra == 'torch'", "torch>=2.8.0 ; extra == 'torch-cu12'", "torch>=2.8.0 ; extra == 'torch-cu13'"]
 provides-extras = ["torch", "torch-cu12", "torch-cu13"]
 
 [[package]]
@@ -3639,6 +3639,7 @@ cu12 = [
     { name = "nvalchemi-toolkit-ops", extra = ["torch-cu12"], marker = "(sys_platform != 'darwin' and extra == 'extra-17-nvalchemi-toolkit-cu12') or (extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "nvidia-physicsnemo", extra = ["cu12"], marker = "(sys_platform != 'darwin' and extra == 'extra-17-nvalchemi-toolkit-cu12') or (extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.27.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "sys_platform != 'darwin'" },
 ]
 cu13 = [
     { name = "cuequivariance-ops-torch-cu13", marker = "sys_platform != 'darwin'" },
@@ -3646,6 +3647,7 @@ cu13 = [
     { name = "nvalchemi-toolkit-ops", extra = ["torch-cu13"], marker = "(sys_platform != 'darwin' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "nvidia-physicsnemo", extra = ["cu13"], marker = "(sys_platform != 'darwin' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform != 'darwin'" },
 ]
 mace = [
     { name = "cuequivariance-torch" },
@@ -3713,9 +3715,9 @@ requires-dist = [
     { name = "loguru" },
     { name = "mace-torch", marker = "extra == 'mace'", specifier = "==0.3.15" },
     { name = "numpy" },
-    { name = "nvalchemi-toolkit-ops", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=7a73c012b7fd5bc649701d2aec802b4b9511a355" },
-    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=7a73c012b7fd5bc649701d2aec802b4b9511a355" },
-    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=7a73c012b7fd5bc649701d2aec802b4b9511a355" },
+    { name = "nvalchemi-toolkit-ops", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=0.4.0-rc" },
+    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=0.4.0-rc" },
+    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=0.4.0-rc" },
     { name = "nvidia-physicsnemo", specifier = ">=2.0.0" },
     { name = "nvidia-physicsnemo", extras = ["cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", specifier = ">=2.0.0" },
     { name = "nvidia-physicsnemo", extras = ["cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", specifier = ">=2.0.0" },
@@ -3728,6 +3730,8 @@ requires-dist = [
     { name = "torch", specifier = ">=2.8" },
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cu12'", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "nvalchemi-toolkit", extra = "cu12" } },
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cu13'", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "nvalchemi-toolkit", extra = "cu13" } },
+    { name = "torchvision", marker = "sys_platform != 'darwin' and extra == 'cu12'", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "nvalchemi-toolkit", extra = "cu12" } },
+    { name = "torchvision", marker = "sys_platform != 'darwin' and extra == 'cu13'", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "nvalchemi-toolkit", extra = "cu13" } },
     { name = "zarr", specifier = ">=3" },
 ]
 provides-extras = ["aimnet", "ase", "cu12", "cu13", "mace", "pymatgen"]
@@ -3776,8 +3780,8 @@ docs = [
 
 [[package]]
 name = "nvalchemi-toolkit-ops"
-version = "0.3.1"
-source = { git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=7a73c012b7fd5bc649701d2aec802b4b9511a355#7a73c012b7fd5bc649701d2aec802b4b9511a355" }
+version = "0.4.0"
+source = { git = "https://github.com/NVIDIA/nvalchemi-toolkit-ops.git?rev=0.4.0-rc#83efef3214b1d66b53e3802036c9d8d79d3a2c81" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13' or extra != 'extra-17-nvalchemi-toolkit-cu12'" },
@@ -4800,7 +4804,9 @@ dependencies = [
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
-    { name = "torchvision" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
+    { name = "torchvision", version = "0.27.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
     { name = "tqdm" },
     { name = "treelib" },
     { name = "warp-lang" },
@@ -4816,7 +4822,7 @@ cu12 = [
     { name = "nvidia-dali-cuda120" },
     { name = "pylibraft-cu12" },
     { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
-    { name = "torchvision" },
+    { name = "torchvision", version = "0.27.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
 ]
 cu13 = [
     { name = "cuml-cu13" },
@@ -4824,7 +4830,7 @@ cu13 = [
     { name = "nvidia-dali-cuda130" },
     { name = "pylibraft-cu13" },
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
-    { name = "torchvision" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 
 [[package]]
@@ -6969,7 +6975,9 @@ dependencies = [
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
     { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
-    { name = "torchvision" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
+    { name = "torchvision", version = "0.27.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -7264,13 +7272,30 @@ wheels = [
 name = "torchvision"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13' or extra != 'extra-17-nvalchemi-toolkit-cu12'" },
-    { name = "pillow" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
+    { name = "pillow", marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-17-nvalchemi-toolkit-cu12' and extra == 'extra-17-nvalchemi-toolkit-cu13') or (extra != 'extra-17-nvalchemi-toolkit-cu12' and extra != 'extra-17-nvalchemi-toolkit-cu13')" },
-    { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/d6/a7e71e981042d5c573e2e61891b9023b190c88adb75b18bed8594371250c/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", size = 1758812, upload-time = "2026-05-13T14:57:16.662Z" },
@@ -7289,6 +7314,130 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
     { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
     { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.27.0+cu126"
+source = { registry = "https://download.pytorch.org/whl/cu126" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
+    { name = "pillow", marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
+    { name = "torch", version = "2.12.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cb9c6377ff8d1716689a58f641a5ccc74e58f7c8c0d1495139d7ca3bc055754d", upload-time = "2026-05-12T16:20:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:70e142b5ab5dea7f70dba395f1cee17eb43f58f4c6c625e368b626b41b6f6c3b", upload-time = "2026-05-12T16:20:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:6cb74e3accf038fb375273f2bc31d6128dfb00824c8ce8264d9d0fce051e9fb7", upload-time = "2026-05-13T02:00:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a4bcd3ea7e9124fb40674dd143a3a28cbde63adc8de6d6ffe1d6810cd40032be", upload-time = "2026-05-12T16:20:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d4d03bbe04a2a9320554f31e6219638f869fc289c175388525cb49ac589ee027", upload-time = "2026-05-12T16:20:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:038691814aef031fddb1c654cc514168b375067840ce189f03de0382f6a72c13", upload-time = "2026-05-13T02:00:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:313c8fbc1fa7b0e5192752601e91c3c9987f6f5ee1342691b465e0c33653a307", upload-time = "2026-05-12T16:20:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:56477bd091009afc733931724d66c56b21c9fa14ba2c3a1ec24c8ddce86b5cd8", upload-time = "2026-05-12T16:20:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313-win_amd64.whl", hash = "sha256:b92a80f74b638f6e8c29b1319eb69701ceea98c0ac3c166ac8ef3f45a0493400", upload-time = "2026-05-13T02:00:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af5367582f4189ec76b3ec0ef9b3503a55b03e57e05cdea62d44e12cacbf4b8a", upload-time = "2026-05-12T16:20:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:836e7bb5c54238cb810bc263529f63b4b6ed8d183d5c764d5368902fb1acab19", upload-time = "2026-05-12T16:20:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.27.0%2Bcu126-cp313-cp313t-win_amd64.whl", hash = "sha256:3335086359b4e210ebd6240cb383c63ad265345cb8f8041bf0fe876822a6ab4d", upload-time = "2026-05-13T02:00:40Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.27.0+cu130"
+source = { registry = "https://download.pytorch.org/whl/cu130" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
+    { name = "pillow", marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2aab6d1ce1c476b6e5ddba884d5b65e6819ca3db58ad4d9f863aba102d487a1d", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f90237398efb8ce7001b80e1870c921b3a375d91c892ba8b46415f8085a3711d", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:cf6b38f3828868962e5469800353be923983ff90a34c9a1ceebc83fafd662e79", upload-time = "2026-05-13T02:00:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0a839a2921410b1135add4c3d90f784c9d1e9e9f3c7b401b216d356ddca23ab2", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:664dff46fac97a730c90a976a370ae2cad52780df6ae40fad74be77eee8b4528", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:a79f78d23557b5299c1a1eceeef846d6799ea0a3afe30c600c80ebd26a80bbf8", upload-time = "2026-05-13T02:00:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:da81245777c47f6dfd60e02f510d9778fb7f6e23119e2fc1ea1bb06777aae338", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:afa4128f37066b83af9d426841a53147dd3c208efea893c93dc3eb6fa2af2287", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:31533c28f23bf642989a9ae12caa40a2f8cc9b443d556ba2ffb7a51f759e6a11", upload-time = "2026-05-13T02:00:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:bb511f033cd3d6f304dc25753d2a28a1d77aa4dd54a219242d9df7fa57d8dd0a", upload-time = "2026-05-12T16:20:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:0c375ac4e9a1c09308f81b73d111d50b76eec335dc91a1811ae370467db2cf47", upload-time = "2026-05-12T16:20:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:34d108e1ce8255e017bf1f732a51ab2e9ddffb443d118db499a0fbbeb0164650", upload-time = "2026-05-13T02:00:47Z" },
 ]
 
 [[package]]
@@ -7467,17 +7616,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.1"
+version = "1.14.0"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu12'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-17-nvalchemi-toolkit-cu13' or extra != 'extra-17-nvalchemi-toolkit-cu12'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1ad11f1fa775269e991a3d55039152c8a504baf86701c849b485cb8e66c49d15" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8b098f41e71d421d80ee7562e38aa8380ff6b0d3b4c6ee866cfbdef733ac5bdc" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5d0904b0eefcc81f39ba65375427a3de99006088aa43e24a9011263f07d0cd07" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.1-py3-none-win_amd64.whl", hash = "sha256:15dc10aa51fb0fdbe1ca16d52e5fadca35a47ffd9d0c636826506f96bb2e7c41" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:12656050545cc77bf9b9b155399496c1a6279b5b6c59e407507d6858a2beb4a2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:70cd127d0e9109417099649fedf9d00f39f1307ccb7a6e9fb87661337868d7de" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:f482787e8da9c9ef045601fde99095e16d604fbcc3cbb4a1e0cef0769388b316" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-win_amd64.whl", hash = "sha256:936b49ec78237f9760e58cbe9c46ee6f4244aefbd62071c4fa9fd3b313dfa878" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR bumps the pinned `nvalchemi-toolkit-ops` to version 0.4.0.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Update the lockfile as well as `pyproject.toml` with the new version.
- Fixes a neighbor list hook issue due to changes in the toolkit-ops API and `torch.compile` compatibility
- Adds the neighbor list strategy mapping for tile and non-tile method selection

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
