### PR TITLE
docs(skills): add use-when trigger clauses to skill descriptions; document agent access in README

### DIFF
--- a/.claude/skills/nvalchemi-data-storage/SKILL.md
+++ b/.claude/skills/nvalchemi-data-storage/SKILL.md
@@ -3,7 +3,10 @@ name: nvalchemi-data-storage
 description: >-
   How to write, read, compose, and load atomic data using nvalchemi's
   composable Zarr-backed storage pipeline (Writer, Reader, Dataset,
-  MultiDataset, DataLoader).
+  MultiDataset, DataLoader). Use when saving simulation outputs or
+  trajectories to disk, converting structures (e.g. ASE / extxyz) into Zarr
+  stores, assembling datasets for training or inference, or wiring a
+  DataLoader to stream batches to the GPU.
 ---
 
 # nvalchemi Data Storage

--- a/.claude/skills/nvalchemi-data-structures/SKILL.md
+++ b/.claude/skills/nvalchemi-data-structures/SKILL.md
@@ -2,7 +2,10 @@
 name: nvalchemi-data-structures
 description: >-
   How to use AtomicData and Batch, the core graph-based data structures for
-  representing atomic systems and batching them for GPU computation.
+  representing atomic systems and batching them for GPU computation. Use when
+  building systems from positions, cells, and atomic numbers, converting from
+  ASE Atoms, batching or unbatching structures, reading per-atom vs per-graph
+  tensors, or debugging shape, dtype, or device errors in model inputs.
 ---
 
 # nvalchemi Data Structures

--- a/.claude/skills/nvalchemi-dynamics-api/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-api/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: nvalchemi-dynamics-api
-description: How to configure and run dynamics simulations, compose multi-stage pipelines (FusedStage, DistributedPipeline), use inflight batching, and manage data sinks.
+description: >-
+  How to configure and run dynamics simulations, compose multi-stage pipelines
+  (FusedStage, DistributedPipeline), use inflight batching, and manage data
+  sinks. Use when writing any simulation script — molecular dynamics
+  (NVE/NVT), structure relaxation or geometry optimization (e.g. FIRE),
+  equation-of-state or adsorption scans — or orchestrating many structures
+  through a batched GPU pipeline.
 ---
 
 # nvalchemi Dynamics API

--- a/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-hooks/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: nvalchemi-dynamics-hooks
-description: How to use and write dynamics hooks — callbacks that observe or
-  modify batch state at specific points during each simulation step.
+description: >-
+  How to use and write dynamics hooks — callbacks that observe or modify batch
+  state at specific points during each simulation step. Use when a simulation
+  needs neighbor-list rebuilds, convergence checks or early stopping,
+  temperature control, per-step logging or trajectory capture, or any custom
+  per-step behavior attached to a dynamics run.
 ---
 
 # nvalchemi Hooks

--- a/.claude/skills/nvalchemi-dynamics-implementation/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-implementation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: nvalchemi-dynamics-implementation
-description: How to implement a dynamics integrator by subclassing BaseDynamics and overriding pre_update() and post_update() methods.
+description: >-
+  How to implement a dynamics integrator by subclassing BaseDynamics and
+  overriding pre_update() and post_update() methods. Use when creating a
+  custom integrator, optimizer, or sampler that the built-in stages do not
+  provide; for configuring existing dynamics, see nvalchemi-dynamics-api.
 ---
 
 # nvalchemi Dynamics Implementation

--- a/.claude/skills/nvalchemi-fine-tuning/SKILL.md
+++ b/.claude/skills/nvalchemi-fine-tuning/SKILL.md
@@ -5,6 +5,9 @@ description: >-
   pretrained checkpoint initialization, module patches, trainable-parameter
   filters, conservative optimizer defaults, validation, restart checkpoints,
   and model-agnostic MACE, AIMNet2, custom BaseModelMixin, or PyTorch inputs.
+  Use when adapting a pretrained MLIP (e.g. MACE-MP) to new reference data,
+  freezing or patching submodules during training, or resuming an interrupted
+  fine-tune from a checkpoint.
 ---
 
 # nvalchemi Fine Tuning

--- a/.claude/skills/nvalchemi-loss-api/SKILL.md
+++ b/.claude/skills/nvalchemi-loss-api/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: nvalchemi-loss-api
-description: How to use built-in loss functions and implement custom losses using the BaseLossFunction template-method pattern — residual types, per-atom normalization, masking, and graph-balanced reductions.
+description: >-
+  How to use built-in loss functions and implement custom losses using the
+  BaseLossFunction template-method pattern — residual types, per-atom
+  normalization, masking, and graph-balanced reductions. Use when choosing or
+  weighting energy, force, or stress objectives for training or fine-tuning,
+  masking atoms or graphs out of the loss, or writing a custom loss term.
 ---
 
 # nvalchemi Loss API

--- a/.claude/skills/nvalchemi-model-wrapping/SKILL.md
+++ b/.claude/skills/nvalchemi-model-wrapping/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: nvalchemi-model-wrapping
-description: How to wrap an arbitrary MLIP (Machine Learning Interatomic Potential) using the BaseModelMixin interface to standardize inputs, outputs, and embeddings.
+description: >-
+  How to wrap an arbitrary MLIP (Machine Learning Interatomic Potential) using
+  the BaseModelMixin interface to standardize inputs, outputs, and embeddings.
+  Use when integrating a model such as MACE or AIMNet2 (e.g. MACEWrapper,
+  loading pretrained checkpoints) so dynamics, training, or fine-tuning stages
+  can call it, or when exposing energies, forces, or embeddings from a custom
+  PyTorch model.
 ---
 
 # nvalchemi Model Wrapping

--- a/.claude/skills/nvalchemi-reporting/SKILL.md
+++ b/.claude/skills/nvalchemi-reporting/SKILL.md
@@ -3,10 +3,11 @@ name: nvalchemi-reporting
 description: >-
   How to add observability to nvalchemi dynamics and training workflows using
   ReportingOrchestrator, RichReporter, TensorBoardReporter, scalar extraction,
-  custom reporter callbacks, and dynamics LoggingHook. Use when Codex needs to
-  show live progress, write TensorBoard summaries, preserve dynamics CSV rows,
-  add rank-safe distributed reporting, preview Rich dashboards, or decide
-  between logging and reporting for training or molecular dynamics runs.
+  custom reporter callbacks, and dynamics LoggingHook. Use when showing live
+  progress, writing TensorBoard summaries, preserving dynamics CSV rows,
+  adding rank-safe distributed reporting, previewing Rich dashboards, or
+  deciding between logging and reporting for training or molecular dynamics
+  runs.
 ---
 
 # nvalchemi Reporting

--- a/.claude/skills/nvalchemi-training-api/SKILL.md
+++ b/.claude/skills/nvalchemi-training-api/SKILL.md
@@ -4,7 +4,9 @@ description: >-
   How to configure nvalchemi training workflows with TrainingStrategy, custom
   training functions, standalone or composed losses, loss-weight schedules,
   optimizer and scheduler configs, validation, hooks, restartable checkpoints,
-  and model-agnostic inputs.
+  and model-agnostic inputs. Use when training a model from scratch or setting
+  up optimizers, schedulers, validation, or checkpointing for a training run;
+  for adapting a pretrained model, see nvalchemi-fine-tuning.
 ---
 
 # nvalchemi Training API

--- a/README.md
+++ b/README.md
@@ -33,11 +33,24 @@ NVIDIA GPUs.
   [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
   for GPU-optimized neighbor lists, dispersion, and electrostatics via
   NVIDIA `warp-lang`
-- Agents as first-class citizens; includes core `SKILLS.md` library that
-  teach agents how to use `nvalchemi` efficiently in agentic workflows.
-  Simply copy the `.claude/skills` folder contents to your project repository
-  or home directory depending on use case and agent platform (e.g. Claude
-  Code, Cursor, OpenCode).
+- Agents as first-class citizens; includes a core skills library that
+  teaches agents how to use `nvalchemi` efficiently in agentic workflows
+  (see [Using with AI coding agents](#using-with-ai-coding-agents))
+
+### Using with AI coding agents
+
+The repository ships agent-facing guidance at two levels:
+
+- **Skills** — task-specific API guides under `.claude/skills/`. Claude Code
+  discovers them automatically when working inside a clone; for other
+  platforms (e.g. Cursor, OpenCode), or to use them outside this repository,
+  copy the folder contents into your project's or home skills directory.
+- **`AGENTS.md`** — repository-wide guidance (setup, conventions, gotchas).
+  Agents that follow the `AGENTS.md` convention (e.g. Codex, Cursor,
+  OpenCode) load it natively. Claude Code auto-loads `CLAUDE.md` instead: to
+  get the same guidance there, add a `CLAUDE.md` to your clone containing the
+  single line `@AGENTS.md` (an import), or symlink it
+  (`ln -s AGENTS.md CLAUDE.md`).
 
 ### Example Snippets
 


### PR DESCRIPTION
## Description

Coding agents auto-invoke a skill based solely on its `SKILL.md` frontmatter `description`; the body is only loaded after invocation. The official [Agent Skills authoring guidance](https://code.claude.com/docs/en/skills) therefore recommends descriptions that pair *what the skill does* with an explicit *"Use when ..."* trigger clause naming the user situations it serves. Nine of the eleven skills here describe only their content ("How to X...") with no trigger clause, and `nvalchemi-reporting`'s existing clause addresses one agent ("Codex") by name. Measurably, this under-triggers: task-phrased prompts ("relax bulk silicon...", "compute an equation of state...") fail to surface `nvalchemi-dynamics-api` because *relaxation*, *geometry optimization*, and *EOS* appear nowhere in its description.

This PR: **(1)** appends a third-person "Use when ..." clause to the nine descriptions, naming concrete tasks; **(2)** makes the reporting clause agent-agnostic; **(3)** adds a README *Using with AI coding agents* section documenting how agents on any platform reach both guidance levels: the skills library, and `AGENTS.md` (which Claude Code does not auto-load; per the [memory documentation](https://code.claude.com/docs/en/memory#agents-md), a clone-local `CLAUDE.md` importing it is the recommended integration). No skill bodies or code paths are touched; all descriptions remain well under the documented 1,536-character limit.

## Type of Change

- [x] Documentation update

## Related Issues

N/A

## Changes Made

- Add "Use when ..." trigger clauses to 9 skill descriptions (MD, relaxation/geometry optimization, EOS/adsorption scans, checkpoint loading, dataset assembly, custom losses, observability, custom integrators, training)
- `nvalchemi-reporting`: drop the "Codex" actor from its clause
- README: new *Using with AI coding agents* section (skills discovery/copying; `AGENTS.md` natively, or via a `CLAUDE.md` import/symlink for Claude Code)

## Testing

Measured skill auto-triggering with headless Claude Code against this repo at `526cb8b` (stock) vs this branch: 12 task-phrased positive prompts covering all 11 skills plus 4 negative prompts (over-triggering guards), in two regimes: *easy* (repo-anchored question, read-only tools) and *hard* (cold "write a script" request with file-writing enabled, resembling real usage). Two models (Claude Opus 4.8, Claude Sonnet 5), ~420 scored runs.

| evidence | stock | this PR |
|---|---|---|
| Opus, hard, EOS prompt (n=10/condition) | **1/10** triggered `dynamics-api` | **10/10** |
| Opus, hard, relax prompt (n=3) | 0/3 | 3/3 |
| Sonnet, hard, EOS prompt (n=3) | 0/3 | 2/3 |
| Opus, easy, EOS prompt (n=10) | 9/10 | 8/10 (no effect: the gap only exists under generation pressure) |
| all other skills, both models/regimes | at ceiling | unchanged |
| 4 negative prompts, all conditions (~100 runs) | 100% clean | 100% clean (no over-triggering) |

**Model-dependent finding:** the under-triggering is worst on the *stronger* model. Sonnet consults skills liberally and mostly compensates for sparse descriptions; Opus under generation pressure skips skills whose descriptions don't lexically match the task (relaxation/EOS: 0/3 and 1/10 stock) and recovers fully with the clauses (3/3, 10/10). The only prompt that failed on *both* models was the EOS one, which has zero vocabulary overlap with the stock description; it recovers on both with this PR. Importantly, the clauses make nothing meaningfully worse for either model: run-to-run variation at three repeats affected one Sonnet batching prompt in both directions of the comparison, overall Sonnet means were unchanged, every other skill stayed at ceiling, and no negative prompt ever mis-triggered. Ideally triggering would be validated across more models, agent platforms, and prompt combinations; we consider that out of scope here and report two Claude tiers as directional evidence.

Stock-description misses either invoked no skill or only adjacent ones (`model-wrapping`, `data-structures`), never the simulation API itself.

- [ ] Unit tests pass locally (`make pytest`): n/a, no code changed
- [x] Linting passes: `pre-commit run` on all touched files passes
- [ ] New tests added: n/a

## Checklist

- [x] I have read and understand the Contributing Guidelines
- [ ] I have updated the CHANGELOG.md: not needed (docs/metadata only, no library changes)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes: n/a
- [x] I have updated the documentation (README)

## Additional Notes

The eval methodology is a small self-contained harness (headless `claude -p` runs in a throwaway worktree, scoring `Skill`-tool invocations from stream-json, easy/hard regimes, negative controls); happy to contribute it in a follow-up if useful. Separately observed while auditing: `nvalchemi-dynamics-api`'s body is 548 lines vs the documented ~500-line guideline, a possible follow-up to split reference material into supporting files.
