### PR TITLE
Aimnet ewald example fix

### DIFF
--- a/examples/advanced/08_aimnet2_ewald_pipeline.py
+++ b/examples/advanced/08_aimnet2_ewald_pipeline.py
@@ -198,8 +198,8 @@ pipe = PipelineModelWrapper(
             use_autograd=True,
         ),
     ]
-)
-pipe.set_config("active_outputs", {"energy", "forces", "stress", "charge"})
+).eval()
+pipe.set_config("active_outputs", {"energy", "forces", "stress", "charges"})
 print(f"\nPipeline: {[type(m).__name__ for m in pipe._models]}")
 print(f"  Output Capabilities: {sorted(pipe.model_config.outputs)}")
 print(f"  Active Outputs: {sorted(pipe.model_config.active_outputs)}")

--- a/examples/advanced/08_aimnet2_ewald_pipeline.py
+++ b/examples/advanced/08_aimnet2_ewald_pipeline.py
@@ -16,7 +16,7 @@
 AIMNet2 + Ewald Pipeline Geometry Optimization
 ===============================================
 
-This example demonstrates the **autograd pipeline** — the most powerful
+This example demonstrates the **autograd pipeline** — a powerful
 composition pattern in nvalchemi — by combining a machine-learning
 potential (AIMNet2) with a long-range electrostatics model (Ewald
 summation) for geometry optimization of water clusters.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR fixes two issues with the AIMNet + Ewald example:

- Not putting the pipeline in `eval` mode, which by default has models in training mode and causes an issue by attempting to backprop twice through `torch.compile`
-  Fixed a typo with the input parameter names (`charges`, not `charge`)

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
