### PR TITLE
Fix strategy checkpoint restore order for model architecture hooks

### DIFF
--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1706,7 +1706,7 @@ def load_checkpoint(
     )
     load_location = _strategy_target_device(strategy_metadata, map_location)
 
-    # Path 1: construct a user-supplied live strategy.
+    # Path 1: restore a user-supplied live strategy.
     # The model structure must already match the checkpoint.
     # This includes registration-time module patches or adapters.
     if strategy is not None:

--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1402,6 +1402,32 @@ def _with_strategy_device_override(
     return metadata
 
 
+def _build_model_from_checkpoint_spec(
+    root: Path,
+    name: str,
+    *,
+    load_location: torch.device | None,
+) -> tuple[nn.Module, BaseSpec]:
+    """Build a model without its saved weights from its checkpoint spec."""
+    spec = _load_spec(root / "models" / name / "spec.json")
+    build_kwargs = (
+        {"device": load_location}
+        if load_location is not None and spec.accepts_kwarg("device")
+        else {}
+    )
+    model = spec.build(**build_kwargs)
+    if not isinstance(model, nn.Module):
+        raise RuntimeError(
+            f"Model spec for {name!r} built {type(model)!r}, expected nn.Module."
+        )
+    # Move models whose factories do not accept device after construction.
+    # Factory-loaded models such as MACE + cuEq need the device during
+    # construction so conversion happens on the intended accelerator.
+    if load_location is not None and not build_kwargs:
+        model.to(load_location)
+    return model, spec
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -1692,6 +1718,44 @@ def load_checkpoint(
         _run_validators(loaded, validators)
         return loaded
 
+    if strategy_metadata is not None and model_names is None:
+        from nvalchemi.training.strategy import TrainingStrategy
+
+        unweighted_models = {
+            name: _build_model_from_checkpoint_spec(
+                root,
+                name,
+                load_location=load_location,
+            )[0]
+            for name in manifest.models
+        }
+        loaded_strategy_models: Any = unweighted_models
+        if strategy_metadata.get("single_model_input") is True and set(
+            unweighted_models
+        ) == {"main"}:
+            loaded_strategy_models = unweighted_models["main"]
+
+        runtime_strategy_metadata = _with_strategy_device_override(
+            strategy_metadata, map_location
+        )
+        restored_strategy = TrainingStrategy.from_checkpoint_dict(
+            runtime_strategy_metadata,
+            models=loaded_strategy_models,
+            hooks=hooks,
+            training_fn=training_fn,
+        )
+        loaded = _restore_checkpoint_into_strategy(
+            root,
+            manifest,
+            checkpoint_index=checkpoint_index,
+            strategy=restored_strategy,
+            strategy_metadata=runtime_strategy_metadata,
+            map_location=load_location,
+        )
+        loaded["strategy_metadata"] = runtime_strategy_metadata
+        _run_validators(loaded, validators)
+        return loaded
+
     # determine what models to load
     selected_models = set(manifest.models) if model_names is None else set(model_names)
     unknown = selected_models - set(manifest.models)
@@ -1701,6 +1765,10 @@ def load_checkpoint(
             f"Available: {sorted(manifest.models)!r}"
         )
 
+    # Remaining paths are component-level loads: either the checkpoint has no
+    # strategy metadata, or ``model_names`` requested a partial load from a
+    # strategy checkpoint. Partial loads do not reconstruct strategy hooks.
+    
     # Build the load set as the union of each selected model's associations.
     # When ``model_names is None`` this is equivalent to loading every
     # component listed in the manifest.
@@ -1721,22 +1789,11 @@ def load_checkpoint(
     # --- Models ---
     loaded_models: dict[str, tuple[nn.Module, BaseSpec]] = {}
     for name in models_to_load:
-        spec = _load_spec(root / "models" / name / "spec.json")
-        build_kwargs = (
-            {"device": load_location}
-            if load_location is not None and spec.accepts_kwarg("device")
-            else {}
+        model, spec = _build_model_from_checkpoint_spec(
+            root,
+            name,
+            load_location=load_location,
         )
-        model = spec.build(**build_kwargs)
-        if not isinstance(model, nn.Module):
-            raise RuntimeError(
-                f"Model spec for {name!r} built {type(model)!r}, expected nn.Module."
-            )
-        # Move models whose factories do not accept device after construction.
-        # Factory-loaded models such as MACE + cuEq need the device during
-        # construction so conversion happens on the intended accelerator.
-        if load_location is not None and not build_kwargs:
-            model.to(load_location)
         weights = torch.load(
             root / "models" / name / "checkpoints" / f"{checkpoint_index}.pt",
             weights_only=True,
@@ -1788,37 +1845,10 @@ def load_checkpoint(
             _run_validators(loaded, validators)
         return manifest
 
-    strategy = None
-    if strategy_metadata is not None and model_names is None:
-        from nvalchemi.training.strategy import TrainingStrategy
-
-        loaded_strategy_models: Any = _loaded_model_objects(manifest)
-        if strategy_metadata.get("single_model_input") is True and set(
-            loaded_strategy_models
-        ) == {"main"}:
-            loaded_strategy_models = loaded_strategy_models["main"]
-
-        runtime_strategy_metadata = _with_strategy_device_override(
-            strategy_metadata, map_location
-        )
-        strategy = TrainingStrategy.from_checkpoint_dict(
-            runtime_strategy_metadata,
-            models=loaded_strategy_models,
-            hooks=hooks,
-            training_fn=training_fn,
-        )
-        _install_strategy_optimizer_state(strategy, manifest)
-        _load_hook_states(
-            root,
-            strategy,
-            checkpoint_index,
-            map_location=load_location,
-        )
-
     loaded = _manifest_to_loaded_checkpoint(
         manifest,
         root=root,
-        strategy=strategy,
+        strategy=None,
     )
     if strategy_metadata is not None:
         loaded["strategy_metadata"] = _with_strategy_device_override(

--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1768,7 +1768,6 @@ def load_checkpoint(
     # Remaining paths are component-level loads: either the checkpoint has no
     # strategy metadata, or ``model_names`` requested a partial load from a
     # strategy checkpoint. Partial loads do not reconstruct strategy hooks.
-    
     # Build the load set as the union of each selected model's associations.
     # When ``model_names is None`` this is equivalent to loading every
     # component listed in the manifest.

--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1706,7 +1706,7 @@ def load_checkpoint(
     )
     load_location = _strategy_target_device(strategy_metadata, map_location)
 
-    # Path 1: hydrate a user-supplied live strategy.
+    # Path 1: construct a user-supplied live strategy.
     # The model structure must already match the checkpoint.
     # This includes registration-time module patches or adapters.
     if strategy is not None:

--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1160,6 +1160,7 @@ def _restore_checkpoint_into_strategy(
 ) -> dict[str, Any]:
     """Load checkpoint state into an already-constructed strategy."""
     from nvalchemi.training.strategy import TrainingStrategy
+    from nvalchemi.training.runtime import move_to_devices
 
     if not isinstance(strategy, TrainingStrategy):
         raise TypeError(
@@ -1187,6 +1188,7 @@ def _restore_checkpoint_into_strategy(
         spec = _load_spec(spec_path) if spec_path.exists() else None
         loaded_models[name] = (model, spec)
 
+    strategy.models = move_to_devices(strategy.models, strategy.devices)
     live_optimizers, live_schedulers = _optimizer_scheduler_maps_from_strategy(strategy)
 
     loaded_optimizers: dict[str, tuple[torch.optim.Optimizer, BaseSpec | None]] = {}
@@ -1407,15 +1409,22 @@ def _build_model_from_checkpoint_spec(
     name: str,
     *,
     load_location: torch.device | None,
+    **kwargs: Any,
 ) -> tuple[nn.Module, BaseSpec]:
-    """Build a model without its saved weights from its checkpoint spec."""
+    """Build a model without its saved weights from its checkpoint spec.
+
+    Extra ``**kwargs`` are forwarded to :meth:`BaseSpec.build` as
+    runtime construction overrides for the model factory.
+    """
     spec = _load_spec(root / "models" / name / "spec.json")
-    build_kwargs = (
-        {"device": load_location}
-        if load_location is not None and spec.accepts_kwarg("device")
-        else {}
-    )
+    build_on_device = load_location is not None and spec.accepts_kwarg("device")
+    build_kwargs = {
+        **kwargs,
+        **({"device": load_location} if build_on_device else {}),
+    }
     model = spec.build(**build_kwargs)
+    # Native checkpoints load weights and optimizer through :class:`nn.Module`
+    # state_dict APIs; non-modules are not supported here.
     if not isinstance(model, nn.Module):
         raise RuntimeError(
             f"Model spec for {name!r} built {type(model)!r}, expected nn.Module."
@@ -1423,7 +1432,7 @@ def _build_model_from_checkpoint_spec(
     # Move models whose factories do not accept device after construction.
     # Factory-loaded models such as MACE + cuEq need the device during
     # construction so conversion happens on the intended accelerator.
-    if load_location is not None and not build_kwargs:
+    if load_location is not None and not build_on_device:
         model.to(load_location)
     return model, spec
 
@@ -1697,6 +1706,9 @@ def load_checkpoint(
     )
     load_location = _strategy_target_device(strategy_metadata, map_location)
 
+    # Path 1: hydrate a user-supplied live strategy.
+    # The model structure must already match the checkpoint.
+    # This includes registration-time module patches or adapters.
     if strategy is not None:
         if model_names is not None:
             raise ValueError(
@@ -1718,9 +1730,12 @@ def load_checkpoint(
         _run_validators(loaded, validators)
         return loaded
 
+    # Path 2: rebuild the strategy from strategy metadata.
+    # Registration-time hooks run before weights are loaded.
     if strategy_metadata is not None and model_names is None:
         from nvalchemi.training.strategy import TrainingStrategy
 
+        # Build models from specs without loading weights.
         unweighted_models = {
             name: _build_model_from_checkpoint_spec(
                 root,
@@ -1735,15 +1750,18 @@ def load_checkpoint(
         ) == {"main"}:
             loaded_strategy_models = unweighted_models["main"]
 
+        # Reconstruct the strategy and run registration-time hooks.
         runtime_strategy_metadata = _with_strategy_device_override(
             strategy_metadata, map_location
         )
         restored_strategy = TrainingStrategy.from_checkpoint_dict(
             runtime_strategy_metadata,
             models=loaded_strategy_models,
-            hooks=hooks,
+            hooks=hooks, # extra user-supplied runtime hooks
             training_fn=training_fn,
         )
+
+        # Load model weights and optimizer/scheduler/runtime state.
         loaded = _restore_checkpoint_into_strategy(
             root,
             manifest,
@@ -1756,7 +1774,10 @@ def load_checkpoint(
         _run_validators(loaded, validators)
         return loaded
 
-    # determine what models to load
+    # Path 3: component-level loads: either the checkpoint has no strategy 
+    # metadata, or ``model_names`` requested a partial load from a strategy
+    # checkpoint. Partial loads do not reconstruct strategy hooks.
+    # Determine what models to load.
     selected_models = set(manifest.models) if model_names is None else set(model_names)
     unknown = selected_models - set(manifest.models)
     if unknown:
@@ -1765,9 +1786,6 @@ def load_checkpoint(
             f"Available: {sorted(manifest.models)!r}"
         )
 
-    # Remaining paths are component-level loads: either the checkpoint has no
-    # strategy metadata, or ``model_names`` requested a partial load from a
-    # strategy checkpoint. Partial loads do not reconstruct strategy hooks.
     # Build the load set as the union of each selected model's associations.
     # When ``model_names is None`` this is equivalent to loading every
     # component listed in the manifest.

--- a/nvalchemi/training/_checkpoint.py
+++ b/nvalchemi/training/_checkpoint.py
@@ -1159,8 +1159,8 @@ def _restore_checkpoint_into_strategy(
     map_location: str | torch.device | None,
 ) -> dict[str, Any]:
     """Load checkpoint state into an already-constructed strategy."""
-    from nvalchemi.training.strategy import TrainingStrategy
     from nvalchemi.training.runtime import move_to_devices
+    from nvalchemi.training.strategy import TrainingStrategy
 
     if not isinstance(strategy, TrainingStrategy):
         raise TypeError(
@@ -1757,7 +1757,7 @@ def load_checkpoint(
         restored_strategy = TrainingStrategy.from_checkpoint_dict(
             runtime_strategy_metadata,
             models=loaded_strategy_models,
-            hooks=hooks, # extra user-supplied runtime hooks
+            hooks=hooks,  # extra user-supplied runtime hooks
             training_fn=training_fn,
         )
 
@@ -1774,7 +1774,7 @@ def load_checkpoint(
         _run_validators(loaded, validators)
         return loaded
 
-    # Path 3: component-level loads: either the checkpoint has no strategy 
+    # Path 3: component-level loads: either the checkpoint has no strategy
     # metadata, or ``model_names`` requested a partial load from a strategy
     # checkpoint. Partial loads do not reconstruct strategy hooks.
     # Determine what models to load.

--- a/test/training/test_checkpoint.py
+++ b/test/training/test_checkpoint.py
@@ -1319,12 +1319,17 @@ class TestStrategyCheckpoint:
         assert restored.step_count == 4
         assert restored.global_step_count == 4
 
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
     def test_finetuning_checkpoint_loads_after_registration_patches(
-        self, tmp_path: Path
+        self, tmp_path: Path, device: str
     ) -> None:
         """Strategy restore applies topology patches before loading state dicts."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("No CUDA device available.")
+
         from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
+        torch_device = torch.device(device)
         torch.manual_seed(0)
         strategy = FineTuningStrategy(
             models=DemoModelWrapper(DemoModel(num_atom_types=20, hidden_dim=8)),
@@ -1343,7 +1348,7 @@ class TestStrategyCheckpoint:
             num_steps=1,
             training_fn=checkpoint_training_fn,
             loss_fn=EnergyMSELoss(),
-            devices=[torch.device("cpu")],
+            devices=[torch_device],
         )
 
         model = strategy.models["main"].model
@@ -1360,16 +1365,22 @@ class TestStrategyCheckpoint:
         state = torch.load(
             tmp_path / "models" / "main" / "checkpoints" / "0.pt",
             weights_only=True,
+            map_location=torch_device,
         )
         assert "model.aux_projection.weight" in state
+        if device == "cuda":
+            assert state["model.aux_projection.weight"].is_cuda
 
         # Confirm loading works fine.
-        restored = FineTuningStrategy.load_checkpoint(tmp_path, map_location="cpu")
+        restored = FineTuningStrategy.load_checkpoint(
+            tmp_path, map_location=torch_device
+        )
         restored_model = restored.models["main"].model
 
         assert isinstance(restored_model.aux_projection, nn.Linear)
         for name, parameter in restored_model.aux_projection.named_parameters():
-            assert torch.equal(parameter, saved_aux_projection[name])
+            assert parameter.device.type == torch_device.type
+            assert torch.equal(parameter.cpu(), saved_aux_projection[name].cpu())
 
     def test_loaded_strategy_reuses_restored_optimizer_state(
         self, tmp_path: Path

--- a/test/training/test_checkpoint.py
+++ b/test/training/test_checkpoint.py
@@ -1329,17 +1329,13 @@ class TestStrategyCheckpoint:
         strategy = FineTuningStrategy(
             models=DemoModelWrapper(DemoModel(num_atom_types=20, hidden_dim=8)),
             module_patches={
-                "main.model.projection": create_model_spec(
-                    nn.Linear,
-                    in_features=8,
-                    out_features=1,
-                ),
                 "main.model.aux_projection": create_model_spec(
                     nn.Linear,
                     in_features=8,
                     out_features=2,
                 ),
             },
+            trainable_patterns=("main.model.aux_projection.*",),
             optimizer_configs=OptimizerConfig(
                 optimizer_cls=torch.optim.Adam,
                 optimizer_kwargs={"lr": 1e-3},
@@ -1349,40 +1345,31 @@ class TestStrategyCheckpoint:
             loss_fn=EnergyMSELoss(),
             devices=[torch.device("cpu")],
         )
-        strategy.train_batch(_make_checkpoint_batch(seed=1))
 
         model = strategy.models["main"].model
-        saved_projection = {
-            name: parameter.detach().clone()
-            for name, parameter in model.projection.named_parameters()
-        }
+        # Mimic training by filling the projection weights.
+        with torch.no_grad():
+            model.aux_projection.weight.fill_(7.0)
+            model.aux_projection.bias.fill_(8.0)
         saved_aux_projection = {
             name: parameter.detach().clone()
             for name, parameter in model.aux_projection.named_parameters()
         }
+        # Save the checkpoint and verify the projection weights are present.
         save_checkpoint(tmp_path, strategy=strategy)
+        state = torch.load(
+            tmp_path / "models" / "main" / "checkpoints" / "0.pt",
+            weights_only=True,
+        )
+        assert "model.aux_projection.weight" in state
 
+        # Confirm loading works fine.
         restored = FineTuningStrategy.load_checkpoint(tmp_path, map_location="cpu")
         restored_model = restored.models["main"].model
 
-        assert isinstance(restored_model.projection, nn.Linear)
         assert isinstance(restored_model.aux_projection, nn.Linear)
-        for name, parameter in restored_model.projection.named_parameters():
-            assert torch.equal(parameter, saved_projection[name])
         for name, parameter in restored_model.aux_projection.named_parameters():
             assert torch.equal(parameter, saved_aux_projection[name])
-
-        optimizer_params = {
-            id(parameter)
-            for group in restored._optimizers[0].param_groups
-            for parameter in group["params"]
-        }
-        assert id(restored_model.projection.weight) in optimizer_params
-        assert id(restored_model.aux_projection.weight) in optimizer_params
-        assert any(
-            parameter is restored_model.projection.weight
-            for parameter in restored._optimizers[0].state
-        )
 
     def test_loaded_strategy_reuses_restored_optimizer_state(
         self, tmp_path: Path

--- a/test/training/test_checkpoint.py
+++ b/test/training/test_checkpoint.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.models.base import BaseModelMixin
-from nvalchemi.training import EnergyMSELoss, TrainingStage
+from nvalchemi.training import EnergyMSELoss, FineTuningStrategy, TrainingStage
 from nvalchemi.training._checkpoint import (
     CheckpointManifest,
     load_checkpoint,
@@ -1318,6 +1318,71 @@ class TestStrategyCheckpoint:
         )
         assert restored.step_count == 4
         assert restored.global_step_count == 4
+
+    def test_finetuning_checkpoint_loads_after_registration_patches(
+        self, tmp_path: Path
+    ) -> None:
+        """Strategy restore applies topology patches before loading state dicts."""
+        from nvalchemi.models.demo import DemoModel, DemoModelWrapper
+
+        torch.manual_seed(0)
+        strategy = FineTuningStrategy(
+            models=DemoModelWrapper(DemoModel(num_atom_types=20, hidden_dim=8)),
+            module_patches={
+                "main.model.projection": create_model_spec(
+                    nn.Linear,
+                    in_features=8,
+                    out_features=1,
+                ),
+                "main.model.aux_projection": create_model_spec(
+                    nn.Linear,
+                    in_features=8,
+                    out_features=2,
+                ),
+            },
+            optimizer_configs=OptimizerConfig(
+                optimizer_cls=torch.optim.Adam,
+                optimizer_kwargs={"lr": 1e-3},
+            ),
+            num_steps=1,
+            training_fn=checkpoint_training_fn,
+            loss_fn=EnergyMSELoss(),
+            devices=[torch.device("cpu")],
+        )
+        strategy.train_batch(_make_checkpoint_batch(seed=1))
+
+        model = strategy.models["main"].model
+        saved_projection = {
+            name: parameter.detach().clone()
+            for name, parameter in model.projection.named_parameters()
+        }
+        saved_aux_projection = {
+            name: parameter.detach().clone()
+            for name, parameter in model.aux_projection.named_parameters()
+        }
+        save_checkpoint(tmp_path, strategy=strategy)
+
+        restored = FineTuningStrategy.load_checkpoint(tmp_path, map_location="cpu")
+        restored_model = restored.models["main"].model
+
+        assert isinstance(restored_model.projection, nn.Linear)
+        assert isinstance(restored_model.aux_projection, nn.Linear)
+        for name, parameter in restored_model.projection.named_parameters():
+            assert torch.equal(parameter, saved_projection[name])
+        for name, parameter in restored_model.aux_projection.named_parameters():
+            assert torch.equal(parameter, saved_aux_projection[name])
+
+        optimizer_params = {
+            id(parameter)
+            for group in restored._optimizers[0].param_groups
+            for parameter in group["params"]
+        }
+        assert id(restored_model.projection.weight) in optimizer_params
+        assert id(restored_model.aux_projection.weight) in optimizer_params
+        assert any(
+            parameter is restored_model.projection.weight
+            for parameter in restored._optimizers[0].state
+        )
 
     def test_loaded_strategy_reuses_restored_optimizer_state(
         self, tmp_path: Path


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Fix full strategy checkpoint restore to address #132 so registration-time model architecture hooks are applied before model weights and optimizer state are restored. This preserves restart semantics for fine-tuning module patches and adapter-style hooks whose modules must exist before loading checkpoint state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Rebuild full strategy checkpoints by constructing unweighted models, registering strategy hooks, then restoring model, optimizer, scheduler, runtime, and hook state.
- Add a regression test covering `FineTuningStrategy.module_patches` that replace an existing module and add a new module before checkpoint state restore.

## Testing

Targeted tests run:

- `uv run pytest test/training/test_checkpoint.py` (passed, 62 tests)
- `uv run pytest test/training/test_finetune.py` (passed, 20 tests)
- `uv run ruff check nvalchemi/training/_checkpoint.py test/training/test_checkpoint.py` (passed)

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

When `model_names` is provided, loading remains component-level. For checkpoints whose model architecture comes from hooks, users should load the full strategy and extract the model.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
