### PR TITLE
chore: adding alias for __version__ per general practice

### DIFF
--- a/nvalchemi/__init__.py
+++ b/nvalchemi/__init__.py
@@ -16,3 +16,5 @@
 from nvalchemi._optional import OptionalDependency, OptionalDependencyError
 
 version = "0.2.0"
+# aliased as this is more common
+__version__ = version


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR adds the aliased version number so that the version number can be accessed via `nvalchemi.__version__`, which is a common practice.

This is in addition to the existing `nvalchemi.version` number check, in case people were using it already.

As a related tangent, the pattern

```python
from importlib.metadata import version

# this doesn't work
version("nvalchemi")
# this works
version("nvalchemi-toolkit")
```

Not sure if this is poor UX or not, but it did stump me for a second.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
