### PR TITLE
Add in-memory dataset data pipe

### DIFF
--- a/.claude/skills/nvalchemi-data-storage/SKILL.md
+++ b/.claude/skills/nvalchemi-data-storage/SKILL.md
@@ -183,9 +183,32 @@ ds.cancel_prefetch()       # cancel all
 ds.cancel_prefetch(0)      # cancel specific index
 ```
 
+### In-memory datasets
+
+When advising on dataset choice, suggest `InMemoryDataset` if the full dataset is
+small enough to fit comfortably in host memory. A good rule of thumb is "on the
+order of a few GB after batching." This avoids storage I/O after startup and can
+speed up training or benchmarking.
+
+If the dataset is larger than host memory, or if keeping an extra resident copy
+would pressure the training job, recommend regular reader-backed `Dataset`
+instead so samples are loaded from storage on demand.
+
+```python
+from nvalchemi.data.datapipes import AtomicDataZarrReader, InMemoryDataset
+
+reader = AtomicDataZarrReader("dataset.zarr")
+ds = InMemoryDataset(
+    reader=reader,
+    chunk_size=32768,
+    device="cuda",          # emitted batch target; resident cache stays on CPU
+    skip_validation=True,   # only for trusted toolkit-written stores
+)
+```
+
 ### High-level: DataLoader
 
-Iterates over a `Dataset` in batches, producing `Batch` objects.
+Iterates over a batch-loadable dataset in batches, producing `Batch` objects.
 
 ```python
 from nvalchemi.data.datapipes import AtomicDataZarrReader, Dataset, DataLoader
@@ -221,8 +244,9 @@ batch reads, use `load_batches(...)`.
 
 ### Composing multiple datasets
 
-Use `MultiDataset` to concatenate multiple `Dataset` instances behind one global
-index space while keeping the same `load_batches(...)` fast path:
+Use `MultiDataset` to concatenate multiple batch-loadable datasets, including
+reader-backed `Dataset` and `InMemoryDataset`, behind one global index space
+while keeping the same `load_batches(...)` fast path:
 
 ```python
 from nvalchemi.data.datapipes import (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 
 ### Core Data Layer
 
+- **In-memory datapipes** - new `InMemoryDataset` stores a fully materialized
+  `Batch` in memory and serves graph-indexed `Batch` selections through the
+  same `load_batches` / fused-prefetch interface used by `DataLoader`. It can
+  be constructed from an existing `Batch` or materialized from a reader in
+  chunks, with optional field-level metadata and batch transforms.
 - **User-specified transforms** - `Dataset` accepts a `transforms=` kwarg
   (per-sample `(AtomicData, metadata) -> (AtomicData, metadata)`) and
   `DataLoader` accepts a `batch_transforms=` kwarg (per-batch `Batch -> Batch`).

--- a/docs/modules/data.rst
+++ b/docs/modules/data.rst
@@ -28,6 +28,7 @@ I/O and pipelines
    AtomicDataZarrWriter
    AtomicDataZarrReader
    Dataset
+   InMemoryDataset
    DataLoader
    Reader
 

--- a/docs/userguide/datapipes.md
+++ b/docs/userguide/datapipes.md
@@ -9,9 +9,10 @@ workloads. It is built from four composable pieces: a **Reader** that pulls raw
 tensors from storage, a **Dataset** that validates them into
 {py:class}`nvalchemi.data.AtomicData` objects, a **DataLoader** that batches them
 into {py:class}`nvalchemi.data.Batch` objects, and an optional **Sampler** that
-controls batching strategy. A **MultiDataset** can also compose several datasets
-behind one global index space. Each layer adds exactly one concern, and you can
-swap any of them independently.
+controls batching strategy. An **InMemoryDataset** can replace Dataset when the
+full dataset can fit in memory for faster performance, and a **MultiDataset** can
+compose several datasets behind one global index space. Each layer adds exactly
+one concern, and you can swap any of them independently.
 
 ```{note}
 The ``datapipes`` abstraction is shared with ``physicsnemo``: there are some
@@ -189,6 +190,56 @@ deciding which samples to group into a batch.
 {py:meth}`~nvalchemi.data.datapipes.dataset.Dataset.get_metadata` returns
 `(num_atoms, num_edges)` for a given index without constructing the full
 `AtomicData`, keeping the overhead low.
+
+### In-memory datasets
+
+{py:class}`~nvalchemi.data.datapipes.in_memory_dataset.InMemoryDataset` keeps the
+entire dataset as one {py:class}`nvalchemi.data.Batch` and serves graph selections
+from that resident batch. Use it when a dataset is small enough to keep in memory,
+when data has already been materialized by another pipeline stage, or when
+benchmarking/training should avoid storage I/O after startup.
+
+You can pass a fully loaded batch directly, or provide a Reader and let the
+dataset materialize it once at construction time:
+
+```python
+from nvalchemi.data.datapipes import AtomicDataZarrReader, DataLoader, InMemoryDataset
+
+reader = AtomicDataZarrReader("/path/to/store.zarr")
+dataset = InMemoryDataset(
+    reader=reader,
+    chunk_size=32768,
+    device="cuda",
+    skip_validation=True,  # use for trusted stores written by the toolkit
+)
+
+loader = DataLoader(
+    dataset=dataset,
+    batch_size=64,
+    shuffle=True,
+    pin_memory=True,
+)
+```
+
+`InMemoryDataset` implements the same DataLoader-facing batch contract as
+`Dataset`: `load_batches(...)`, `prefetch_fused_batches(...)`,
+`get_fused_batches()`, `has_pending_fused_batches()`, and
+`cancel_prefetch(...)`.
+Reader-backed in-memory datasets keep the resident cache on CPU, while
+``device`` controls the emitted batch target device. With a CPU cache and CUDA
+target, fused prefetch enqueues the CPU-to-GPU transfer on the DataLoader CUDA
+stream. Per-batch transforms supplied at construction are applied while
+materializing Reader chunks; DataLoader `batch_transforms` still run on each
+emitted batch. Keep `pin_memory=True` for CPU-resident in-memory datasets that
+feed CUDA training; disable pinning if the in-memory batch already lives on CUDA.
+
+Like `Dataset`, `InMemoryDataset` validates reader samples by default while it
+materializes the resident batch. Pass `skip_validation=True` for trusted stores
+written by the toolkit to build chunks directly from raw tensor dictionaries via
+{py:meth}`~nvalchemi.data.Batch.from_raw_dicts`. This avoids per-sample
+Pydantic overhead during startup and matches the fastest Dataset loading path.
+Do not use it for untrusted stores or data whose schema has not already been
+validated.
 
 ## DataLoader: batching and iteration
 

--- a/docs/userguide/datapipes.md
+++ b/docs/userguide/datapipes.md
@@ -10,9 +10,9 @@ tensors from storage, a **Dataset** that validates them into
 {py:class}`nvalchemi.data.AtomicData` objects, a **DataLoader** that batches them
 into {py:class}`nvalchemi.data.Batch` objects, and an optional **Sampler** that
 controls batching strategy. An **InMemoryDataset** can replace Dataset when the
-full dataset can fit in memory for faster performance, and a **MultiDataset** can
-compose several datasets behind one global index space. Each layer adds exactly
-one concern, and you can swap any of them independently.
+full dataset fits comfortably in host memory, and a **MultiDataset** can compose
+several datasets behind one global index space. Each layer adds exactly one concern,
+and you can swap any of them independently.
 
 ```{note}
 The ``datapipes`` abstraction is shared with ``physicsnemo``: there are some
@@ -195,9 +195,13 @@ deciding which samples to group into a batch.
 
 {py:class}`~nvalchemi.data.datapipes.in_memory_dataset.InMemoryDataset` keeps the
 entire dataset as one {py:class}`nvalchemi.data.Batch` and serves graph selections
-from that resident batch. Use it when a dataset is small enough to keep in memory,
-when data has already been materialized by another pipeline stage, or when
-benchmarking/training should avoid storage I/O after startup.
+from that resident batch. Use it when a dataset is small enough to keep in host
+memory --- as a rule of thumb, on the order of a few GB after batching --- when
+data has already been materialized by another pipeline stage, or when
+benchmarking/training should avoid storage I/O after startup. For larger datasets
+that do not fit comfortably in host memory, use the regular
+{py:class}`~nvalchemi.data.datapipes.dataset.Dataset` so samples are loaded from
+storage on demand.
 
 You can pass a fully loaded batch directly, or provide a Reader and let the
 dataset materialize it once at construction time:
@@ -318,11 +322,18 @@ tensors before asynchronous transfer. See
 ## MultiDataset: composing datasets
 
 {py:class}`~nvalchemi.data.datapipes.multidataset.MultiDataset` concatenates
-multiple {py:class}`~nvalchemi.data.datapipes.dataset.Dataset` instances behind
+multiple batch-loadable datasets, such as
+{py:class}`~nvalchemi.data.datapipes.dataset.Dataset` and
+{py:class}`~nvalchemi.data.datapipes.in_memory_dataset.InMemoryDataset`, behind
 one global index space. It follows the PhysicsNeMo multidataset indexing contract
 while preserving the nvalchemi batch fast path: `load_batches(...)` routes each
 global batch to the relevant child datasets and recombines mixed-child batches in
 the requested sample order.
+
+You can mix reader-backed `Dataset` children with `InMemoryDataset` children in
+the same `MultiDataset`. This is covered by unit tests for correctness, but
+mixed in-memory/on-demand performance depends on the workload and has not yet
+been benchmarked.
 
 ```python
 from nvalchemi.data.datapipes import (

--- a/docs/userguide/zarr_compression.md
+++ b/docs/userguide/zarr_compression.md
@@ -761,11 +761,19 @@ own writer --- you can bypass this:
 dataset = Dataset(reader=reader, device="cuda:0", skip_validation=True)
 ```
 
-With `skip_validation=True` the Dataset constructs
+`InMemoryDataset` accepts the same flag when materializing a reader-backed
+resident batch:
+
+```python
+dataset = InMemoryDataset(reader=reader, device="cuda:0", skip_validation=True)
+```
+
+With `skip_validation=True` the Dataset or InMemoryDataset constructs
 {py:class}`~nvalchemi.data.Batch` objects directly from raw tensor
 dictionaries via
 {py:meth}`~nvalchemi.data.Batch.from_raw_dicts`, avoiding per-sample
-Pydantic overhead entirely.
+Pydantic overhead. For InMemoryDataset this speeds up initial materialization;
+subsequent DataLoader iteration selects graphs from the resident batch.
 
 ```{warning}
 ``skip_validation`` trusts the store contents.  Use it only with stores

--- a/nvalchemi/data/__init__.py
+++ b/nvalchemi/data/__init__.py
@@ -20,6 +20,7 @@ from nvalchemi.data.batch import Batch
 from nvalchemi.data.datapipes import (
     AtomicDataZarrReader,
     AtomicDataZarrWriter,
+    BatchDatasetProtocol,
     DataLoader,
     Dataset,
     InMemoryDataset,
@@ -35,6 +36,7 @@ __all__ = [
     "Reader",
     "AtomicDataZarrReader",
     "AtomicDataZarrWriter",
+    "BatchDatasetProtocol",
     "Dataset",
     "InMemoryDataset",
     "DataLoader",

--- a/nvalchemi/data/__init__.py
+++ b/nvalchemi/data/__init__.py
@@ -22,6 +22,7 @@ from nvalchemi.data.datapipes import (
     AtomicDataZarrWriter,
     DataLoader,
     Dataset,
+    InMemoryDataset,
     Reader,
 )
 from nvalchemi.data.transforms import Compose
@@ -35,6 +36,7 @@ __all__ = [
     "AtomicDataZarrReader",
     "AtomicDataZarrWriter",
     "Dataset",
+    "InMemoryDataset",
     "DataLoader",
     # Transforms
     "Compose",

--- a/nvalchemi/data/datapipes/__init__.py
+++ b/nvalchemi/data/datapipes/__init__.py
@@ -77,6 +77,7 @@ from nvalchemi.data.datapipes.backends.zarr import (
 )
 from nvalchemi.data.datapipes.dataloader import DataLoader
 from nvalchemi.data.datapipes.dataset import Dataset
+from nvalchemi.data.datapipes.in_memory_dataset import InMemoryDataset
 from nvalchemi.data.datapipes.multidataset import MultiDataset
 from nvalchemi.data.datapipes.samplers import (
     DistributedSamplerProtocol,
@@ -93,6 +94,7 @@ __all__ = [
     "ZarrWriteConfig",
     # Pipeline
     "Dataset",
+    "InMemoryDataset",
     "MultiDataset",
     "DistributedSamplerProtocol",
     "MultiDatasetSampler",

--- a/nvalchemi/data/datapipes/__init__.py
+++ b/nvalchemi/data/datapipes/__init__.py
@@ -76,7 +76,7 @@ from nvalchemi.data.datapipes.backends.zarr import (
     ZarrWriteConfig,
 )
 from nvalchemi.data.datapipes.dataloader import DataLoader
-from nvalchemi.data.datapipes.dataset import Dataset
+from nvalchemi.data.datapipes.dataset import BatchDatasetProtocol, Dataset
 from nvalchemi.data.datapipes.in_memory_dataset import InMemoryDataset
 from nvalchemi.data.datapipes.multidataset import MultiDataset
 from nvalchemi.data.datapipes.samplers import (
@@ -93,6 +93,7 @@ __all__ = [
     "ZarrArrayConfig",
     "ZarrWriteConfig",
     # Pipeline
+    "BatchDatasetProtocol",
     "Dataset",
     "InMemoryDataset",
     "MultiDataset",

--- a/nvalchemi/data/datapipes/dataloader.py
+++ b/nvalchemi/data/datapipes/dataloader.py
@@ -35,21 +35,21 @@ from torch.utils.data import RandomSampler, Sampler, SequentialSampler
 
 from nvalchemi._typing import BatchTransform
 from nvalchemi.data.batch import Batch
-from nvalchemi.data.datapipes.dataset import Dataset
+from nvalchemi.data.datapipes.dataset import BatchDatasetProtocol
 from nvalchemi.data.transforms import Compose
 
 
 class DataLoader:
     """Batch-iterating data loader that yields :class:`~nvalchemi.data.batch.Batch`.
 
-    Wraps a :class:`Dataset` and yields ``Batch`` objects
-    built via :meth:`Batch.from_data_list`. Fused prefetching is used by
+    Wraps a batch-loadable dataset and yields ``Batch`` objects. Fused
+    prefetching is used by
     default to amortize I/O across multiple emitted batches; CUDA streams are
     supported for overlapping device transfers when available.
 
     Parameters
     ----------
-    dataset : Dataset
+    dataset : BatchDatasetProtocol
         AtomicData-native dataset to load from.
     batch_size : int, default=1
         Number of samples per batch.
@@ -82,7 +82,7 @@ class DataLoader:
 
     Attributes
     ----------
-    dataset : Dataset
+    dataset : BatchDatasetProtocol
         The underlying dataset.
     batch_size : int
         Number of samples per batch.
@@ -142,7 +142,7 @@ class DataLoader:
 
     def __init__(
         self,
-        dataset: Dataset,
+        dataset: BatchDatasetProtocol,
         *,
         batch_size: int = 1,
         shuffle: bool = False,

--- a/nvalchemi/data/datapipes/dataset.py
+++ b/nvalchemi/data/datapipes/dataset.py
@@ -74,6 +74,74 @@ class ReaderProtocol(Protocol):
         ...
 
 
+@runtime_checkable
+class BatchDatasetProtocol(Protocol):
+    """Protocol for nvalchemi datasets that load :class:`Batch` objects.
+
+    Implementations provide the batch-loading and prefetch contract used by
+    :class:`~nvalchemi.data.datapipes.dataloader.DataLoader` and
+    :class:`~nvalchemi.data.datapipes.multidataset.MultiDataset`.
+    """
+
+    def __len__(self) -> int:
+        """Return the number of samples available for batching."""
+        ...
+
+    def __getitem__(self, index: int) -> tuple[AtomicData, dict[str, Any]]:
+        """Return one sample and its metadata by index."""
+        ...
+
+    def load_batches(
+        self,
+        batch_index_lists: Sequence[Sequence[int]],
+        stream: torch.cuda.Stream | None = None,
+    ) -> list[Batch]:
+        """Load several batches immediately."""
+        ...
+
+    def prefetch(self, index: int, stream: torch.cuda.Stream | None = None) -> None:
+        """Submit one sample for prefetching."""
+        ...
+
+    def prefetch_fused_batches(
+        self,
+        batch_index_lists: Sequence[Sequence[int]],
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """Submit multiple batches for fused prefetch."""
+        ...
+
+    def get_fused_batches(self) -> Iterator[Batch]:
+        """Consume the next pending fused prefetch result."""
+        ...
+
+    def has_pending_fused_batches(self) -> bool:
+        """Return whether fused prefetch results are waiting."""
+        ...
+
+    def cancel_prefetch(self, index: int | None = None) -> None:
+        """Cancel pending prefetch work."""
+        ...
+
+    @property
+    def prefetch_count(self) -> int:
+        """Return the number of queued prefetch requests."""
+        ...
+
+    @property
+    def field_names(self) -> list[str]:
+        """Return field names available in dataset samples."""
+        ...
+
+    def get_metadata(self, index: int) -> tuple[int, int]:
+        """Return lightweight metadata for a sample."""
+        ...
+
+    def close(self) -> None:
+        """Release resources held by the dataset."""
+        ...
+
+
 @dataclass
 class _PrefetchResult:
     """Container for async prefetch results.
@@ -147,6 +215,8 @@ class Dataset:
     Wraps a :class:`~nvalchemi.data.datapipes.backends.base.Reader` and returns
     :class:`~nvalchemi.data.atomic_data.AtomicData` objects directly,
     with CUDA-stream prefetching support.
+    ``Dataset`` implements :class:`BatchDatasetProtocol`, the batch-loading
+    protocol consumed by :class:`~nvalchemi.data.datapipes.dataloader.DataLoader`.
 
     Parameters
     ----------

--- a/nvalchemi/data/datapipes/in_memory_dataset.py
+++ b/nvalchemi/data/datapipes/in_memory_dataset.py
@@ -22,10 +22,11 @@ to materialize the full dataset during initialization.
 
 Once loaded, iteration and :meth:`load_batches` select graphs from the
 in-memory batch instead of reading from storage on each access.
-``InMemoryDataset`` implements the same DataLoader-facing batch contract as
-``Dataset``: ``load_batches(...)``, ``prefetch_fused_batches(...)``,
-``get_fused_batches()``, ``has_pending_fused_batches()``, and
-``cancel_prefetch(...)``.
+``InMemoryDataset`` follows
+:class:`~nvalchemi.data.datapipes.dataset.BatchDatasetProtocol`, exposing the
+same DataLoader-facing batch methods as ``Dataset``: ``load_batches(...)``,
+``prefetch_fused_batches(...)``, ``get_fused_batches()``,
+``has_pending_fused_batches()``, and ``cancel_prefetch(...)``.
 """
 
 from __future__ import annotations
@@ -72,11 +73,14 @@ class InMemoryDataset:
 
     Once loaded, iteration and :meth:`load_batches` select graphs from that
     in-memory batch instead of reading from storage on each access.
-    ``InMemoryDataset`` implements the same DataLoader-facing batch contract as
-    ``Dataset``: :meth:`__len__`, :meth:`load_batches`,
-    :meth:`prefetch_fused_batches`, :meth:`get_fused_batches`,
-    :meth:`has_pending_fused_batches`, and :meth:`cancel_prefetch`. The
-    :meth:`__getitem__` and :meth:`__iter__` methods are provided for
+    ``InMemoryDataset`` follows
+    :class:`~nvalchemi.data.datapipes.dataset.BatchDatasetProtocol`, exposing
+    the same DataLoader-facing batch methods as ``Dataset``: :meth:`__len__`,
+    :meth:`load_batches`, :meth:`prefetch_fused_batches`,
+    :meth:`get_fused_batches`, :meth:`has_pending_fused_batches`, and
+    :meth:`cancel_prefetch`. These methods use in-memory implementations rather
+    than reader-backed implementations. The :meth:`__getitem__` and
+    :meth:`__iter__` methods are provided for
     dataset-style access, but normal
     :class:`~nvalchemi.data.datapipes.DataLoader` iteration loads whole
     :class:`Batch` objects through the aforementioned methods instead of calling
@@ -317,6 +321,29 @@ class InMemoryDataset:
         return self.in_memory_batch.num_graphs
 
     @property
+    def field_names(self) -> list[str]:
+        """Return field names available in in-memory samples.
+
+        Returns
+        -------
+        list[str]
+            Field names exposed by the resident batch.
+        """
+        if len(self) > 0:
+            return [
+                key
+                for key in self.in_memory_batch[0].to_dict()
+                if not key.startswith("__")
+            ]
+        if self.in_memory_batch.keys is None:
+            return []
+        return [
+            *sorted(self.in_memory_batch.keys.get("node", set())),
+            *sorted(self.in_memory_batch.keys.get("edge", set())),
+            *sorted(self.in_memory_batch.keys.get("system", set())),
+        ]
+
+    @property
     def pin_memory(self) -> bool:
         """Whether the materialized CPU batch is pinned in page-locked memory."""
         return self._pin_memory
@@ -467,6 +494,21 @@ class InMemoryDataset:
             self._prepare_batches(batch_index_lists, stream=stream)
         )
 
+    def prefetch(self, index: int, stream: torch.cuda.Stream | None = None) -> None:
+        """Satisfy the sample-prefetch API without queuing work.
+
+        ``InMemoryDataset`` already holds every graph in ``in_memory_batch``, so
+        there is no reader I/O to overlap for an individual sample.
+
+        Parameters
+        ----------
+        index : int
+            Graph index within ``in_memory_batch``.
+        stream : torch.cuda.Stream | None, default=None
+            Unused CUDA stream argument retained for compatibility.
+        """
+        del index, stream
+
     def has_pending_fused_batches(self) -> bool:
         """Return whether a fused prefetch chunk is waiting to be consumed."""
         return bool(self._fused_batch_prefetch_queue)
@@ -510,6 +552,27 @@ class InMemoryDataset:
         """
         del index
         self._fused_batch_prefetch_queue.clear()
+
+    @property
+    def prefetch_count(self) -> int:
+        """Return the number of queued fused-batch prefetch requests."""
+        return len(self._fused_batch_prefetch_queue)
+
+    def get_metadata(self, index: int) -> tuple[int, int]:
+        """Return lightweight graph-size metadata for an in-memory sample.
+
+        Parameters
+        ----------
+        index : int
+            Graph index within ``in_memory_batch``.
+
+        Returns
+        -------
+        tuple[int, int]
+            ``(num_atoms, num_edges)`` for the sample.
+        """
+        data = self.in_memory_batch[index]
+        return data.num_nodes, data.num_edges
 
     def __getitem__(self, index: int) -> tuple["AtomicData", dict[str, Any]]:
         """Get an AtomicData sample by graph index.

--- a/nvalchemi/data/datapipes/in_memory_dataset.py
+++ b/nvalchemi/data/datapipes/in_memory_dataset.py
@@ -103,9 +103,19 @@ class InMemoryDataset:
         :meth:`~nvalchemi.data.batch.Batch.from_raw_dicts`. Enable this for
         trusted stores that are already validated.
     batch_transforms : Sequence[BatchTransform] | None, default=None
-        Optional per-batch transforms applied to each materialized chunk before
-        it is appended to the in-memory batch. This mirrors the
-        ``DataLoader(batch_transforms=...)`` API.
+        Optional per-batch transforms applied while building the resident
+        batch. For reader-backed construction they run on each materialized
+        chunk; for a pre-built ``in_memory_batch`` they run once on the full
+        batch. This mirrors the ``DataLoader(batch_transforms=...)`` API.
+
+    Raises
+    ------
+    ValueError
+        If neither or both of ``in_memory_batch`` and ``reader`` are provided.
+    TypeError
+        If ``batch_transforms`` is not a
+        :class:`~collections.abc.Sequence` (e.g. a single callable or a
+        generator was passed).
 
     Attributes
     ----------
@@ -139,51 +149,21 @@ class InMemoryDataset:
         skip_validation: bool = False,
         batch_transforms: "Sequence[BatchTransform] | None" = None,
     ) -> None:
-        """Initialize the in-memory dataset.
-
-        Parameters
-        ----------
-        in_memory_batch : Batch | None
-            Fully loaded batch containing all graphs in the dataset.
-        reader : ReaderProtocol | None
-            Reader to materialize the full dataset into ``in_memory_batch``.
-        chunk_size : int, default=4096
-            Number of reader samples to materialize per intermediate batch.
-        device : str | torch.device | None, default=None
-            Target device for emitted samples and batches. ``None`` leaves
-            emitted batches on the resident cache device. ``"auto"`` selects
-            CUDA when available, otherwise CPU.
-        skip_validation : bool, default=False
-            If ``True``, bypass ``AtomicData`` construction and Pydantic
-            validation while materializing from a reader, building batches
-            directly from raw tensor dicts via
-            :meth:`~nvalchemi.data.batch.Batch.from_raw_dicts`.
-        batch_transforms : Sequence[BatchTransform] | None, default=None
-            Optional per-batch transforms applied to each materialized chunk
-            before it is appended to the in-memory batch.
-
-        Raises
-        ------
-        ValueError
-            If neither or both of ``in_memory_batch`` and ``reader`` are
-            provided.
-        TypeError
-            If ``batch_transforms`` is not a
-            :class:`~collections.abc.Sequence` (e.g. a single callable or a
-            generator was passed).
-        """
+        """Initialize the in-memory dataset."""
         if (in_memory_batch is None) == (reader is None):
             raise ValueError("Pass exactly one of in_memory_batch or reader.")
         self.target_device = self._resolve_target_device(device)
-        if in_memory_batch is None:
-            if reader is None:
-                raise ValueError("reader must be provided when in_memory_batch is None")
+        if reader is not None:
             in_memory_batch = self._materialize_reader(
                 reader,
                 chunk_size=chunk_size,
                 skip_validation=skip_validation,
                 batch_transforms=batch_transforms,
             )
+        else:
+            transform = self._build_batch_transform(batch_transforms)
+            if transform is not None:
+                in_memory_batch = transform(in_memory_batch)
         self.in_memory_batch = in_memory_batch
         self._pin_memory = False
         self._fused_batch_prefetch_queue: deque[_PendingInMemoryBatches] = deque()
@@ -219,6 +199,35 @@ class InMemoryDataset:
                 f"Device expected to be a string, torch.device, or None. Got {device}."
             )
         return torch.device(device)
+
+    @staticmethod
+    def _build_batch_transform(
+        batch_transforms: "Sequence[BatchTransform] | None",
+    ) -> Compose | None:
+        """Validate and compose optional per-batch transforms.
+
+        Parameters
+        ----------
+        batch_transforms : Sequence[BatchTransform] | None
+            Optional per-batch transforms.
+
+        Returns
+        -------
+        Compose | None
+            Composed transform pipeline, or ``None`` when no transforms are set.
+
+        Raises
+        ------
+        TypeError
+            If ``batch_transforms`` is not a
+            :class:`~collections.abc.Sequence`.
+        """
+        if batch_transforms is not None and not isinstance(batch_transforms, Sequence):
+            raise TypeError(
+                "batch_transforms must be a Sequence of callables, not a "
+                "single callable or generator. Pass [fn] instead of fn."
+            )
+        return Compose(batch_transforms) if batch_transforms else None
 
     @staticmethod
     def _materialize_reader(
@@ -258,20 +267,13 @@ class InMemoryDataset:
         RuntimeError
             If no samples were materialized from ``reader``.
         """
-        if chunk_size <= 0:
-            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
-        if batch_transforms is not None and not isinstance(batch_transforms, Sequence):
-            raise TypeError(
-                "batch_transforms must be a Sequence of callables, not a "
-                "single callable or generator. Pass [fn] instead of fn."
-            )
-
-        reader_field_levels = getattr(reader, "field_levels", None)
-        transform: Compose | None = (
-            Compose(batch_transforms) if batch_transforms else None
-        )
         in_memory_batch: Batch | None = None
         try:
+            if chunk_size <= 0:
+                raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+            reader_field_levels = getattr(reader, "field_levels", None)
+            transform = InMemoryDataset._build_batch_transform(batch_transforms)
             reader_len = len(reader)
             if reader_len <= 0:
                 raise ValueError("Cannot materialize an empty reader.")

--- a/nvalchemi/data/datapipes/in_memory_dataset.py
+++ b/nvalchemi/data/datapipes/in_memory_dataset.py
@@ -507,7 +507,7 @@ class InMemoryDataset:
         stream : torch.cuda.Stream | None, default=None
             Unused CUDA stream argument retained for compatibility.
         """
-        del index, stream
+        return None
 
     def has_pending_fused_batches(self) -> bool:
         """Return whether a fused prefetch chunk is waiting to be consumed."""

--- a/nvalchemi/data/datapipes/in_memory_dataset.py
+++ b/nvalchemi/data/datapipes/in_memory_dataset.py
@@ -1,0 +1,574 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+In-memory dataset with fully loaded :class:`Batch` support.
+
+:class:`InMemoryDataset` keeps the entire dataset resident in memory as one
+:class:`~nvalchemi.data.batch.Batch`. Provide the batch directly when data is
+already loaded, or pass a :class:`~nvalchemi.data.datapipes.dataset.ReaderProtocol`
+to materialize the full dataset during initialization.
+
+Once loaded, iteration and :meth:`load_batches` select graphs from the
+in-memory batch instead of reading from storage on each access.
+``InMemoryDataset`` implements the same DataLoader-facing batch contract as
+``Dataset``: ``load_batches(...)``, ``prefetch_fused_batches(...)``,
+``get_fused_batches()``, ``has_pending_fused_batches()``, and
+``cancel_prefetch(...)``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch import Tensor
+
+from nvalchemi.data.atomic_data import AtomicData
+from nvalchemi.data.batch import Batch
+from nvalchemi.data.transforms import Compose
+
+if TYPE_CHECKING:
+    from nvalchemi._typing import BatchTransform
+    from nvalchemi.data.datapipes.dataset import ReaderProtocol
+
+
+@dataclass(slots=True)
+class _PendingInMemoryBatches:
+    """Prepared in-memory batches with an optional CUDA transfer event.
+
+    Attributes
+    ----------
+    batches : list[Batch]
+        Selected batches ready for consumption.
+    event : torch.cuda.Event | None
+        CUDA event for stream synchronization, or None.
+    """
+
+    batches: list[Batch]
+    event: torch.cuda.Event | None = None
+
+
+class InMemoryDataset:
+    """Dataset that keeps the full dataset in memory as one :class:`Batch`.
+
+    The entire dataset is stored in ``in_memory_batch``. Provide it directly if
+    you have already loaded the data, or pass a ``reader`` to materialize the
+    full dataset during initialization.
+
+    Once loaded, iteration and :meth:`load_batches` select graphs from that
+    in-memory batch instead of reading from storage on each access.
+    ``InMemoryDataset`` implements the same DataLoader-facing batch contract as
+    ``Dataset``: :meth:`__len__`, :meth:`load_batches`,
+    :meth:`prefetch_fused_batches`, :meth:`get_fused_batches`,
+    :meth:`has_pending_fused_batches`, and :meth:`cancel_prefetch`. The
+    :meth:`__getitem__` and :meth:`__iter__` methods are provided for
+    dataset-style access, but normal
+    :class:`~nvalchemi.data.datapipes.DataLoader` iteration loads whole
+    :class:`Batch` objects through the aforementioned methods instead of calling
+    :meth:`__getitem__` for each sample.
+
+    Parameters
+    ----------
+    in_memory_batch : Batch | None, default=None
+        Fully loaded batch containing all graphs in the dataset. Pass this when
+        the batch has already been built.
+    reader : ReaderProtocol | None, default=None
+        Reader to materialize the full dataset into ``in_memory_batch``. Pass
+        either ``in_memory_batch`` or ``reader``, not both.
+    chunk_size : int, default=4096
+        Number of reader samples to materialize per intermediate batch.
+    device : str | torch.device | None, default=None
+        Target device for emitted samples and batches. ``None`` leaves emitted
+        batches on the resident cache device. ``"auto"`` selects CUDA when
+        available, otherwise CPU.
+    skip_validation : bool, default=False
+        If ``True``, bypass ``AtomicData`` construction and Pydantic
+        validation while materializing from a reader, building batches
+        directly from raw tensor dicts via
+        :meth:`~nvalchemi.data.batch.Batch.from_raw_dicts`. Enable this for
+        trusted stores that are already validated.
+    batch_transforms : Sequence[BatchTransform] | None, default=None
+        Optional per-batch transforms applied to each materialized chunk before
+        it is appended to the in-memory batch. This mirrors the
+        ``DataLoader(batch_transforms=...)`` API.
+
+    Attributes
+    ----------
+    in_memory_batch : Batch
+        Fully loaded batch containing all graphs in the dataset.
+    target_device : torch.device | None
+        Resolved target device for emitted samples and batches.
+
+    Examples
+    --------
+    >>> from nvalchemi.data.datapipes.in_memory_dataset import InMemoryDataset
+    >>> # Assuming a concrete Reader implementation exists:
+    >>> # reader = MyReader("dataset.zarr")  # doctest: +SKIP
+    >>> # ds = InMemoryDataset(reader=reader, device="cpu")  # doctest: +SKIP
+    >>> # batch = ds.load_batches([[0, 1, 2]])[0]              # doctest: +SKIP
+    >>> # trusted = InMemoryDataset(reader=reader, device="cuda", skip_validation=True)  # doctest: +SKIP
+
+    With a pre-built in-memory batch:
+
+    >>> # batch = Batch.from_raw_dicts(raw_dicts)              # doctest: +SKIP
+    >>> # ds = InMemoryDataset(in_memory_batch=batch)          # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        in_memory_batch: Batch | None = None,
+        *,
+        reader: "ReaderProtocol | None" = None,
+        chunk_size: int = 4096,
+        device: str | torch.device | None = None,
+        skip_validation: bool = False,
+        batch_transforms: "Sequence[BatchTransform] | None" = None,
+    ) -> None:
+        """Initialize the in-memory dataset.
+
+        Parameters
+        ----------
+        in_memory_batch : Batch | None
+            Fully loaded batch containing all graphs in the dataset.
+        reader : ReaderProtocol | None
+            Reader to materialize the full dataset into ``in_memory_batch``.
+        chunk_size : int, default=4096
+            Number of reader samples to materialize per intermediate batch.
+        device : str | torch.device | None, default=None
+            Target device for emitted samples and batches. ``None`` leaves
+            emitted batches on the resident cache device. ``"auto"`` selects
+            CUDA when available, otherwise CPU.
+        skip_validation : bool, default=False
+            If ``True``, bypass ``AtomicData`` construction and Pydantic
+            validation while materializing from a reader, building batches
+            directly from raw tensor dicts via
+            :meth:`~nvalchemi.data.batch.Batch.from_raw_dicts`.
+        batch_transforms : Sequence[BatchTransform] | None, default=None
+            Optional per-batch transforms applied to each materialized chunk
+            before it is appended to the in-memory batch.
+
+        Raises
+        ------
+        ValueError
+            If neither or both of ``in_memory_batch`` and ``reader`` are
+            provided.
+        TypeError
+            If ``batch_transforms`` is not a
+            :class:`~collections.abc.Sequence` (e.g. a single callable or a
+            generator was passed).
+        """
+        if (in_memory_batch is None) == (reader is None):
+            raise ValueError("Pass exactly one of in_memory_batch or reader.")
+        self.target_device = self._resolve_target_device(device)
+        if in_memory_batch is None:
+            if reader is None:
+                raise ValueError("reader must be provided when in_memory_batch is None")
+            in_memory_batch = self._materialize_reader(
+                reader,
+                chunk_size=chunk_size,
+                skip_validation=skip_validation,
+                batch_transforms=batch_transforms,
+            )
+        self.in_memory_batch = in_memory_batch
+        self._pin_memory = False
+        self._fused_batch_prefetch_queue: deque[_PendingInMemoryBatches] = deque()
+
+    @staticmethod
+    def _resolve_target_device(device: str | torch.device | None) -> torch.device | None:
+        """Resolve the optional emitted-batch target device.
+
+        Parameters
+        ----------
+        device : str | torch.device | None
+            Requested device. ``None`` leaves emitted batches on the resident
+            cache device. ``"auto"`` selects CUDA when available, otherwise CPU.
+
+        Returns
+        -------
+        torch.device | None
+            Resolved target device, or ``None`` when no transfer is requested.
+
+        Raises
+        ------
+        TypeError
+            If *device* is not a string, ``torch.device``, or ``None``.
+        """
+        if device is None:
+            return None
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        elif not isinstance(device, (str, torch.device)):
+            raise TypeError(
+                "Device expected to be a string, torch.device, or None. "
+                f"Got {device}."
+            )
+        return torch.device(device)
+
+    @staticmethod
+    def _materialize_reader(
+        reader: "ReaderProtocol",
+        *,
+        chunk_size: int,
+        skip_validation: bool,
+        batch_transforms: "Sequence[BatchTransform] | None",
+    ) -> Batch:
+        """Read an entire reader into one in-memory batch.
+
+        Parameters
+        ----------
+        reader : ReaderProtocol
+            Reader providing raw tensor dicts from a data source.
+        chunk_size : int
+            Number of reader samples to materialize per intermediate batch.
+        skip_validation : bool
+            If ``True``, build chunks directly from raw tensor dictionaries.
+            If ``False``, validate raw samples as :class:`AtomicData` before
+            batching.
+        batch_transforms : Sequence[BatchTransform] | None
+            Optional per-batch transforms applied to each materialized chunk.
+
+        Returns
+        -------
+        Batch
+            Fully loaded batch containing all graphs from ``reader``.
+
+        Raises
+        ------
+        ValueError
+            If ``chunk_size`` is not positive or ``reader`` is empty.
+        TypeError
+            If ``batch_transforms`` is not a
+            :class:`~collections.abc.Sequence`.
+        RuntimeError
+            If no samples were materialized from ``reader``.
+        """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if batch_transforms is not None and not isinstance(batch_transforms, Sequence):
+            raise TypeError(
+                "batch_transforms must be a Sequence of callables, not a "
+                "single callable or generator. Pass [fn] instead of fn."
+            )
+
+        reader_field_levels = getattr(reader, "field_levels", None)
+        transform: Compose | None = (
+            Compose(batch_transforms) if batch_transforms else None
+        )
+        in_memory_batch: Batch | None = None
+        try:
+            reader_len = len(reader)
+            if reader_len <= 0:
+                raise ValueError("Cannot materialize an empty reader.")
+            for start in range(0, reader_len, chunk_size):
+                end = min(start + chunk_size, reader_len)
+                raw_samples = reader.read_many(range(start, end))
+                raw_dicts = [tensor_dict for tensor_dict, _metadata in raw_samples]
+                if skip_validation:
+                    chunk = Batch.from_raw_dicts(
+                        raw_dicts,
+                        device="cpu",
+                        field_levels=reader_field_levels,
+                    )
+                else:
+                    chunk = Batch.from_data_list(
+                        [AtomicData.model_validate(data) for data in raw_dicts],
+                        device="cpu",
+                        field_levels=reader_field_levels,
+                    )
+                if transform is not None:
+                    chunk = transform(chunk)
+                if in_memory_batch is None:
+                    in_memory_batch = chunk
+                else:
+                    in_memory_batch.append(chunk)
+        finally:
+            reader.close()
+
+        if in_memory_batch is None:
+            raise RuntimeError("No samples were materialized from reader.")
+        return in_memory_batch
+
+    def __len__(self) -> int:
+        """Return the number of graphs in the in-memory batch.
+
+        Returns
+        -------
+        int
+            Number of graphs stored in ``in_memory_batch``.
+        """
+        return self.in_memory_batch.num_graphs
+
+    @property
+    def pin_memory(self) -> bool:
+        """Whether the materialized CPU batch is pinned in page-locked memory."""
+        return self._pin_memory
+
+    @pin_memory.setter
+    def pin_memory(self, enabled: bool) -> None:
+        """Pin the materialized CPU batch when enabled by :class:`DataLoader`.
+
+        Parameters
+        ----------
+        enabled : bool
+            Whether the resident CPU batch should be page-locked.
+        """
+        enabled = bool(enabled)
+        if enabled and not self._pin_memory and self.in_memory_batch.device.type == "cpu":
+            self.in_memory_batch.pin_memory()
+        self._pin_memory = enabled
+
+    def _normalize_indices(self, indices: Any) -> Tensor:
+        """Normalize DataLoader sampler output to CPU int64 indices.
+
+        Parameters
+        ----------
+        indices : Any
+            Index batch from a sampler or batch-index list.
+
+        Returns
+        -------
+        Tensor
+            1-D CPU tensor of graph indices with dtype ``torch.long``.
+
+        Raises
+        ------
+        TypeError
+            If *indices* is not a supported index container type.
+        """
+        if isinstance(indices, Tensor):
+            return indices.to(dtype=torch.long, device="cpu")
+        if isinstance(indices, list) and indices and isinstance(indices[0], Tensor):
+            return torch.stack(indices).to(dtype=torch.long, device="cpu")
+        if isinstance(indices, Sequence):
+            return torch.as_tensor(indices, dtype=torch.long, device="cpu")
+        raise TypeError(f"Unexpected index batch type: {type(indices).__name__}")
+
+    def _move_batch_to_target(self, batch: Batch) -> Batch:
+        """Move a selected batch to the configured target device when needed."""
+        if self.target_device is None or batch.device == self.target_device:
+            return batch
+        return batch.to(self.target_device, non_blocking=True)
+
+    def _prepare_batches(
+        self,
+        batch_index_lists: Sequence[Sequence[int]] | Sequence[Tensor],
+        stream: torch.cuda.Stream | None = None,
+    ) -> _PendingInMemoryBatches:
+        """Select batches and optionally enqueue target-device transfers.
+
+        Parameters
+        ----------
+        batch_index_lists : Sequence[Sequence[int]] | Sequence[Tensor]
+            Per-batch graph indices.
+        stream : torch.cuda.Stream | None, default=None
+            Optional CUDA stream for target-device transfers.
+
+        Returns
+        -------
+        _PendingInMemoryBatches
+            Selected batches with an optional CUDA synchronization event.
+        """
+        batches = [
+            self.in_memory_batch.index_select(self._normalize_indices(indices))
+            for indices in batch_index_lists
+        ]
+        event: torch.cuda.Event | None = None
+        if (
+            stream is not None
+            and self.target_device is not None
+            and self.target_device.type == "cuda"
+        ):
+            with torch.cuda.stream(stream):
+                batches = [self._move_batch_to_target(batch) for batch in batches]
+            event = torch.cuda.Event()
+            event.record(stream)
+        else:
+            batches = [self._move_batch_to_target(batch) for batch in batches]
+        return _PendingInMemoryBatches(batches=batches, event=event)
+
+    def load_batches(
+        self,
+        batch_index_lists: Sequence[Sequence[int]] | Sequence[Tensor],
+        stream: torch.cuda.Stream | None = None,
+    ) -> list[Batch]:
+        """Load several batches immediately.
+
+        This is the synchronous counterpart to
+        :meth:`prefetch_fused_batches`/:meth:`get_fused_batches`. Each
+        requested index list selects graphs from ``in_memory_batch`` and
+        returns one :class:`~nvalchemi.data.batch.Batch` per input list.
+
+        Parameters
+        ----------
+        batch_index_lists : Sequence[Sequence[int]] | Sequence[Tensor]
+            Per-batch graph indices.
+        stream : torch.cuda.Stream | None, default=None
+            CUDA stream for target-device transfers when supported.
+
+        Returns
+        -------
+        list[Batch]
+            One :class:`Batch` per input batch-index list.
+        """
+        pending = self._prepare_batches(batch_index_lists, stream=stream)
+        if pending.event is not None:
+            pending.event.synchronize()
+        return pending.batches
+
+    def prefetch_fused_batches(
+        self,
+        batch_index_lists: Sequence[Sequence[int]] | Sequence[Tensor],
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """Submit multiple batches for fused prefetch.
+
+        Selected batches are prepared immediately and queued for later
+        consumption via :meth:`get_fused_batches`.
+
+        Parameters
+        ----------
+        batch_index_lists : Sequence[Sequence[int]] | Sequence[Tensor]
+            Per-batch graph indices.
+        stream : torch.cuda.Stream | None, default=None
+            CUDA stream for target-device transfers when supported.
+
+        Raises
+        ------
+        RuntimeError
+            If the fused batch prefetch queue is already full.
+        """
+        if len(self._fused_batch_prefetch_queue) >= 2:
+            raise RuntimeError(
+                "Fused batch prefetch queue is full; consume a pending chunk first."
+            )
+        self._fused_batch_prefetch_queue.append(
+            self._prepare_batches(batch_index_lists, stream=stream)
+        )
+
+    def has_pending_fused_batches(self) -> bool:
+        """Return whether a fused prefetch chunk is waiting to be consumed."""
+        return bool(self._fused_batch_prefetch_queue)
+
+    def get_fused_batches(self) -> Iterator[Batch]:
+        """Consume the pending fused prefetch and yield per-batch results.
+
+        Blocks until any queued CUDA transfers complete, then yields one
+        :class:`~nvalchemi.data.batch.Batch` per sub-batch from the prepared
+        request.
+
+        Yields
+        ------
+        Batch
+            One batch per sub-batch from the fused prefetch request.
+
+        Raises
+        ------
+        RuntimeError
+            If no fused prefetch is pending.
+        """
+        if not self._fused_batch_prefetch_queue:
+            raise RuntimeError(
+                "No fused batch prefetch pending; call prefetch_fused_batches() "
+                "before get_fused_batches()."
+            )
+        pending = self._fused_batch_prefetch_queue.popleft()
+        if pending.event is not None:
+            pending.event.synchronize()
+        yield from pending.batches
+
+    def cancel_prefetch(self, index: int | None = None) -> None:
+        """Cancel pending prefetch operations.
+
+        Parameters
+        ----------
+        index : int | None, default=None
+            Unused; retained for API compatibility with
+            :class:`~nvalchemi.data.datapipes.dataset.Dataset`. Clears all
+            pending fused batch requests.
+        """
+        del index
+        self._fused_batch_prefetch_queue.clear()
+
+    def __getitem__(self, index: int) -> tuple["AtomicData", dict[str, Any]]:
+        """Get an AtomicData sample by graph index.
+
+        Parameters
+        ----------
+        index : int
+            Graph index within ``in_memory_batch``.
+
+        Returns
+        -------
+        tuple[AtomicData, dict[str, Any]]
+            Tuple of (:class:`~nvalchemi.data.atomic_data.AtomicData`, empty
+            metadata dict).
+
+        Raises
+        ------
+        IndexError
+            If *index* is out of range.
+        """
+        data = self.in_memory_batch[index]
+        if self.target_device is not None:
+            data = data.to(self.target_device, non_blocking=True)
+        return data, {}
+
+    def __iter__(self) -> Iterator[tuple["AtomicData", dict[str, Any]]]:
+        """Iterate over all samples in the dataset.
+
+        Yields
+        ------
+        tuple[AtomicData, dict[str, Any]]
+            ``(AtomicData, metadata)`` for each graph in
+            ``in_memory_batch``.
+        """
+        for index in range(len(self)):
+            yield self[index]
+
+    def close(self) -> None:
+        """Release resources held by the dataset.
+
+        Clears any pending fused batch prefetch requests.
+        """
+        self.cancel_prefetch()
+
+    def __enter__(self) -> InMemoryDataset:
+        """Enter context manager.
+
+        Returns
+        -------
+        InMemoryDataset
+            This dataset instance.
+        """
+        return self
+
+    def __exit__(
+        self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
+        """Exit context manager, calling :meth:`close`.
+
+        Parameters
+        ----------
+        exc_type : type | None
+            Exception type, if any.
+        exc_val : BaseException | None
+            Exception value, if any.
+        exc_tb : Any
+            Exception traceback, if any.
+        """
+        self.close()

--- a/nvalchemi/data/datapipes/in_memory_dataset.py
+++ b/nvalchemi/data/datapipes/in_memory_dataset.py
@@ -189,7 +189,9 @@ class InMemoryDataset:
         self._fused_batch_prefetch_queue: deque[_PendingInMemoryBatches] = deque()
 
     @staticmethod
-    def _resolve_target_device(device: str | torch.device | None) -> torch.device | None:
+    def _resolve_target_device(
+        device: str | torch.device | None,
+    ) -> torch.device | None:
         """Resolve the optional emitted-batch target device.
 
         Parameters
@@ -214,8 +216,7 @@ class InMemoryDataset:
             device = "cuda" if torch.cuda.is_available() else "cpu"
         elif not isinstance(device, (str, torch.device)):
             raise TypeError(
-                "Device expected to be a string, torch.device, or None. "
-                f"Got {device}."
+                f"Device expected to be a string, torch.device, or None. Got {device}."
             )
         return torch.device(device)
 
@@ -328,7 +329,11 @@ class InMemoryDataset:
             Whether the resident CPU batch should be page-locked.
         """
         enabled = bool(enabled)
-        if enabled and not self._pin_memory and self.in_memory_batch.device.type == "cpu":
+        if (
+            enabled
+            and not self._pin_memory
+            and self.in_memory_batch.device.type == "cpu"
+        ):
             self.in_memory_batch.pin_memory()
         self._pin_memory = enabled
 

--- a/nvalchemi/data/datapipes/multidataset.py
+++ b/nvalchemi/data/datapipes/multidataset.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Compose multiple AtomicData-native datasets behind one index space."""
+"""Compose multiple batch-loadable AtomicData-native datasets behind one index space."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ import torch
 
 from nvalchemi.data.atomic_data import AtomicData
 from nvalchemi.data.batch import Batch
-from nvalchemi.data.datapipes.dataset import Dataset
+from nvalchemi.data.datapipes.dataset import BatchDatasetProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -85,14 +85,14 @@ PendingFusedBatch = Future[_FusedBatchResult] | _DelegatedFusedBatch
 
 
 class MultiDataset:
-    """Compose multiple :class:`Dataset` instances behind one index space.
+    """Compose multiple batch-loadable datasets behind one index space.
 
     The class provides concatenated indexing and nvalchemi-specific batch APIs
     used by :class:`~nvalchemi.data.datapipes.dataloader.DataLoader`.
 
     Parameters
     ----------
-    *datasets : Dataset
+    *datasets : BatchDatasetProtocol
         One or more nvalchemi datasets. Order defines the global index mapping.
     output_strict : bool, default=True
         If True, require all datasets to expose identical field names.
@@ -102,7 +102,7 @@ class MultiDataset:
 
     def __init__(
         self,
-        *datasets: Dataset,
+        *datasets: BatchDatasetProtocol,
         output_strict: bool = True,
         num_workers: int = 2,
     ) -> None:
@@ -110,7 +110,7 @@ class MultiDataset:
 
         Parameters
         ----------
-        *datasets : Dataset
+        *datasets : BatchDatasetProtocol
             Datasets to concatenate.
         output_strict : bool, default=True
             Require matching field names across datasets.
@@ -120,7 +120,7 @@ class MultiDataset:
         Raises
         ------
         TypeError
-            If any child is not a nvalchemi Dataset.
+            If any dataset provided is not compatible with :class:`BatchDatasetProtocol`.
         ValueError
             If no datasets are provided or strict field names differ.
         """
@@ -129,9 +129,10 @@ class MultiDataset:
                 f"MultiDataset requires at least one dataset, got {len(datasets)}"
             )
         for i, dataset in enumerate(datasets):
-            if not isinstance(dataset, Dataset):
+            if not isinstance(dataset, BatchDatasetProtocol):
                 raise TypeError(
-                    f"datasets[{i}] must be a Dataset instance, got {type(dataset).__name__}"
+                    f"datasets[{i}] must implement BatchDatasetProtocol, got "
+                    f"{type(dataset).__name__}"
                 )
 
         self._datasets = list(datasets)
@@ -196,7 +197,7 @@ class MultiDataset:
                 continue
 
             reference_set = set(reference)
-            field_names = set(dataset.field_names)
+            field_names = set(current)
             if field_names != reference_set:
                 raise ValueError(
                     "output_strict=True requires identical field names across "
@@ -309,7 +310,7 @@ class MultiDataset:
         return self._cumul[-1]
 
     @property
-    def datasets(self) -> tuple[Dataset, ...]:
+    def datasets(self) -> tuple[BatchDatasetProtocol, ...]:
         """Child datasets in global index order."""
         return tuple(self._datasets)
 

--- a/nvalchemi/hooks/neighbor_list.py
+++ b/nvalchemi/hooks/neighbor_list.py
@@ -155,6 +155,10 @@ class NeighborListHook:
     stage : Enum | None, optional
         The workflow stage at which this hook runs.  Defaults to
         ``DynamicsStage.BEFORE_COMPUTE``.
+    method : str | None, optional
+        Explicit ``nvalchemiops`` neighbor-list method to use.  When ``None``
+        (default), the hook selects an appropriate method from the batch shape
+        and periodic-cell metadata.
     """
 
     def __init__(
@@ -163,10 +167,12 @@ class NeighborListHook:
         skin: float = 0.0,
         max_neighbors: int | None = None,
         stage: Enum | None = None,
+        method: str | None = None,
     ) -> None:
         self.config = config
         self.skin = skin
         self.stage = stage
+        self.method = method
         self._max_neighbors_override = max_neighbors
         self.frequency = 1
         self._neighbor_list_flag = config.format == NeighborListFormat.COO
@@ -724,6 +730,8 @@ class NeighborListHook:
         dtype: torch.dtype,
     ) -> str:
         """Choose the explicit method to use inside the compiled hot path."""
+        if self.method is not None:
+            return self.method
         fallback = "cell_list" if N // max(B, 1) >= 2000 else "naive"
         if cell is None or pbc is None:
             return fallback

--- a/nvalchemi/models/base.py
+++ b/nvalchemi/models/base.py
@@ -628,7 +628,11 @@ class BaseModelMixin(abc.ABC):
             ]
         )
 
-    def make_neighbor_hooks(self, max_neighbors: int | None = None) -> list:
+    def make_neighbor_hooks(
+        self,
+        max_neighbors: int | None = None,
+        neighbor_list_method: str | None = None,
+    ) -> list:
         """Return a list of :class:`~nvalchemi.hooks.NeighborListHook` instances
         for this model's neighbor configuration.
 
@@ -640,6 +644,9 @@ class BaseModelMixin(abc.ABC):
         max_neighbors : int | None, optional
             Maximum neighbors per atom for MATRIX format.  When ``None``
             (default), auto-estimated from the cutoff at first use.
+        neighbor_list_method : str | None, optional
+            Explicit ``nvalchemiops`` neighbor-list method to use.  When
+            ``None`` (default), the hook selects an appropriate method.
         """
         from nvalchemi.dynamics.base import DynamicsStage  # noqa: PLC0415
         from nvalchemi.hooks import NeighborListHook  # noqa: PLC0415
@@ -652,6 +659,7 @@ class BaseModelMixin(abc.ABC):
                 nc,
                 skin=nc.skin,
                 max_neighbors=max_neighbors,
+                method=neighbor_list_method,
                 stage=DynamicsStage.BEFORE_COMPUTE,
             )
         ]

--- a/nvalchemi/models/pipeline.py
+++ b/nvalchemi/models/pipeline.py
@@ -638,7 +638,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
     # ------------------------------------------------------------------
 
     def make_neighbor_hooks(
-        self, max_neighbors: int | None = None
+        self,
+        max_neighbors: int | None = None,
+        neighbor_list_method: str | None = None,
     ) -> list[NeighborListHook]:
         """Return a single :class:`NeighborListHook` for the composite neighbor config.
 
@@ -647,6 +649,9 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
         max_neighbors : int | None, optional
             Maximum neighbors per atom for MATRIX format.  When ``None``
             (default), auto-estimated from the cutoff at first use.
+        neighbor_list_method : str | None, optional
+            Explicit ``nvalchemiops`` neighbor-list method to use.  When
+            ``None`` (default), the hook selects an appropriate method.
         """
         from nvalchemi.dynamics.base import DynamicsStage  # noqa: PLC0415
 
@@ -658,6 +663,7 @@ class PipelineModelWrapper(nn.Module, BaseModelMixin):
                 nc,
                 skin=nc.skin,
                 max_neighbors=max_neighbors,
+                method=neighbor_list_method,
                 stage=DynamicsStage.BEFORE_COMPUTE,
             )
         ]

--- a/nvalchemi/training/hooks/ddp.py
+++ b/nvalchemi/training/hooks/ddp.py
@@ -26,6 +26,9 @@ from torch.utils.data import BatchSampler, DistributedSampler, RandomSampler
 
 from nvalchemi.data.datapipes.dataloader import DataLoader as ALCHEMIDataLoader
 from nvalchemi.data.datapipes.dataset import Dataset as ALCHEMIDataset
+from nvalchemi.data.datapipes.in_memory_dataset import (
+    InMemoryDataset as ALCHEMIInMemoryDataset,
+)
 from nvalchemi.data.datapipes.multidataset import MultiDataset as ALCHEMIMultiDataset
 from nvalchemi.data.datapipes.samplers import (
     DistributedSamplerProtocol,
@@ -414,7 +417,7 @@ class DDPHook(BaseModel):
                 batch_size=dataloader.batch_size,
                 **kwargs,
             )
-        elif isinstance(dataset, ALCHEMIDataset):
+        elif isinstance(dataset, (ALCHEMIDataset, ALCHEMIInMemoryDataset)):
             sampler = DistributedSampler(dataset, **kwargs)
             dataloader.batch_sampler = BatchSampler(
                 sampler,
@@ -424,7 +427,7 @@ class DDPHook(BaseModel):
         else:
             raise TypeError(
                 "DDPHook expected nvalchemi.data.datapipes.DataLoader.dataset to be "
-                "Dataset or MultiDataset when installing the default distributed "
+                "Dataset, InMemoryDataset, or MultiDataset when installing the default distributed "
                 f"batch sampler; got {type(dataset).__name__}."
             )
 

--- a/nvalchemi/training/hooks/ddp.py
+++ b/nvalchemi/training/hooks/ddp.py
@@ -25,9 +25,8 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from torch.utils.data import BatchSampler, DistributedSampler, RandomSampler
 
 from nvalchemi.data.datapipes.dataloader import DataLoader as ALCHEMIDataLoader
-from nvalchemi.data.datapipes.dataset import Dataset as ALCHEMIDataset
-from nvalchemi.data.datapipes.in_memory_dataset import (
-    InMemoryDataset as ALCHEMIInMemoryDataset,
+from nvalchemi.data.datapipes.dataset import (
+    BatchDatasetProtocol as ALCHEMIBatchDatasetProtocol,
 )
 from nvalchemi.data.datapipes.multidataset import MultiDataset as ALCHEMIMultiDataset
 from nvalchemi.data.datapipes.samplers import (
@@ -417,7 +416,7 @@ class DDPHook(BaseModel):
                 batch_size=dataloader.batch_size,
                 **kwargs,
             )
-        elif isinstance(dataset, (ALCHEMIDataset, ALCHEMIInMemoryDataset)):
+        elif isinstance(dataset, ALCHEMIBatchDatasetProtocol):
             sampler = DistributedSampler(dataset, **kwargs)
             dataloader.batch_sampler = BatchSampler(
                 sampler,
@@ -427,8 +426,9 @@ class DDPHook(BaseModel):
         else:
             raise TypeError(
                 "DDPHook expected nvalchemi.data.datapipes.DataLoader.dataset to be "
-                "Dataset, InMemoryDataset, or MultiDataset when installing the default distributed "
-                f"batch sampler; got {type(dataset).__name__}."
+                "a batch-loadable dataset or MultiDataset when installing the "
+                "default distributed batch sampler; got "
+                f"{type(dataset).__name__}."
             )
 
         dataloader.sampler = None

--- a/nvalchemi/training/hooks/ddp.py
+++ b/nvalchemi/training/hooks/ddp.py
@@ -25,9 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from torch.utils.data import BatchSampler, DistributedSampler, RandomSampler
 
 from nvalchemi.data.datapipes.dataloader import DataLoader as ALCHEMIDataLoader
-from nvalchemi.data.datapipes.dataset import (
-    BatchDatasetProtocol as ALCHEMIBatchDatasetProtocol,
-)
+from nvalchemi.data.datapipes.dataset import BatchDatasetProtocol
 from nvalchemi.data.datapipes.multidataset import MultiDataset as ALCHEMIMultiDataset
 from nvalchemi.data.datapipes.samplers import (
     DistributedSamplerProtocol,
@@ -416,7 +414,7 @@ class DDPHook(BaseModel):
                 batch_size=dataloader.batch_size,
                 **kwargs,
             )
-        elif isinstance(dataset, ALCHEMIBatchDatasetProtocol):
+        elif isinstance(dataset, BatchDatasetProtocol):
             sampler = DistributedSampler(dataset, **kwargs)
             dataloader.batch_sampler = BatchSampler(
                 sampler,

--- a/test/data/test_zarr_datapipe.py
+++ b/test/data/test_zarr_datapipe.py
@@ -35,6 +35,7 @@ from nvalchemi.data.datapipes import (
     AtomicDataZarrWriter,
     DataLoader,
     Dataset,
+    InMemoryDataset,
     MultiDataset,
 )
 from nvalchemi.data.datapipes.backends.base import Reader
@@ -1388,6 +1389,164 @@ def test_dataset_and_dataloader_are_standalone_datapipes() -> None:
     assert dataset.reader is not None
     assert loader.dataset is dataset
     assert multidataset.datasets == (dataset,)
+
+
+def test_in_memory_dataset_load_batches_selects_from_batch() -> None:
+    """Verify InMemoryDataset serves batches from an existing Batch."""
+    source = Batch.from_data_list(list(_data_generator(4)), device="cpu")
+    dataset = InMemoryDataset(source)
+
+    batch = dataset.load_batches([[3, 1]])[0]
+
+    assert len(dataset) == 4
+    assert batch.num_graphs == 2
+    assert torch.allclose(batch.energy, source.index_select([3, 1]).energy)
+
+
+def test_in_memory_dataset_can_materialize_reader_in_init() -> None:
+    """Verify InMemoryDataset validates by default when materializing a reader."""
+    reader = _OrderedReadManyReader(n=5)
+    reader.close = MagicMock(wraps=reader.close)  # type: ignore[method-assign]
+
+    def scale_positions(batch: Batch) -> Batch:
+        batch.positions = batch.positions * 2.0
+        return batch
+
+    dataset = InMemoryDataset(
+        reader=reader,
+        chunk_size=2,
+        batch_transforms=[scale_positions],
+    )
+    batch = dataset.load_batches([[4, 0]])[0]
+
+    assert len(dataset) == 5
+    assert reader.read_many_calls == [[0, 1], [2, 3], [4]]
+    reader.close.assert_called_once()
+    assert batch.num_graphs == 2
+    assert batch.atomic_numbers.tolist() == [5, 1]
+    assert torch.allclose(
+        batch.positions,
+        torch.tensor([[10.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+    )
+
+
+def test_in_memory_dataset_can_materialize_reader_without_validation() -> None:
+    """Verify InMemoryDataset can use the raw fast materialization path."""
+    reader = _OrderedReadManyReader(n=3)
+    reader.close = MagicMock(wraps=reader.close)  # type: ignore[method-assign]
+
+    dataset = InMemoryDataset(reader=reader, skip_validation=True)
+    batch = dataset.load_batches([[2, 0]])[0]
+
+    assert len(dataset) == 3
+    reader.close.assert_called_once()
+    assert batch.num_graphs == 2
+    assert batch.atomic_numbers.tolist() == [3, 1]
+
+
+def test_in_memory_dataset_reader_cache_stays_cpu_and_device_targets_output() -> None:
+    """Verify reader materialization stays on CPU while device targets output."""
+    reader = _OrderedReadManyReader(n=3)
+    dataset = InMemoryDataset(
+        reader=reader,
+        device="cpu",
+    )
+
+    batch = dataset.load_batches([[2, 0]])[0]
+
+    assert dataset.in_memory_batch.device == torch.device("cpu")
+    assert dataset.target_device == torch.device("cpu")
+    assert batch.device == torch.device("cpu")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_in_memory_dataset_prefetch_transfers_to_cuda_stream() -> None:
+    """Verify fused prefetch can transfer CPU-resident batches to CUDA."""
+    source = Batch.from_data_list(list(_data_generator(4)), device="cpu")
+    dataset = InMemoryDataset(source, device="cuda")
+    dataset.pin_memory = True
+    stream = torch.cuda.Stream()
+
+    dataset.prefetch_fused_batches([[3, 1]], stream=stream)
+    batch = next(dataset.get_fused_batches())
+
+    assert dataset.in_memory_batch.device == torch.device("cpu")
+    assert batch.device.type == "cuda"
+    torch.testing.assert_close(
+        batch.energy.cpu(),
+        source.index_select([3, 1]).energy,
+    )
+
+
+def test_in_memory_dataset_works_with_simple_dataloader() -> None:
+    """Verify InMemoryDataset supports DataLoader without fused prefetch."""
+    source = Batch.from_data_list(list(_data_generator(5)), device="cpu")
+    loader = DataLoader(
+        InMemoryDataset(source),
+        batch_size=2,
+        prefetch_factor=0,
+        use_streams=False,
+    )
+
+    batches = list(loader)
+
+    assert [batch.num_graphs for batch in batches] == [2, 2, 1]
+    assert sum(batch.num_graphs for batch in batches) == source.num_graphs
+
+
+def test_in_memory_dataset_works_with_prefetch_dataloader() -> None:
+    """Verify InMemoryDataset supports DataLoader fused prefetch mode."""
+    source = Batch.from_data_list(list(_data_generator(5)), device="cpu")
+    loader = DataLoader(
+        InMemoryDataset(source),
+        batch_size=2,
+        prefetch_factor=2,
+        use_streams=False,
+    )
+
+    batches = list(loader)
+
+    assert [batch.num_graphs for batch in batches] == [2, 2, 1]
+    assert sum(batch.num_graphs for batch in batches) == source.num_graphs
+
+
+def test_in_memory_dataset_close_clears_prefetch_queue() -> None:
+    """Verify InMemoryDataset close releases queued fused batches."""
+    source = Batch.from_data_list(list(_data_generator(3)), device="cpu")
+    dataset = InMemoryDataset(source)
+
+    dataset.prefetch_fused_batches([[0], [1]])
+    assert dataset.has_pending_fused_batches()
+
+    dataset.close()
+
+    assert not dataset.has_pending_fused_batches()
+
+
+def test_in_memory_dataset_iterates_samples() -> None:
+    """Verify InMemoryDataset iteration mirrors Dataset sample tuples."""
+    source = Batch.from_data_list(list(_data_generator(3)), device="cpu")
+    dataset = InMemoryDataset(source)
+
+    samples = list(dataset)
+
+    assert len(samples) == 3
+    for index, (data, metadata) in enumerate(samples):
+        assert metadata == {}
+        torch.testing.assert_close(data.energy, source[index].energy)
+
+
+def test_in_memory_dataset_context_exit_calls_close() -> None:
+    """Verify InMemoryDataset context manager clears pending prefetches."""
+    source = Batch.from_data_list(list(_data_generator(3)), device="cpu")
+    dataset = InMemoryDataset(source)
+
+    with dataset as entered:
+        assert entered is dataset
+        dataset.prefetch_fused_batches([[0], [1]])
+        assert dataset.has_pending_fused_batches()
+
+    assert not dataset.has_pending_fused_batches()
 
 
 def test_dataloader_fused_prefetches_sampler_batches_without_streams() -> None:

--- a/test/data/test_zarr_datapipe.py
+++ b/test/data/test_zarr_datapipe.py
@@ -1403,6 +1403,21 @@ def test_in_memory_dataset_load_batches_selects_from_batch() -> None:
     assert torch.allclose(batch.energy, source.index_select([3, 1]).energy)
 
 
+def test_in_memory_dataset_applies_batch_transforms_to_prebuilt_batch() -> None:
+    """Verify batch_transforms run once when a pre-built batch is provided."""
+    source = Batch.from_data_list(list(_data_generator(3)), device="cpu")
+    expected_positions = source.index_select([2, 0]).positions * 2.0
+
+    def scale_positions(batch: Batch) -> Batch:
+        batch.positions = batch.positions * 2.0
+        return batch
+
+    dataset = InMemoryDataset(source, batch_transforms=[scale_positions])
+    batch = dataset.load_batches([[2, 0]])[0]
+
+    assert torch.allclose(batch.positions, expected_positions)
+
+
 def test_in_memory_dataset_can_materialize_reader_in_init() -> None:
     """Verify InMemoryDataset validates by default when materializing a reader."""
     reader = _OrderedReadManyReader(n=5)
@@ -1442,6 +1457,30 @@ def test_in_memory_dataset_can_materialize_reader_without_validation() -> None:
     reader.close.assert_called_once()
     assert batch.num_graphs == 2
     assert batch.atomic_numbers.tolist() == [3, 1]
+
+
+@pytest.mark.parametrize(
+    "bad_batch_transforms",
+    [
+        lambda batch: batch,
+        (x for x in [lambda batch: batch]),
+    ],
+    ids=["single_callable", "generator"],
+)
+def test_in_memory_dataset_invalid_batch_transforms_closes_reader(
+    bad_batch_transforms: object,
+) -> None:
+    """Invalid batch_transforms must still close a materializing reader."""
+    reader = _OrderedReadManyReader(n=3)
+    reader.close = MagicMock(wraps=reader.close)  # type: ignore[method-assign]
+
+    with pytest.raises(TypeError, match="Sequence"):
+        InMemoryDataset(
+            reader=reader,
+            batch_transforms=bad_batch_transforms,  # type: ignore[arg-type]
+        )
+
+    reader.close.assert_called_once()
 
 
 def test_in_memory_dataset_reader_cache_stays_cpu_and_device_targets_output() -> None:

--- a/test/data/test_zarr_datapipe.py
+++ b/test/data/test_zarr_datapipe.py
@@ -33,6 +33,7 @@ from nvalchemi.data.batch import Batch
 from nvalchemi.data.datapipes import (
     AtomicDataZarrReader,
     AtomicDataZarrWriter,
+    BatchDatasetProtocol,
     DataLoader,
     Dataset,
     InMemoryDataset,
@@ -1391,6 +1392,15 @@ def test_dataset_and_dataloader_are_standalone_datapipes() -> None:
     assert multidataset.datasets == (dataset,)
 
 
+def test_batch_dataset_protocol_matches_supported_datasets() -> None:
+    """Verify the DataLoader-facing protocol matches concrete datasets."""
+    dataset = Dataset(_OrderedReadManyReader(), device="cpu")
+    in_memory = InMemoryDataset(Batch.from_data_list(list(_data_generator(2))))
+
+    assert isinstance(dataset, BatchDatasetProtocol)
+    assert isinstance(in_memory, BatchDatasetProtocol)
+
+
 def test_in_memory_dataset_load_batches_selects_from_batch() -> None:
     """Verify InMemoryDataset serves batches from an existing Batch."""
     source = Batch.from_data_list(list(_data_generator(4)), device="cpu")
@@ -1720,6 +1730,37 @@ def test_multidataset_load_batches_routes_mixed_indices_to_child_batches() -> No
     assert batch.atomic_numbers.tolist() == [1, 1, 3, 4]
 
 
+def test_multidataset_accepts_dataset_and_in_memory_dataset() -> None:
+    """Verify MultiDataset can compose reader-backed and in-memory datasets."""
+    dataset_a = Dataset(_OrderedReadManyReader(n=3), device="cpu")
+    source_b = Batch.from_data_list(
+        [_make_ordered_atomic_data(index + 1) for index in range(4)],
+        device="cpu",
+    )
+    dataset_b = InMemoryDataset(source_b)
+    dataset = MultiDataset(dataset_a, dataset_b)
+
+    batch = dataset.load_batches([[0, 3, 2, 6]])[0]
+    loader = DataLoader(
+        dataset,
+        batch_size=2,
+        prefetch_factor=2,
+        use_streams=False,
+    )
+    batches = list(loader)
+
+    assert isinstance(dataset, BatchDatasetProtocol)
+    assert dataset.datasets == (dataset_a, dataset_b)
+    assert dataset.field_names == dataset_a.field_names
+    assert batch.atomic_numbers.tolist() == [1, 1, 3, 4]
+    assert [batch.atomic_numbers.tolist() for batch in batches] == [
+        [1, 2],
+        [3, 1],
+        [2, 3],
+        [4],
+    ]
+
+
 def test_multidataset_dataloader_delegates_single_child_fused_prefetch() -> None:
     """Verify same-child fused chunks use the child fused read path."""
     reader_a = _OrderedReadManyReader(n=6)
@@ -1974,6 +2015,27 @@ def test_dataloader_distributed_sampler(tmp_path: Path) -> None:
 
     assert [batch.atomic_numbers.tolist() for batch in batches] == [[2, 4], [6]]
     assert [list(call.args[0]) for call in read_many.call_args_list] == [[1, 3, 5]]
+
+
+def test_in_memory_dataloader_distributed_sampler() -> None:
+    """Verify InMemoryDataset works with PyTorch's DistributedSampler."""
+    source = Batch.from_data_list(
+        [_make_ordered_atomic_data(i + 1) for i in range(6)],
+        device="cpu",
+    )
+    dataset = InMemoryDataset(source)
+    sampler = DistributedSampler(
+        dataset,
+        num_replicas=2,
+        rank=1,
+        shuffle=False,
+        drop_last=False,
+    )
+    loader = DataLoader(dataset, batch_size=2, sampler=sampler, use_streams=False)
+
+    batches = list(loader)
+
+    assert [batch.atomic_numbers.tolist() for batch in batches] == [[2, 4], [6]]
 
 
 class TestDatasetPrefetch:

--- a/test/hooks/test_neighbor_list_hook.py
+++ b/test/hooks/test_neighbor_list_hook.py
@@ -270,6 +270,23 @@ class TestNeighborListHookProtocol:
             NeighborListHook(_cfg(), stage=DynamicsStage.BEFORE_COMPUTE), Hook
         )
 
+    def test_explicit_method_override(self):
+        hook = NeighborListHook(
+            _cfg(), method="batch_naive_tile", stage=DynamicsStage.BEFORE_COMPUTE
+        )
+        batch = _line_batch("cpu", pbc=False)
+
+        method = hook._select_neighbor_list_method(
+            batch.num_nodes,
+            batch.num_graphs,
+            batch.batch_ptr,
+            None,
+            None,
+            batch.positions.dtype,
+        )
+
+        assert method == "batch_naive_tile"
+
 
 # ===========================================================================
 # TestStagingBufferAllocation

--- a/test/models/test_base.py
+++ b/test/models/test_base.py
@@ -559,6 +559,22 @@ class TestBaseModelMixinMakeNeighborHooks:
         hooks = model.make_neighbor_hooks()
         assert len(hooks) == 1
 
+    def test_hooks_forward_neighbor_list_method(self):
+        class _NLModel(DemoModelWrapper):
+            def __init__(self):
+                super().__init__(DemoModel())
+                self.model_config = ModelConfig(
+                    outputs=frozenset({"energy"}),
+                    neighbor_config=NeighborConfig(cutoff=5.0),
+                    needs_pbc=False,
+                )
+
+        model = _NLModel()
+        hooks = model.make_neighbor_hooks(neighbor_list_method="batch_naive_tile")
+
+        assert len(hooks) == 1
+        assert hooks[0].method == "batch_naive_tile"
+
 
 class TestBaseModelMixinExportModel:
     def test_add_output_head_raises(self, demo_model):

--- a/test/models/test_pipeline.py
+++ b/test/models/test_pipeline.py
@@ -848,6 +848,27 @@ class TestPipelineNeighborHooks:
         hooks = pipe.make_neighbor_hooks()
         assert len(hooks) == 1
 
+    def test_forwards_neighbor_list_method(self):
+        class _NLModel(MockEnergyForceModel):
+            def __init__(self):
+                super().__init__()
+                self.model_config = ModelConfig(
+                    outputs=frozenset({"energy", "forces"}),
+                    needs_pbc=False,
+                    neighbor_config=NeighborConfig(cutoff=5.0),
+                    active_outputs={"energy", "forces"},
+                )
+
+        pipe = PipelineModelWrapper(
+            groups=[
+                PipelineGroup(steps=[_NLModel()]),
+            ]
+        )
+        hooks = pipe.make_neighbor_hooks(neighbor_list_method="cell_list")
+
+        assert len(hooks) == 1
+        assert hooks[0].method == "cell_list"
+
 
 # ===========================================================================
 # Neighbor adaptation tests


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Add an in-memory dataset data pipe for datasets that fit in CPU memory, integrating reader-backed resident `Batch` materialization with the existing ALCHEMI `DataLoader` fused-prefetch path and DDP sampler setup. This also exposes an explicit neighbor-list method override through model and pipeline neighbor-hook creation.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- `InMemoryDataset`
  - Added a resident-batch data pipe that materializes reader-backed data into memory, with optional validation skipping, device transfer, fused batch prefetch, and context management.
  - Integrated `InMemoryDataset` with the existing ALCHEMI `DataLoader` batch contract and DDP default distributed sampler path.
  - Documented the new data pipe, including user guide examples and changelog notes.
  - Added targeted regression coverage for in-memory loading, fused prefetch, DataLoader behavior, and DDP integration.
- Neighbor list method selection: allowed callers to pass an explicit `neighbor_list_method` from model and pipeline neighbor-hook creation into `NeighborListHook`, with regression coverage for forwarding.

## Testing

Targeted tests run:

- `uv run --extra cu12 --extra mace pytest test/data/test_zarr_datapipe.py test/hooks/test_neighbor_list_hook.py test/models/test_base.py test/models/test_pipeline.py test/training/test_ddp_hook.py` (passed: 540 passed, 15 warnings)

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

A number of class methods such as `_resolve_target_device` and `get_fused_batches` are copied from `Dataset`. Recommend creating shared utility functions in the future.

### MACE training benchmark

These runs use the MACE training example with batch size 256, 8 CPUs, 1 GPU, and `skip_validation=True`. The averaged profiler columns use 990 measured training steps, excluding the first 10 steps. Rows 1-4 use the existing `Dataset` path with different prefetch factors. Rows 5-6 show the impact of `InMemoryDataset` on data loading and end-to-end runtime. Row 7 adds explicit neighbor-list method selection, reducing the before-forward hook time, which is dominated by neighbor-list construction in this workload.

| Configuration | Slurm elapsed | Training run (s) | Batch avg (ms) | Data loading avg (ms) | Before-forward hooks avg (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Dataset`, prefetch 4 | 00:06:03 | 330.626 | 134.994 | 120.358 | 27.058 |
| `Dataset`, prefetch 128 | 00:06:27 | 344.255 | 115.078 | 82.093 | 28.791 |
| `Dataset`, prefetch 512 | 00:08:59 | 513.106 | 83.278 | 78.866 | 16.392 |
| `Dataset`, prefetch 4096 | 00:08:03 | 454.566 | 65.321 | 0.453 | 8.758 |
| `InMemoryDataset`, CPU-resident | 00:03:58 | 142.020 | 69.292 | 1.500 | 11.413 |
| `InMemoryDataset`, async H2D prefetch 2 | 00:03:54 | 144.222 | 63.167 | 6.034 | 8.234 |
| `InMemoryDataset`, async H2D prefetch 2, explicit neighbor-list method | 00:03:56 | 133.569 | 58.445 | 1.742 | 2.980 |

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
