### PR TITLE
Fix mixed-dtype segmented buffer copies

### DIFF
--- a/nvalchemi/data/batch.py
+++ b/nvalchemi/data/batch.py
@@ -946,7 +946,8 @@ class Batch(DataMixin):
 
         Drops graphs where copied_mask[i] is True (e.g. from a prior
         :meth:`put`). Uses Warp buffer kernels; one host sync per group to
-        trim. Only float32 attributes are compacted.
+        trim. Attributes with buffer-kernel-supported dtypes (``bool``,
+        ``int32``, ``int64``, ``float32``, ``float64``) are compacted.
 
         Parameters
         ----------

--- a/nvalchemi/data/level_storage.py
+++ b/nvalchemi/data/level_storage.py
@@ -603,6 +603,38 @@ def _validate_trailing_shapes(tensors: list[Tensor]) -> bool:
     return all(t.shape[1:] == trailing for t in tensors)
 
 
+_SUPPORTED_BUFFER_DTYPES = ", ".join(
+    str(dtype) for dtype in sorted(TORCH_TO_WP, key=str)
+)
+
+
+def _validate_buffer_tensor_dtype(key: str, tensor: Tensor) -> None:
+    """Raise a clear error when a buffer kernel cannot handle *tensor*'s dtype."""
+    if tensor.dtype not in TORCH_TO_WP:
+        raise TypeError(
+            f"Attribute '{key}' has unsupported dtype {tensor.dtype}; "
+            f"supported dtypes: {_SUPPORTED_BUFFER_DTYPES}"
+        )
+
+
+def _validated_buffer_copy_tensors(
+    dest_data: TensorDict, src_data: TensorDict, common: list[str]
+) -> list[tuple[str, Tensor, Tensor]]:
+    """Validate shared buffer attributes before any copy kernels mutate state."""
+    tensors: list[tuple[str, Tensor, Tensor]] = []
+    for key in common:
+        src_t = src_data[key]
+        dest_t = dest_data[key]
+        if src_t.dtype != dest_t.dtype:
+            raise TypeError(
+                f"Attribute '{key}' dtype mismatch: source {src_t.dtype}, "
+                f"destination {dest_t.dtype}"
+            )
+        _validate_buffer_tensor_dtype(key, src_t)
+        tensors.append((key, src_t, dest_t))
+    return tensors
+
+
 # ---------------------------------------------------------------------------
 # BaseLevelStorage (ABC)
 # ---------------------------------------------------------------------------
@@ -710,7 +742,8 @@ class BaseLevelStorage(ABC):
     # -- Abstract -----------------------------------------------------------
 
     @abstractmethod
-    def __len__(self) -> int: ...
+    def __len__(self) -> int:
+        ...
 
     @abstractmethod
     def select(self, idx: IndexType) -> BaseLevelStorage:
@@ -733,7 +766,8 @@ class BaseLevelStorage(ABC):
         """Return ``True`` if this container uses segmented storage."""
 
     @abstractmethod
-    def _validate_setitem(self, key: str, value: Tensor) -> None: ...
+    def _validate_setitem(self, key: str, value: Tensor) -> None:
+        ...
 
     # -- Dict-like interface ------------------------------------------------
 
@@ -1119,7 +1153,9 @@ class UniformLevelStorage(BaseLevelStorage):
     ) -> None:
         """Put rows where mask[i] is True from src into this storage (buffer).
 
-        Copies only float32 attributes; only as many rows as fit in this
+        Copies attributes with buffer-kernel-supported dtypes (``bool``,
+        ``int32``, ``int64``, ``float32``, ``float64``); source and
+        destination dtypes must match. Only as many rows as fit in this
         storage's empty slots (dest_mask[i] False = empty). Uses Warp buffer
         kernels (no host sync). If copied_mask is provided, it is updated in
         place with True for each row that was copied.
@@ -1141,9 +1177,10 @@ class UniformLevelStorage(BaseLevelStorage):
         """
         if self._data.is_empty() or src._data.is_empty():
             raise ValueError("put requires non-empty source and dest")
-        common = set(self._data.keys()) & set(src._data.keys())
+        common = [key for key in self._data.keys() if key in src._data]
         if not common:
             raise ValueError("put requires at least one common attribute")
+        tensors = _validated_buffer_copy_tensors(self._data, src._data, common)
         n_src = len(src)
         dest_capacity = self._data.shape[0]
         if mask.shape[0] != n_src:
@@ -1164,9 +1201,7 @@ class UniformLevelStorage(BaseLevelStorage):
                 raise ValueError(
                     f"dest_mask shape {dest_mask.shape[0]} != dest capacity {dest_capacity}"
                 )
-        for key in common:
-            src_t = src._data[key]
-            dest_t = self._data[key]
+        for key, src_t, dest_t in tensors:
             if dest_t.shape[0] < dest_capacity:
                 raise ValueError(
                     f"dest attribute '{key}' first dim {dest_t.shape[0]} < {dest_capacity}"
@@ -1189,10 +1224,10 @@ class UniformLevelStorage(BaseLevelStorage):
         """Defrag in-place: remove rows where copied_mask[i] is True.
 
         Rows with copied_mask[i] True (previously put) are dropped; remaining
-        rows move to the front in place. Only float32 attributes are
-        compacted. Buffer shape is unchanged (fixed-size batches). Other
-        attributes are indexed with the same indices (so must be kept in sync
-        if present).
+        rows move to the front in place. Attributes with buffer-kernel-
+        supported dtypes (``bool``, ``int32``, ``int64``, ``float32``,
+        ``float64``) are compacted in place. Buffer shape is unchanged
+        (fixed-size batches).
 
         Parameters
         ----------
@@ -1216,10 +1251,10 @@ class UniformLevelStorage(BaseLevelStorage):
             copied_mask = copied_mask.to(device=self.device, dtype=torch.bool)
         if copied_mask.shape[0] != n_src:
             raise ValueError(f"copied_mask shape {copied_mask.shape[0]} != {n_src}")
-        for key in list(self._data.keys()):
-            t = self._data[key]
-            if t.dtype not in TORCH_TO_WP:
-                continue
+        tensors = [(key, self._data[key]) for key in self._data.keys()]
+        for key, t in tensors:
+            _validate_buffer_tensor_dtype(key, t)
+        for _, t in tensors:
             # Pass a clone so the kernel's in-place mask update doesn't affect other keys
             defrag_per_system(t, copied_mask.clone())
         object.__setattr__(self, "_num_kept", int((~copied_mask).sum().item()))
@@ -1836,8 +1871,10 @@ class SegmentedLevelStorage(BaseLevelStorage):
     ) -> None:
         """Put segments where mask[i] is True from src into this storage (buffer).
 
-        New segment boundaries are appended to this storage's batch_ptr. Only
-        float32 attributes are copied. Uses Warp buffer kernels; one host sync
+        New segment boundaries are appended to this storage's batch_ptr.
+        Copies attributes with buffer-kernel-supported dtypes (``bool``,
+        ``int32``, ``int64``, ``float32``, ``float64``); source and
+        destination dtypes must match. Uses Warp buffer kernels; one host sync
         after all attributes to update this storage's segment count. If
         copied_mask is provided, it is updated in place with True for each
         segment that was copied.
@@ -1855,9 +1892,10 @@ class SegmentedLevelStorage(BaseLevelStorage):
         """
         if self._data.is_empty() or src._data.is_empty():
             raise ValueError("put requires non-empty source and dest")
-        common = set(self._data.keys()) & set(src._data.keys())
+        common = [key for key in self._data.keys() if key in src._data]
         if not common:
             raise ValueError("put requires at least one common attribute")
+        tensors = _validated_buffer_copy_tensors(self._data, src._data, common)
         n_seg = len(src)
         if mask.shape[0] != n_seg:
             raise ValueError(f"mask shape {mask.shape[0]} != num segments {n_seg}")
@@ -1877,13 +1915,7 @@ class SegmentedLevelStorage(BaseLevelStorage):
         if dest_batch_ptr.shape[0] < min_batch_ptr_size:
             return
         new_num_dest = None
-        for key in common:
-            src_t = src._data[key]
-            if src_t.dtype != torch.float32:
-                continue
-            dest_t = self._data[key]
-            if dest_t.dtype != torch.float32:
-                continue
+        for _, src_t, dest_t in tensors:
             new_num_dest = put_masked_segmented(
                 src_t,
                 src._batch_ptr,
@@ -1910,7 +1942,9 @@ class SegmentedLevelStorage(BaseLevelStorage):
 
         Kept segments move to the front; batch_ptr is updated in place (tail
         filled so batch_ptr[-1] == total_kept_elems); segment_lengths derived
-        from it; no trim. All attributes must be float32 (uses Warp kernels).
+        from it; no trim. Attributes with buffer-kernel-supported dtypes
+        (``bool``, ``int32``, ``int64``, ``float32``, ``float64``) are
+        compacted in place.
 
         Parameters
         ----------
@@ -1936,6 +1970,8 @@ class SegmentedLevelStorage(BaseLevelStorage):
             raise ValueError(f"copied_mask shape {copied_mask.shape[0]} != {n_seg}")
         self._lazy_init_batch_ptr()
         keys = list(self._data.keys())
+        for key in keys:
+            _validate_buffer_tensor_dtype(key, self._data[key])
         original_bp = self._batch_ptr.clone()
         num_kept_t = defrag_segmented(self._data[keys[0]], self._batch_ptr, copied_mask)
         for key in keys[1:]:

--- a/nvalchemi/data/level_storage.py
+++ b/nvalchemi/data/level_storage.py
@@ -1227,7 +1227,8 @@ class UniformLevelStorage(BaseLevelStorage):
         rows move to the front in place. Attributes with buffer-kernel-
         supported dtypes (``bool``, ``int32``, ``int64``, ``float32``,
         ``float64``) are compacted in place. Buffer shape is unchanged
-        (fixed-size batches).
+        (fixed-size batches). Unsupported dtypes raise ``TypeError`` before
+        any attribute is compacted.
 
         Parameters
         ----------
@@ -1944,7 +1945,8 @@ class SegmentedLevelStorage(BaseLevelStorage):
         filled so batch_ptr[-1] == total_kept_elems); segment_lengths derived
         from it; no trim. Attributes with buffer-kernel-supported dtypes
         (``bool``, ``int32``, ``int64``, ``float32``, ``float64``) are
-        compacted in place.
+        compacted in place. Unsupported dtypes raise ``TypeError`` before
+        any attribute is compacted.
 
         Parameters
         ----------

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -505,9 +505,9 @@ class TestBatchMutation:
         )
         ei_before = b2["neighbor_list"].clone()
         b1.append(b2)
-        assert torch.equal(b2["neighbor_list"], ei_before), (
-            "append() mutated other batch's neighbor_list"
-        )
+        assert torch.equal(
+            b2["neighbor_list"], ei_before
+        ), "append() mutated other batch's neighbor_list"
         # Verify result is structurally correct.
         assert b1.num_graphs == 2
         assert b1.num_nodes_list == [2, 3]
@@ -853,6 +853,35 @@ class TestBatchPutDefrag:
         assert copied_mask.sum().item() == 0
         assert buffer.num_graphs == 2
 
+    def test_put_copies_mixed_supported_dtypes_for_atoms_and_edges(self):
+        """put preserves integer atom and edge fields alongside floating payloads."""
+        sample = AtomicData(
+            positions=torch.tensor(
+                [[0.1, 0.2, 0.3], [1.0, 1.1, 1.2], [2.0, 2.1, 2.2]],
+                dtype=torch.float32,
+            ),
+            atomic_numbers=torch.tensor([6, 8, 1], dtype=torch.int64),
+            neighbor_list=torch.tensor([[0, 1], [1, 2]], dtype=torch.int64),
+            pbc=torch.tensor([[True, False, True]], dtype=torch.bool),
+        )
+        src_batch = Batch.from_data_list([sample])
+        buffer = Batch.empty(
+            num_systems=2,
+            num_nodes=6,
+            num_edges=4,
+            template=sample,
+        )
+
+        buffer.put(src_batch, torch.tensor([True]))
+
+        assert buffer.num_graphs == 1
+        assert buffer.num_nodes_list == [3]
+        assert buffer.num_edges_list == [2]
+        torch.testing.assert_close(buffer.positions[:3], src_batch.positions)
+        torch.testing.assert_close(buffer.atomic_numbers[:3], src_batch.atomic_numbers)
+        torch.testing.assert_close(buffer.neighbor_list[:2], src_batch.neighbor_list)
+        torch.testing.assert_close(buffer.pbc[:1], src_batch.pbc)
+
     def test_defrag_with_copied_mask(self):
         """defrag(copied_mask) compacts batch by removing graphs where copied_mask is True."""
         batch = Batch.from_data_list(
@@ -1164,9 +1193,9 @@ class TestBatchIsendIrecvTagAlignment:
                 handle.wait()
 
         send_tags_after_meta = send_tags[1:]
-        assert send_tags_after_meta == recv_tags, (
-            f"Tag mismatch: send (after meta)={send_tags_after_meta}, recv={recv_tags}"
-        )
+        assert (
+            send_tags_after_meta == recv_tags
+        ), f"Tag mismatch: send (after meta)={send_tags_after_meta}, recv={recv_tags}"
 
 
 class TestBatchFromRawDicts:

--- a/test/data/test_level_storage.py
+++ b/test/data/test_level_storage.py
@@ -810,6 +810,100 @@ class TestSegmentedLevelStorage:
             src["x"][:2], torch.tensor([[2.0], [3.0]], device=device)
         )
 
+    def test_put_and_defrag_preserve_mixed_supported_dtypes(self):
+        """put and defrag keep int64 atom data in sync with float32 payloads."""
+        device = "cpu"
+        src = SegmentedLevelStorage(
+            data={
+                "positions": torch.tensor(
+                    [[1.0, 1.5, 2.0], [3.0, 3.5, 4.0], [5.0, 5.5, 6.0]],
+                    device=device,
+                    dtype=torch.float32,
+                ),
+                "atomic_numbers": torch.tensor(
+                    [6, 8, 1], device=device, dtype=torch.int64
+                ),
+            },
+            segment_lengths=[1, 2],
+            device=device,
+            validate=False,
+        )
+        expected_remaining_positions = src["positions"][1:].clone()
+        expected_remaining_numbers = src["atomic_numbers"][1:].clone()
+        dest = SegmentedLevelStorage(
+            data={
+                "positions": torch.zeros(4, 3, device=device, dtype=torch.float32),
+                "atomic_numbers": torch.zeros(4, device=device, dtype=torch.int64),
+            },
+            segment_lengths=[0],
+            device=device,
+            batch_ptr_capacity=5,
+            validate=False,
+        )
+        copied_mask = torch.zeros(2, dtype=torch.bool, device=device)
+        dest.put(
+            src,
+            torch.tensor([True, False], device=device),
+            copied_mask=copied_mask,
+        )
+
+        assert copied_mask.tolist() == [True, False]
+        assert len(dest) == 2
+        torch.testing.assert_close(
+            dest["positions"][:1],
+            torch.tensor([[1.0, 1.5, 2.0]], device=device, dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            dest["atomic_numbers"][:1],
+            torch.tensor([6], device=device, dtype=torch.int64),
+        )
+
+        src.defrag(copied_mask=copied_mask)
+
+        assert len(src) == 1
+        assert src.num_elements() == 2
+        torch.testing.assert_close(src["positions"][:2], expected_remaining_positions)
+        torch.testing.assert_close(
+            src["atomic_numbers"][:2], expected_remaining_numbers
+        )
+
+    def test_put_raises_before_copy_if_segmented_dtypes_mismatch(self):
+        """put fails before mutating dest when a shared attribute dtype mismatches."""
+        device = "cpu"
+        src = SegmentedLevelStorage(
+            data={
+                "positions": torch.tensor([[1.0, 2.0, 3.0]], device=device),
+                "atomic_numbers": torch.tensor([6], device=device, dtype=torch.int64),
+            },
+            segment_lengths=[1],
+            device=device,
+            validate=False,
+        )
+        dest = SegmentedLevelStorage(
+            data={
+                "positions": torch.zeros(3, 3, device=device, dtype=torch.float32),
+                "atomic_numbers": torch.zeros(3, device=device, dtype=torch.int32),
+            },
+            segment_lengths=[0],
+            device=device,
+            batch_ptr_capacity=4,
+            validate=False,
+        )
+
+        with pytest.raises(TypeError, match="atomic_numbers"):
+            dest.put(src, torch.tensor([True], device=device))
+
+        torch.testing.assert_close(
+            dest["positions"],
+            torch.zeros(3, 3, device=device, dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            dest["atomic_numbers"],
+            torch.zeros(3, device=device, dtype=torch.int32),
+        )
+        assert dest.batch_ptr[0].item() == 0
+        assert len(dest) == 1
+
     def test_compute_put_per_system_fit_mask(self):
         """compute_put_per_system_fit_mask writes fit_mask; put with it copies same set."""
         device = "cpu"

--- a/test/data/test_level_storage.py
+++ b/test/data/test_level_storage.py
@@ -340,6 +340,63 @@ class TestUniformLevelStorage:
         src.defrag(copied_mask=copied_mask)
         assert len(src) == 0
 
+    def test_put_raises_before_copy_if_uniform_dtypes_mismatch(self):
+        """put fails before mutating dest when a later shared dtype mismatches."""
+        device = "cpu"
+        src = UniformLevelStorage(
+            data={
+                "a": torch.tensor([[1.0], [2.0]], device=device, dtype=torch.float32),
+                "b": torch.tensor([6, 8], device=device, dtype=torch.int64),
+            },
+            device=device,
+            validate=False,
+        )
+        dest = UniformLevelStorage(
+            data={
+                "a": torch.zeros(2, 1, device=device, dtype=torch.float32),
+                "b": torch.zeros(2, device=device, dtype=torch.int32),
+            },
+            device=device,
+            validate=False,
+        )
+
+        with pytest.raises(TypeError, match="b"):
+            dest.put(src, torch.tensor([True, True], device=device))
+
+        torch.testing.assert_close(
+            dest["a"],
+            torch.zeros(2, 1, device=device, dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            dest["b"],
+            torch.zeros(2, device=device, dtype=torch.int32),
+        )
+
+    def test_defrag_raises_if_uniform_storage_has_unsupported_dtype(self):
+        """defrag raises before compacting any uniform attribute with unsupported dtypes."""
+        device = "cpu"
+        src = UniformLevelStorage(
+            data={
+                "a": torch.tensor(
+                    [[1.0], [2.0], [3.0]], device=device, dtype=torch.float32
+                ),
+                "bad": torch.tensor(
+                    [9.0, 8.0, 7.0], device=device, dtype=torch.float16
+                ),
+            },
+            device=device,
+            validate=False,
+        )
+        expected_a = src["a"].clone()
+        expected_bad = src["bad"].clone()
+
+        with pytest.raises(TypeError, match="bad"):
+            src.defrag(copied_mask=torch.tensor([True, False, True], device=device))
+
+        torch.testing.assert_close(src["a"], expected_a)
+        torch.testing.assert_close(src["bad"], expected_bad)
+        assert not hasattr(src, "_num_kept")
+
     def test_put_defrag_fixed_tensor_shapes(self):
         """Data tensors are not expanded or trimmed by put or defrag (fixed storage)."""
         device = "cpu"
@@ -903,6 +960,38 @@ class TestSegmentedLevelStorage:
         )
         assert dest.batch_ptr[0].item() == 0
         assert len(dest) == 1
+
+    def test_defrag_raises_if_segmented_storage_has_unsupported_dtype(self):
+        """defrag raises before compacting segmented attributes with unsupported dtypes."""
+        device = "cpu"
+        src = SegmentedLevelStorage(
+            data={
+                "positions": torch.tensor(
+                    [[1.0], [2.0], [3.0]], device=device, dtype=torch.float32
+                ),
+                "bad": torch.tensor(
+                    [9.0, 8.0, 7.0], device=device, dtype=torch.float16
+                ),
+            },
+            segment_lengths=[1, 2],
+            batch_ptr=torch.tensor([0, 1, 3], device=device, dtype=torch.int32),
+            device=device,
+            validate=False,
+        )
+        expected_positions = src["positions"].clone()
+        expected_bad = src["bad"].clone()
+        expected_batch_ptr = src.batch_ptr.clone()
+        expected_segment_lengths = src.segment_lengths.clone()
+
+        with pytest.raises(TypeError, match="bad"):
+            src.defrag(copied_mask=torch.tensor([True, False], device=device))
+
+        torch.testing.assert_close(src["positions"], expected_positions)
+        torch.testing.assert_close(src["bad"], expected_bad)
+        torch.testing.assert_close(src.batch_ptr, expected_batch_ptr)
+        torch.testing.assert_close(src.segment_lengths, expected_segment_lengths)
+        assert not hasattr(src, "_num_segments")
+        assert not hasattr(src, "_num_elements_kept")
 
     def test_compute_put_per_system_fit_mask(self):
         """compute_put_per_system_fit_mask writes fit_mask; put with it copies same set."""


### PR DESCRIPTION
## Summary
- remove the stale float32-only gate from segmented buffer copies and validate shared buffer dtypes up front
- fail loudly on mismatched or unsupported buffer dtypes instead of partially mutating storage
- add regression coverage for mixed-dtype segmented storage copies and batch buffer copies

## Root cause
`SegmentedLevelStorage.put()` still skipped every non-float32 attribute even though the underlying buffer kernels already support `bool`, `int32`, `int64`, and `float64`. In practice that meant segmented buffers could copy positions while leaving `atomic_numbers` or `neighbor_list` stale.

## Validation
- `uv run pytest test/data/test_level_storage.py::TestUniformLevelStorage::test_put_and_defrag test/data/test_level_storage.py::TestSegmentedLevelStorage::test_put_and_defrag test/data/test_level_storage.py::TestSegmentedLevelStorage::test_put_and_defrag_preserve_mixed_supported_dtypes test/data/test_level_storage.py::TestSegmentedLevelStorage::test_put_raises_before_copy_if_segmented_dtypes_mismatch test/data/test_batch.py::TestBatchPutDefrag::test_put_copies_mixed_supported_dtypes_for_atoms_and_edges test/data/test_batch.py::TestBatchPutDefrag::test_defrag_with_copied_mask`
- `uv run ruff check nvalchemi/data/level_storage.py nvalchemi/data/batch.py test/data/test_level_storage.py test/data/test_batch.py`
- `uv run black --check nvalchemi/data/level_storage.py nvalchemi/data/batch.py test/data/test_level_storage.py test/data/test_batch.py`
