### PR TITLE
EMA MACE fix

### DIFF
--- a/docs/modules/training/hooks.rst
+++ b/docs/modules/training/hooks.rst
@@ -465,6 +465,13 @@ Access the averaged model weights via ``ema.averaged_model`` after training.
 
    averaged_model = ema.averaged_model
 
+``AveragedModel`` constructs its module with ``deepcopy``. If a model wrapper
+defines a callable ``modify_ema_methods()`` method, ``EMAHook`` calls it once on
+the copied module immediately after construction and before loading pending EMA
+checkpoint weights. This optional interface is intended for wrappers whose
+third-party models install runtime methods that ``deepcopy`` does not preserve;
+ordinary models do not need to implement it.
+
 Restartable update hooks
 ------------------------
 

--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -134,7 +134,7 @@ safe when called on a freshly copied model.
 ```{tip}
 {py:class}`~nvalchemi.models.mace.MACEWrapper` implements this
 interface to restore cuEquivariance's fused convolution method.
-Take a look at the the `MACEWrapper.modify_ema_methods` to see
+Take a look at the `MACEWrapper.modify_ema_methods` to see
 how this is done.
 ```
 

--- a/docs/userguide/models.md
+++ b/docs/userguide/models.md
@@ -111,6 +111,33 @@ Avoid saving only `ema.state_dict()` for MACE training restarts. Strategy
 checkpoints preserve the model reconstruction recipe, model weights, optimizer
 state, runtime counters, and checkpointable hook state together.
 
+### Repairing methods on EMA copies
+
+{py:class}`~nvalchemi.training.hooks.EMAHook` uses
+{py:class}`torch.optim.swa_utils.AveragedModel`, which deep-copies the live model
+when constructing its averaged copy. Most wrappers require no special handling.
+If a third-party model attaches runtime methods that do not survive
+`deepcopy`, its wrapper can optionally implement `modify_ema_methods()`:
+
+```python
+class MyPotentialWrapper(nn.Module, BaseModelMixin):
+    def modify_ema_methods(self) -> None:
+        """Restore runtime methods on this EMA model copy."""
+        my_method_to_patch_runtime_methods()
+```
+
+The hook calls this method once on the copied wrapper immediately after EMA
+construction and before applying any pending EMA checkpoint weights. The method
+must modify only `self`, must not change parameters or buffers, and should be
+safe when called on a freshly copied model.
+
+```{tip}
+{py:class}`~nvalchemi.models.mace.MACEWrapper` implements this
+interface to restore cuEquivariance's fused convolution method.
+Take a look at the the `MACEWrapper.modify_ema_methods` to see
+how this is done.
+```
+
 ### Using UMA (fairchem-core)
 
 UMA (Universal Models for Atoms) is a multi-task foundation model: one

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -869,6 +869,23 @@ class MACEWrapper(nn.Module, BaseModelMixin):
     # Forward pass
     # ------------------------------------------------------------------
 
+    def modify_ema_methods(self) -> None:
+        """Restore cuEquivariance methods discarded by EMA model copying.
+
+        ``torch.optim.swa_utils.AveragedModel`` deep-copies its source model.
+        cuEquivariance fused convolution modules attach their specialized
+        ``forward`` method at runtime, and that instance method is not retained
+        by the copy. Reapply MACE's fusion wrapper only when it is missing.
+        """
+        from mace.modules.wrapper_ops import with_cueq_conv_fusion
+
+        for interaction in getattr(self.model, "interactions", ()):
+            if not hasattr(interaction, "conv_fusion"):
+                continue
+            conv_tp = interaction.conv_tp
+            if "forward" not in vars(conv_tp):
+                with_cueq_conv_fusion(conv_tp)
+
     def forward(self, data: AtomicData | Batch, **kwargs: Any) -> ModelOutputs:
         """Run the MACE model for the active outputs.
 

--- a/nvalchemi/training/hooks/ema.py
+++ b/nvalchemi/training/hooks/ema.py
@@ -104,6 +104,12 @@ class EMAHook(BaseModel, TrainingUpdateHook):
     monkey-patched modules whose deepcopy/load path materializes registered
     tensors on CPU or in a default dtype usable without model-specific hooks.
 
+    .. note::
+       If the copied module defines ``modify_ema_methods()``, the hook calls it
+       once immediately after constructing the averaged model. Model wrappers
+       can use this optional interface to restore runtime methods discarded by
+       ``deepcopy``.
+
     Parameters
     ----------
     model_key : str, optional
@@ -228,6 +234,7 @@ class EMAHook(BaseModel, TrainingUpdateHook):
         return averaged
 
     def _ensure_initialized(self, ctx: TrainContext) -> None:
+        """Construct and repair the averaged model, then restore pending state."""
         if self._averaged_model is not None:
             return
         try:
@@ -240,6 +247,13 @@ class EMAHook(BaseModel, TrainingUpdateHook):
             ) from exc
 
         self._averaged_model = self._build_averaged_model(_unwrap_model(source))
+        # in the event there are user-defined methods that need
+        # to re-patch effects that are not included in the deepcopy
+        modify_ema_methods = getattr(
+            self._averaged_model.module, "modify_ema_methods", None
+        )
+        if callable(modify_ema_methods):
+            modify_ema_methods()
         if self._pending_averaged_state is not None:
             source_tensors = _module_tensors(_unwrap_model(source))
             self._averaged_model.load_state_dict(self._pending_averaged_state)

--- a/test/training/test_ema_hook.py
+++ b/test/training/test_ema_hook.py
@@ -229,6 +229,23 @@ class _Float64ResetOnDeepcopy(nn.Module):
         return x * self.weight + self.constant
 
 
+class _EMAMethodModifier(nn.Module):
+    """Record whether EMA invoked the optional post-copy model interface."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+        self.methods_modified = False
+
+    def modify_ema_methods(self) -> None:
+        """Mark the copied model as repaired."""
+        self.methods_modified = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the test parameter."""
+        return x * self.weight
+
+
 def _cpu_averaged_state(state: dict[str, Any]) -> dict[str, Any]:
     averaged_state = {
         key: value.cpu() if torch.is_tensor(value) else value
@@ -305,6 +322,16 @@ class TestEMAHookBuildOverride:
         # A fresh deepcopy: distinct object, weights mirrored from source.
         assert averaged.module is not source
         assert _params_equal(averaged.module, source)
+
+    def test_calls_optional_model_method_modifier_after_copy(self) -> None:
+        source = _EMAMethodModifier()
+        hook = EMAHook(model_key="main", decay=0.5)
+
+        hook(_make_ctx({"main": source}, step_count=0), TrainingStage.SETUP)
+
+        averaged = hook.get_averaged_model().module
+        assert averaged.methods_modified is True
+        assert source.methods_modified is False
 
     def test_override_adopts_prebuilt_without_deepcopy(self) -> None:
         source = _make_linear(seed=0)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR fixes the issue where a `deepcopy` applied by the `EMAHook` does not preserve monkey patches from cuEquivariance.

The design here was to expose an interface to wrapper models that may (hopefully not) apply the same patching model, to allow them to do post-copy patch to address any "last minute issues". Wrappers just need to implement a `modify_ema_methods` function, which will then get called during the rebuild process.

This fixes a regression to one of the unit tests that only run on `slow` mode, which didn't get picked up in the CI testing.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
