### PR TITLE
Dist pipeline example fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@
 - **Distributed dynamics lifecycle** — keep per-system integrator state aligned
   when pipeline receives and graduates systems, clear reusable communication
   buffers before every send without shrinking their segmented capacity, and run
-  fixed-duration distributed MD stages with explicit per-system step budgets.
+  distributed stages with explicit per-system step budgets and optional early
+  convergence.
 - **Zarr dataloader custom fields** — validated `Dataset` batch paths now
   preserve reader field-level metadata so custom atom-, edge-, and
   system-level tensors survive batching like the `skip_validation` path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@
 
 ### Fixed
 
+- **Distributed dynamics lifecycle** — keep per-system integrator state aligned
+  when pipeline receives and graduates systems, clear reusable communication
+  buffers before every send without shrinking their segmented capacity, and run
+  fixed-duration distributed MD stages with explicit per-system step budgets.
 - **Zarr dataloader custom fields** — validated `Dataset` batch paths now
   preserve reader field-level metadata so custom atom-, edge-, and
   system-level tensors survive batching like the `skip_validation` path.

--- a/docs/modules/dynamics/distributed_pipeline.rst
+++ b/docs/modules/dynamics/distributed_pipeline.rst
@@ -119,6 +119,8 @@ The context manager handles:
    convergence-driven stages. For a fixed-duration stage, wrap the dynamics
    in a single-sub-stage :class:`~nvalchemi.dynamics.FusedStage`; its
    per-system step counter graduates each system after the configured budget.
+   Combining ``n_steps`` with a convergence criterion on the inner dynamics
+   graduates each system when either condition is reached.
 
 **Launching with** ``torchrun``
 

--- a/docs/modules/dynamics/distributed_pipeline.rst
+++ b/docs/modules/dynamics/distributed_pipeline.rst
@@ -111,6 +111,15 @@ The context manager handles:
    pipeline.run()      # loop until all stages report done
    pipeline.cleanup()
 
+.. warning::
+
+   A plain :class:`~nvalchemi.dynamics.BaseDynamics` stage is advanced with
+   ``step()`` inside a distributed pipeline, so its ``n_steps`` constructor
+   argument does not graduate systems. Use a convergence criterion for
+   convergence-driven stages. For a fixed-duration stage, wrap the dynamics
+   in a single-sub-stage :class:`~nvalchemi.dynamics.FusedStage`; its
+   per-system step counter graduates each system after the configured budget.
+
 **Launching with** ``torchrun``
 
 .. code-block:: bash

--- a/examples/distributed/01_distributed_pipeline.py
+++ b/examples/distributed/01_distributed_pipeline.py
@@ -41,9 +41,10 @@ running in parallel across 4 GPUs using
    }
 
 Each FIRE rank draws molecules from a dataset, optimises them until
-convergence, and sends them to the paired Langevin rank for 20 steps of
-short MD production.  A :class:`~nvalchemi.dynamics.hooks.SnapshotHook`
-on the Langevin ranks writes the trajectories to a
+convergence or a 50-step limit, and sends them to the paired Langevin rank
+for 20 steps of short MD production. A
+:class:`~nvalchemi.dynamics.hooks.SnapshotHook` on the Langevin ranks writes
+the trajectories to a
 :class:`~nvalchemi.dynamics.HostMemory` sink.
 
 .. note::
@@ -184,11 +185,12 @@ def build_dataset() -> list[AtomicData]:
 # with each other.
 
 
-def make_fire(model: DemoModelWrapper, rank: int, **kwargs) -> FIRE:
-    """Create a FIRE optimiser stage."""
-    return FIRE(
+def make_fire(model: DemoModelWrapper, rank: int, **kwargs) -> FusedStage:
+    """Create a convergence- or step-limited FIRE optimiser stage."""
+    dynamics = FIRE(
         model=model,
         dt=1.0,
+        n_steps=50,
         convergence_hook=ConvergenceHook(
             criteria=[
                 {
@@ -199,8 +201,8 @@ def make_fire(model: DemoModelWrapper, rank: int, **kwargs) -> FIRE:
                 }
             ],
         ),
-        **kwargs,
     )
+    return FusedStage(sub_stages=[(0, dynamics)], **kwargs)
 
 
 def make_langevin(

--- a/examples/distributed/01_distributed_pipeline.py
+++ b/examples/distributed/01_distributed_pipeline.py
@@ -41,9 +41,9 @@ running in parallel across 4 GPUs using
    }
 
 Each FIRE rank draws molecules from a dataset, optimises them until
-convergence, and sends them to the paired Langevin rank for short MD
-production.  A :class:`~nvalchemi.dynamics.hooks.ConvergedSnapshotHook`
-on the Langevin ranks writes completed trajectories to a
+convergence, and sends them to the paired Langevin rank for 20 steps of
+short MD production.  A :class:`~nvalchemi.dynamics.hooks.SnapshotHook`
+on the Langevin ranks writes the trajectories to a
 :class:`~nvalchemi.dynamics.HostMemory` sink.
 
 .. note::
@@ -70,13 +70,13 @@ from nvalchemi.dynamics import (
     FIRE,
     ConvergenceHook,
     DistributedPipeline,
+    FusedStage,
     HostMemory,
     NVTLangevin,
     SizeAwareSampler,
 )
-from nvalchemi.dynamics.base import BufferConfig, DynamicsStage
-from nvalchemi.dynamics.hooks import ConvergedSnapshotHook
-from nvalchemi.hooks import DynamicsContext
+from nvalchemi.dynamics.base import BufferConfig
+from nvalchemi.dynamics.hooks import SnapshotHook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
 
 logging.basicConfig(level=logging.INFO)
@@ -119,33 +119,6 @@ class InMemoryDataset:
         """Get the metadata associated with idx"""
         d = self._data[idx]
         return d.num_nodes, d.num_edges
-
-
-class DownstreamDoneHook:
-    """Set ``stage.done = True`` after *patience* consecutive idle steps.
-
-    Downstream (non-inflight) stages never set ``done`` on their own.
-    This hook counts consecutive steps where the batch is empty (no
-    graphs to integrate) and marks the stage as finished once the
-    patience limit is reached.
-
-    The dispatching dynamics engine is available as ``ctx.workflow``.
-    """
-
-    stage = DynamicsStage.AFTER_STEP
-    frequency = 1
-
-    def __init__(self, patience: int = 5) -> None:
-        self.patience = patience
-        self._idle_steps = 0
-
-    def __call__(self, ctx: DynamicsContext, stage_: DynamicsStage) -> None:
-        if ctx.batch.num_graphs == 0:
-            self._idle_steps += 1
-        else:
-            self._idle_steps = 0
-        if self._idle_steps >= self.patience and ctx.workflow is not None:
-            ctx.workflow.done = True
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +189,6 @@ def make_fire(model: DemoModelWrapper, rank: int, **kwargs) -> FIRE:
     return FIRE(
         model=model,
         dt=1.0,
-        n_steps=50,
         convergence_hook=ConvergenceHook(
             criteria=[
                 {
@@ -236,32 +208,17 @@ def make_langevin(
     sink: HostMemory,
     rank: int,
     **kwargs,
-) -> NVTLangevin:
-    """Create an NVTLangevin MD stage with a snapshot hook."""
-    done_hook = DownstreamDoneHook(patience=10)
-    stage = NVTLangevin(
+) -> FusedStage:
+    """Create a fixed-duration NVTLangevin stage with trajectory snapshots."""
+    dynamics = NVTLangevin(
         model=model,
         dt=0.5,
         temperature=300.0,
         friction=0.01,
         n_steps=20,
-        hooks=[
-            ConvergedSnapshotHook(sink=sink, frequency=1),
-            done_hook,
-        ],
-        convergence_hook=ConvergenceHook(
-            criteria=[
-                {
-                    "key": "forces",
-                    "threshold": 0.01,
-                    "reduce_op": "norm",
-                    "reduce_dims": -1,
-                }
-            ],
-        ),
-        **kwargs,
+        hooks=[SnapshotHook(sink=sink, frequency=1)],
     )
-    return stage
+    return FusedStage(sub_stages=[(0, dynamics)], **kwargs)
 
 
 # %%
@@ -272,10 +229,9 @@ def make_langevin(
 # (``dist.init_process_group``) and assigns each rank its GPU device.
 # On ``__exit__`` it tears down the process group gracefully.
 #
-# ``pipeline.run()`` blocks until the local stage signals completion
-# (``dynamics.done = True``).  Upstream ranks finish when their sampler
-# is exhausted; downstream ranks finish via ``DownstreamDoneHook`` after
-# a configurable number of idle steps with no incoming systems.
+# ``pipeline.run()`` blocks until every stage signals completion. Upstream
+# ranks finish when their sampler is exhausted. Downstream ranks finish after
+# the upstream rank is done and all fixed-duration MD work has drained.
 
 
 def main() -> None:
@@ -364,12 +320,19 @@ def main() -> None:
     pipeline = DistributedPipeline(stages=stages, backend=backend, debug_mode=True)
     with pipeline:
         pipeline.run()
-
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank == 1:
-        logger.info(f"Rank 1 sink collected {len(sink_a)} samples")
-    elif rank == 3:
-        logger.info(f"Rank 3 sink collected {len(sink_b)} samples")
+        rank = dist.get_rank()
+        if rank == 1:
+            expected_frames = len(dataset_a) * 20
+            assert len(sink_a) == expected_frames, (
+                f"rank 1 collected {len(sink_a)} of {expected_frames} frames"
+            )
+            logger.info(f"Rank 1 sink collected {len(sink_a)} trajectory frames")
+        elif rank == 3:
+            expected_frames = len(dataset_b) * 20
+            assert len(sink_b) == expected_frames, (
+                f"rank 3 collected {len(sink_b)} of {expected_frames} frames"
+            )
+            logger.info(f"Rank 3 sink collected {len(sink_b)} trajectory frames")
 
 
 if __name__ == "__main__":

--- a/nvalchemi/data/level_storage.py
+++ b/nvalchemi/data/level_storage.py
@@ -1895,8 +1895,9 @@ class SegmentedLevelStorage(BaseLevelStorage):
             )
         if new_num_dest is not None:
             new_n = int(new_num_dest.item())
-            object.__setattr__(self, "_batch_ptr", dest_batch_ptr[: new_n + 1].clone())
-            self.segment_lengths = self._batch_ptr[1:] - self._batch_ptr[:-1]
+            self.segment_lengths = (
+                dest_batch_ptr[1 : new_n + 1] - dest_batch_ptr[:new_n]
+            )
             object.__setattr__(self, "_batch_ptr_np", None)
             if hasattr(self, "_num_segments"):
                 object.__delattr__(self, "_num_segments")

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -49,6 +49,7 @@ execution without needing explicit multiple inheritance.
 from __future__ import annotations
 
 import sys
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from enum import Enum
@@ -809,47 +810,38 @@ class _CommunicationMixin:
         if incoming_batch.num_graphs == 0:
             return
 
-        if self.active_batch is None:
-            if incoming_batch.num_graphs <= self.max_batch_size:
-                # reform the batch without padding
-                self.active_batch = Batch.from_data_list(
-                    incoming_batch.to_data_list(), device=incoming_batch.device
-                )
-            else:
-                # slice out samples that will fit in the active batch
-                # and move the rest to overflow
-                data_list = incoming_batch.to_data_list()
-                fit = data_list[: self.max_batch_size]
-                overflow = data_list[self.max_batch_size :]
-                self.active_batch = Batch.from_data_list(
-                    fit, device=incoming_batch.device
-                )
-                self._overflow_to_sinks(
-                    Batch.from_data_list(overflow, device=incoming_batch.device)
-                )
-            return
+        ensure_bookkeeping = getattr(self, "_ensure_bookkeeping_fields", None)
+        if callable(ensure_bookkeeping):
+            ensure_bookkeeping(incoming_batch)
 
+        n_existing = self.active_batch_size
         room = self.room_in_active_batch
         if room <= 0:
             self._overflow_to_sinks(incoming_batch)
             return
 
         data_list = incoming_batch.to_data_list()
-        if len(data_list) <= room:
-            existing = self.active_batch.to_data_list()
-            self.active_batch = Batch.from_data_list(
-                existing + data_list, device=incoming_batch.device
-            )
+        admitted = data_list[:room]
+        overflow = data_list[room:]
+        if self.active_batch is None:
+            combined = admitted
         else:
-            fit = data_list[:room]
-            overflow = data_list[room:]
-            existing = self.active_batch.to_data_list()
-            self.active_batch = Batch.from_data_list(
-                existing + fit, device=incoming_batch.device
-            )
+            combined = self.active_batch.to_data_list() + admitted
+        self.active_batch = Batch.from_data_list(combined, device=incoming_batch.device)
+
+        if overflow:
             self._overflow_to_sinks(
                 Batch.from_data_list(overflow, device=incoming_batch.device)
             )
+
+        # Received graphs extend the active-batch layout. Preserve state for
+        # resident graphs and append freshly initialized state for arrivals.
+        sync_state = getattr(self, "_sync_state_to_batch", None)
+        if callable(sync_state):
+            existing_indices = torch.arange(
+                n_existing, dtype=torch.long, device=self.active_batch.device
+            )
+            sync_state(existing_indices, len(admitted), self.active_batch)
 
     def _recv_to_batch(self, incoming: Batch) -> None:
         """Stage incoming data through the recv buffer into the active batch.
@@ -1178,6 +1170,14 @@ class _CommunicationMixin:
             Typically obtained from ``BaseDynamics._check_convergence()``.
             If ``None``, no samples are graduated.
         """
+        if self.next_rank is not None:
+            # The send buffer is reused every iteration. A fully asynchronous
+            # send must finish before its storage is cleared and repopulated.
+            if self._pending_send_handle is not None:
+                self._pending_send_handle.wait()
+                self._pending_send_handle = None
+            self.send_buffer.zero()
+
         has_converged = converged_indices is not None and converged_indices.numel() > 0
 
         if has_converged:
@@ -3654,6 +3654,19 @@ class DistributedPipeline:
         for stage in self.stages.values():
             stage.debug_mode = self.debug_mode
 
+        local_stage = self.local_stage
+        local_n_steps = getattr(local_stage, "n_steps", None)
+        if local_n_steps is not None and not isinstance(local_stage, FusedStage):
+            warnings.warn(
+                f"{type(local_stage).__name__}(n_steps={local_n_steps}) is a "
+                "plain DistributedPipeline stage. Its n_steps value is used by "
+                "run(), but pipeline execution calls step() and graduates systems "
+                "only through convergence. Wrap fixed-duration stages in a "
+                "FusedStage to apply a per-system step budget.",
+                UserWarning,
+                stacklevel=2,
+            )
+
     def _setup_grouped(self) -> None:
         """Wire a 2-D ``(pipeline, domain)`` pipeline: each rank runs the one stage
         for its pipeline index (a :class:`DomainParallel` over its domain sub-mesh),
@@ -3988,7 +4001,7 @@ class DistributedPipeline:
                         rank,
                         stage.next_rank,
                     )
-                stage.send_buffer.isend(dst=stage.next_rank).wait()
+                stage._poststep_sync_buffers(None)
         else:
             n_graphs = stage.active_batch.num_graphs if stage.active_batch else 0
             if self.debug_mode:

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -924,8 +924,22 @@ class _CommunicationMixin:
         if self.send_buffer is None:
             raise RuntimeError("No send buffer to write to.")
 
-        self.send_buffer.put(self.active_batch, mask=mask)
-        self.active_batch = self.active_batch.trim(copied_mask=mask)
+        previous_batch = self.active_batch
+        remaining_indices = torch.where(~mask)[0]
+        self.send_buffer.put(previous_batch, mask=mask)
+        self.active_batch = previous_batch.trim(copied_mask=mask)
+
+        # Graph-indexed metadata and integrator state refer to the old batch
+        # layout. Keep only state for retained graphs and prevent the next hook
+        # context from applying stale convergence indices to the smaller batch.
+        sync_state = getattr(self, "_sync_state_to_batch", None)
+        if callable(sync_state):
+            template = (
+                self.active_batch if self.active_batch is not None else previous_batch
+            )
+            sync_state(remaining_indices, 0, template)
+        if hasattr(self, "_last_converged"):
+            self._last_converged = None
 
     def _drain_sinks_to_batch(self) -> None:
         """Pull samples from overflow sinks into the active batch.
@@ -1106,13 +1120,26 @@ class _CommunicationMixin:
         converged_indices : torch.Tensor
             Integer indices of converged samples.
         """
-        graduated = self.active_batch.index_select(converged_indices)
-        all_indices = set(range(self.active_batch.num_graphs))
+        previous_batch = self.active_batch
+        graduated = previous_batch.index_select(converged_indices)
+        all_indices = set(range(previous_batch.num_graphs))
         remaining = sorted(all_indices - set(converged_indices.tolist()))
         if remaining:
-            self.active_batch = self.active_batch.index_select(remaining)
+            self.active_batch = previous_batch.index_select(remaining)
         else:
             self.active_batch = None
+
+        sync_state = getattr(self, "_sync_state_to_batch", None)
+        if callable(sync_state):
+            remaining_indices = torch.tensor(
+                remaining, dtype=torch.long, device=previous_batch.device
+            )
+            template = (
+                self.active_batch if self.active_batch is not None else previous_batch
+            )
+            sync_state(remaining_indices, 0, template)
+        if hasattr(self, "_last_converged"):
+            self._last_converged = None
         if self.debug_mode:
             logger.debug(
                 "[rank {}] final stage, {} converged graphs removed",
@@ -1631,11 +1658,11 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         n_new: int,
         template_batch: Batch,
     ) -> None:
-        """Synchronize ``self._state`` after an inflight batch refill.
+        """Synchronize ``self._state`` after active-batch membership changes.
 
-        Called by :meth:`_refill_check` after graduated systems have been
-        removed and replacement systems appended.  Removes state rows for
-        graduated systems and appends fresh default state for the new ones.
+        Called after graduated systems have been removed, with optional
+        replacement systems appended. Removes state rows for graduated systems
+        and appends fresh default state for the new ones.
 
         If this dynamics has no ``_state`` (e.g. :class:`DemoDynamics`),
         this method is a no-op.
@@ -2848,10 +2875,9 @@ class FusedStage(BaseDynamics):
         """Fan out state sync to all sub-stages.
 
         ``FusedStage`` itself holds no ``_state``; each sub-stage does.
-        This override delegates to every sub-stage so that inflight
-        batch refills (via :meth:`~BaseDynamics._refill_check`) keep
-        each sub-stage's ``_state`` aligned with the new batch
-        composition.
+        This override delegates to every sub-stage so that active-batch
+        membership changes keep each sub-stage's ``_state`` aligned with the
+        new batch composition.
 
         Parameters
         ----------

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -248,6 +248,29 @@ class TestBatchZero:
         assert batch.num_graphs == 0
         assert batch.system_capacity == 5
 
+    def test_batch_zero_preserves_capacity_after_smaller_put(self):
+        """A reused buffer accepts a larger payload after a smaller one."""
+        template = _minimal_atomic_data(2)
+        buffer = Batch.empty(
+            num_systems=4,
+            num_nodes=16,
+            num_edges=0,
+            template=template,
+        )
+        small = Batch.from_data_list([_minimal_atomic_data(2)])
+        larger = Batch.from_data_list(
+            [_minimal_atomic_data(2), _minimal_atomic_data(2)]
+        )
+
+        buffer.put(small, torch.ones(1, dtype=torch.bool))
+        assert buffer.num_graphs == 1
+
+        buffer.zero()
+        buffer.put(larger, torch.ones(2, dtype=torch.bool))
+
+        assert buffer.num_graphs == 2
+        assert buffer.num_nodes_list == [2, 2]
+
 
 # -----------------------------------------------------------------------------
 # Per-graph reconstruction

--- a/test/distributed/model/test_distributed_pipeline_multigpu.py
+++ b/test/distributed/model/test_distributed_pipeline_multigpu.py
@@ -314,7 +314,8 @@ def _md_autograd_pipeline_worker(rank: int, world_size: int) -> None:
     from nvalchemi.distributed.distributed_pipeline import DistributedPipelineModel
     from nvalchemi.distributed.partitioner import SpatialPartitioner
     from nvalchemi.distributed.sharded_batch import ShardedBatch
-    from nvalchemi.neighbors import compute_neighbors
+    from nvalchemi.dynamics.base import DynamicsStage
+    from nvalchemi.hooks import DynamicsContext
 
     dtype = torch.float64
     device = torch.device(f"cuda:{rank}")
@@ -331,7 +332,9 @@ def _md_autograd_pipeline_worker(rank: int, world_size: int) -> None:
         batch = Batch.from_data_list(
             [_md_make_data(an, positions, masses, cell, pbc, device, dtype)]
         )
-        compute_neighbors(batch, config=ref_pipe.model_config.neighbor_config)
+        neighbor_ctx = DynamicsContext(batch=batch, model=ref_pipe)
+        for hook in ref_pipe.make_neighbor_hooks():
+            hook(neighbor_ctx, DynamicsStage.BEFORE_COMPUTE)
         out = ref_pipe(batch)
         e_ref.copy_(out["energy"].sum().detach().view(1))
         f_ref.copy_(out["forces"].detach())

--- a/test/distributed/model/test_uma_gp_partition_multigpu.py
+++ b/test/distributed/model/test_uma_gp_partition_multigpu.py
@@ -177,6 +177,8 @@ def _worker(rank: int, world_size: int) -> None:
     reason="Need 2+ CUDA GPUs",
 )
 def test_uma_gp_partition_2ranks() -> None:
+    pytest.importorskip("fairchem.core", reason="fairchem-core not installed")
+
     w = int(os.environ.get("UMA_GP_WORLD", "2"))
     mp.spawn(_worker, args=(w,), nprocs=w)
 

--- a/test/dynamics/test_pipeline_stage.py
+++ b/test/dynamics/test_pipeline_stage.py
@@ -872,7 +872,7 @@ class TestPoststepNoConvergenceSend:
     """Test that _poststep_sync_buffers uses send_buffer when nothing converges."""
 
     def test_sends_buffer_when_no_convergence_and_next_rank(self) -> None:
-        """When nothing converges and next_rank is set, send the send_buffer."""
+        """When nothing converges, clear and send the empty send_buffer."""
         batch = _make_batch(num_graphs=3)
         stage = _CommunicationMixin(
             active_batch=batch,
@@ -887,6 +887,7 @@ class TestPoststepNoConvergenceSend:
 
         stage._poststep_sync_buffers(converged_indices=None)
 
+        mock_send_buffer.zero.assert_called_once()
         mock_send_buffer.isend.assert_called_once_with(dst=1)
         # Active batch should be unchanged (no samples graduated)
         assert stage.active_batch_size == 3
@@ -958,6 +959,28 @@ class TestPoststepNoConvergenceSend:
         stage._poststep_sync_buffers(converged_indices=None)
 
         assert stage._pending_send_handle is mock_handle
+
+    def test_fully_async_waits_before_reusing_send_buffer(self) -> None:
+        """A pending send completes before its buffer is cleared and reused."""
+        stage = _CommunicationMixin(
+            active_batch=_make_batch(num_graphs=3),
+            next_rank=1,
+            comm_mode="fully_async",
+            buffer_config=_DEFAULT_CFG,
+        )
+        prior_handle = Mock()
+        next_handle = Mock()
+        send_buffer = Mock()
+        send_buffer.isend.return_value = next_handle
+        stage.send_buffer = send_buffer
+        stage._pending_send_handle = prior_handle
+
+        stage._poststep_sync_buffers(converged_indices=None)
+
+        prior_handle.wait.assert_called_once()
+        send_buffer.zero.assert_called_once()
+        send_buffer.isend.assert_called_once_with(dst=1)
+        assert stage._pending_send_handle is next_handle
 
     def test_convergence_sends_send_buffer(self) -> None:
         """When converged_indices is provided, put into send_buffer and send it."""

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -1280,6 +1280,24 @@ class TestDistributedPipelineComposition:
         assert pipeline.stages[2].prior_rank == 1
         assert pipeline.stages[2].next_rank is None
 
+    def test_plain_stage_n_steps_warns_during_setup(self) -> None:
+        """A plain pipeline stage must not silently imply fixed-step graduation."""
+        cfg = BufferConfig(num_systems=2, num_nodes=10, num_edges=0)
+        first = BaseDynamics(
+            model=self.model,
+            n_steps=2,
+            buffer_config=cfg,
+            device_type="cpu",
+        )
+        second = BaseDynamics(
+            model=self.model,
+            buffer_config=cfg,
+            device_type="cpu",
+        )
+
+        with pytest.warns(UserWarning, match="plain DistributedPipeline stage"):
+            DistributedPipeline(stages={0: first, 1: second}).setup()
+
     def test_fused_in_multi_stage_pipeline(self) -> None:
         """(dyn1 + dyn2) | dyn3 | dyn4 works with FusedStage at rank 0."""
         dyn1 = BaseDynamics(model=self.model)

--- a/test/dynamics/test_state_management.py
+++ b/test/dynamics/test_state_management.py
@@ -23,6 +23,8 @@ Tests for BaseDynamics per-system _state batch lifecycle:
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 import torch
 
@@ -430,6 +432,56 @@ class TestStateInvariant:
         for _ in range(3):
             dyn.step(batch)
             assert dyn._state.num_graphs == batch.num_graphs == 3
+
+
+# ---------------------------------------------------------------------------
+# TestPipelineStateMutation
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStateMutation:
+    """Pipeline extraction must invalidate state tied to the old batch layout."""
+
+    @pytest.mark.parametrize("final_stage", [False, True], ids=["sender", "final"])
+    def test_partial_removal_is_safe_for_next_step(self, final_stage):
+        """Non-contiguous graduation keeps convergence and FIRE state aligned."""
+        from nvalchemi.dynamics.optimizers.fire import FIRE
+
+        dyn = FIRE(model=_make_model(), dt=0.1)
+        dyn.active_batch = _make_batch(4)
+        dyn.step(dyn.active_batch)
+
+        # Make state-row preservation observable and reproduce the example's
+        # partial convergence: old graph indices 0 and 3 leave the batch.
+        dyn._state.alpha.copy_(torch.tensor([0.1, 0.2, 0.3, 0.4]))
+        converged = torch.tensor([0, 3])
+        dyn._last_converged = converged
+
+        if final_stage:
+            dyn._remove_converged_final_stage(converged)
+        else:
+            dyn.send_buffer = Mock()
+            mask = torch.zeros(4, dtype=torch.bool)
+            mask[converged] = True
+            dyn._batch_to_buffer(mask)
+
+        assert dyn.active_batch is not None
+        assert dyn.active_batch.num_graphs == 2
+
+        # Build the next hook context before inspecting the repaired metadata.
+        # Before the fix this performs mask[[0, 3]] for a two-graph batch,
+        # reproducing the example's out-of-bounds indexing failure.
+        context = dyn._build_context(dyn.active_batch)
+        assert context.converged_mask is None
+
+        assert dyn._last_converged is None
+        assert dyn._state.num_graphs == 2
+        torch.testing.assert_close(dyn._state.alpha, torch.tensor([0.2, 0.3]))
+
+        # BEFORE_STEP builds a hook context before doing any integration.  This
+        # was the exact next-iteration crash when _last_converged still held 3.
+        dyn.step(dyn.active_batch)
+        assert dyn._state.num_graphs == dyn.active_batch.num_graphs
 
 
 # ---------------------------------------------------------------------------

--- a/test/dynamics/test_state_management.py
+++ b/test/dynamics/test_state_management.py
@@ -442,6 +442,37 @@ class TestStateInvariant:
 class TestPipelineStateMutation:
     """Pipeline extraction must invalidate state tied to the old batch layout."""
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_receive_then_partial_removal_keeps_nvt_state_aligned(self):
+        """Received systems get state before a non-contiguous graduation."""
+        from nvalchemi.dynamics.integrators.nvt_langevin import NVTLangevin
+
+        device = torch.device("cuda")
+        dyn = NVTLangevin(
+            model=_make_model().to(device),
+            dt=0.1,
+            temperature=300.0,
+            friction=0.1,
+        )
+        dyn.active_batch = _make_batch(2).to(device)
+        dyn.step(dyn.active_batch)
+        assert dyn._state.num_graphs == 2
+
+        dyn._buffer_to_batch(_make_batch(2, seed=10).to(device))
+        assert dyn.active_batch is not None
+        assert dyn.active_batch.num_graphs == 4
+        assert dyn._state.num_graphs == 4
+
+        converged = torch.tensor([0, 3], device=device)
+        dyn._remove_converged_final_stage(converged)
+        assert dyn.active_batch is not None
+        assert dyn.active_batch.num_graphs == 2
+        assert dyn._state.num_graphs == 2
+
+        dyn.step(dyn.active_batch)
+        torch.cuda.synchronize()
+        assert dyn._state.num_graphs == dyn.active_batch.num_graphs
+
     @pytest.mark.parametrize("final_stage", [False, True], ids=["sender", "final"])
     def test_partial_removal_is_safe_for_next_step(self, final_stage):
         """Non-contiguous graduation keeps convergence and FIRE state aligned."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

This PR makes some key fixes to the GPU dynamics synchronization code to make the 01 distributed example script functional again. I also omnibus'd some additional unit test fixes discovered whilst trying to fix this issue

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Per-system integrator state is now kept in lock-step when systems enter, leave, or graduate from a batch
- Communication buffer tensors are now safely cleared and reused without losing their capacity, which fixes an issue with stale data/invalid indexing (the core issue with the example failure)
- Semantics of the fixed duration stages now align with what they were initially intended in the example: the optimizer will run for 50 steps and samples will graduate to the next stage if the convergence criteria are met **or** if we reach the 50 steps.
- Added a warning to unwrapped dynamics stages in `DistributedPipeline` to inform users that FusedStages are relied on for enforcing the `n_step` counter
- Added `fairchem` optional guard to one of the unit tests that were missing it

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
