### PR TITLE
fix(DD): Refresh NPT halo geometry

### DIFF
--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -25,7 +25,9 @@ directly.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
 
 import torch
@@ -63,7 +65,9 @@ class ParticleHaloConfig:
     # Computed in __post_init__
     rank: int = field(init=False)
     neighbor_ranks: list[int] = field(init=False)
-    pbc_shifts: dict[tuple[int, int], list[torch.Tensor]] = field(init=False)
+    _pbc_images: dict[tuple[int, int], list[torch.Tensor]] = field(
+        init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         try:
@@ -74,20 +78,39 @@ class ParticleHaloConfig:
         self.neighbor_ranks = [
             r for r in self.partitioner.get_neighbor_ranks(self.rank) if r != self.rank
         ]
-        self.pbc_shifts = _compute_pbc_shift_vectors(self.partitioner)
+        self._pbc_images = _compute_pbc_image_vectors(self.partitioner)
+
+    @property
+    def pbc_shifts(
+        self,
+    ) -> Mapping[tuple[int, int], tuple[torch.Tensor, ...]]:
+        """Materialize a compatibility snapshot of current Cartesian shifts.
+
+        The returned mapping and its value sequences are immutable.
+        """
+        cell_matrix = self.partitioner.cell_matrix
+        shifts = {
+            key: tuple(
+                image.to(device=cell_matrix.device, dtype=cell_matrix.dtype)
+                @ cell_matrix
+                for image in images
+            )
+            for key, images in self._pbc_images.items()
+        }
+        return MappingProxyType(shifts)
 
 
-def _compute_pbc_shift_vectors(
+def _compute_pbc_image_vectors(
     partitioner: Any,  # SpatialPartitioner at runtime
 ) -> dict[tuple[int, int], list[torch.Tensor]]:
-    """Precompute PBC shift vectors for all neighbor rank pairs.
+    """Precompute cell-independent lattice images for neighbor rank pairs.
 
-    Returns ``{(sender, receiver): [shift_1, shift_2, ...]}`` where
-    each shift is a ``(3,)`` Cartesian vector. For a diagonal neighbor
-    crossing D periodic boundaries there are ``2^D - 1`` independent
-    shifts (all non-empty subsets of crossed dims).
+    Returns ``{(sender, receiver): [image_1, image_2, ...]}`` where each
+    ``(3,)`` image contains integer-valued fractional lattice coefficients.
+    For a diagonal neighbor crossing D periodic boundaries there are
+    ``2^D - 1`` independent images (all non-empty subsets of crossed dims).
     """
-    shifts: dict[tuple[int, int], list[torch.Tensor]] = {}
+    images: dict[tuple[int, int], list[torch.Tensor]] = {}
     cell_matrix = partitioner.cell_matrix
     pbc = partitioner.pbc
     grid = partitioner.rank_grid
@@ -98,38 +121,55 @@ def _compute_pbc_shift_vectors(
         for receiver_rank in partitioner.get_neighbor_ranks(sender_rank):
             receiver_coords = partitioner.rank_to_grid_coords(receiver_rank)
 
-            per_dim_shifts: list[torch.Tensor] = []
+            per_dim_images: list[torch.Tensor] = []
             for dim in range(3):
                 if not pbc[dim] or grid[dim] <= 1:
                     continue
-                dim_shift = torch.zeros(
+                dim_image = torch.zeros(
                     3, device=cell_matrix.device, dtype=cell_matrix.dtype
                 )
                 if sender_coords[dim] == grid[dim] - 1 and receiver_coords[dim] == 0:
-                    dim_shift = dim_shift - cell_matrix[dim, :]
+                    dim_image[dim] = -1
                 elif sender_coords[dim] == 0 and receiver_coords[dim] == grid[dim] - 1:
-                    dim_shift = dim_shift + cell_matrix[dim, :]
+                    dim_image[dim] = 1
                 else:
                     continue
-                per_dim_shifts.append(dim_shift)
+                per_dim_images.append(dim_image)
 
-            if not per_dim_shifts:
+            if not per_dim_images:
                 continue
 
-            n = len(per_dim_shifts)
-            combo_shifts: list[torch.Tensor] = []
+            n = len(per_dim_images)
+            combo_images: list[torch.Tensor] = []
             for mask in range(1, 1 << n):
                 combo = torch.zeros(
                     3, device=cell_matrix.device, dtype=cell_matrix.dtype
                 )
                 for bit in range(n):
                     if mask & (1 << bit):
-                        combo = combo + per_dim_shifts[bit]
-                combo_shifts.append(combo)
+                        combo = combo + per_dim_images[bit]
+                combo_images.append(combo)
 
-            shifts[(sender_rank, receiver_rank)] = combo_shifts
+            images[(sender_rank, receiver_rank)] = combo_images
 
-    return shifts
+    return images
+
+
+def _compute_pbc_shift_vectors(
+    partitioner: Any,  # SpatialPartitioner at runtime
+) -> dict[tuple[int, int], list[torch.Tensor]]:
+    """Compute Cartesian PBC shift vectors for all neighbor rank pairs.
+
+    Returns ``{(sender, receiver): [shift_1, shift_2, ...]}`` where
+    each shift is a ``(3,)`` Cartesian vector. For a diagonal neighbor
+    crossing D periodic boundaries there are ``2^D - 1`` independent
+    shifts (all non-empty subsets of crossed dims).
+    """
+    cell_matrix = partitioner.cell_matrix
+    return {
+        key: [image @ cell_matrix for image in images]
+        for key, images in _compute_pbc_image_vectors(partitioner).items()
+    }
 
 
 @dataclass

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -155,23 +155,6 @@ def _compute_pbc_image_vectors(
     return images
 
 
-def _compute_pbc_shift_vectors(
-    partitioner: Any,  # SpatialPartitioner at runtime
-) -> dict[tuple[int, int], list[torch.Tensor]]:
-    """Compute Cartesian PBC shift vectors for all neighbor rank pairs.
-
-    Returns ``{(sender, receiver): [shift_1, shift_2, ...]}`` where
-    each shift is a ``(3,)`` Cartesian vector. For a diagonal neighbor
-    crossing D periodic boundaries there are ``2^D - 1`` independent
-    shifts (all non-empty subsets of crossed dims).
-    """
-    cell_matrix = partitioner.cell_matrix
-    return {
-        key: [image @ cell_matrix for image in images]
-        for key, images in _compute_pbc_image_vectors(partitioner).items()
-    }
-
-
 @dataclass
 class GNNHaloMarkers:
     """Routing metadata for autograd-aware feature exchange on a halo layout.

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import torch
+from jaxtyping import Float
 
 __all__ = [
     "ParticleHaloConfig",
@@ -81,7 +82,7 @@ class ParticleHaloConfig:
     @property
     def pbc_shifts(
         self,
-    ) -> dict[tuple[int, int], list[torch.Tensor]]:
+    ) -> dict[tuple[int, int], list[Float[torch.Tensor, "3"]]]:
         """Materialize current Cartesian shifts from the cached lattice images."""
         cell_matrix = self.partitioner.cell_matrix
         return {
@@ -100,7 +101,7 @@ class ParticleHaloConfig:
 
 def _compute_pbc_image_vectors(
     partitioner: Any,  # SpatialPartitioner at runtime
-) -> dict[tuple[int, int], list[torch.Tensor]]:
+) -> dict[tuple[int, int], list[Float[torch.Tensor, "3"]]]:
     """Precompute cell-independent lattice images for neighbor rank pairs.
 
     Returns ``{(sender, receiver): [image_1, image_2, ...]}`` where each

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -85,11 +85,15 @@ class ParticleHaloConfig:
         """Materialize current Cartesian shifts from the cached lattice images."""
         cell_matrix = self.partitioner.cell_matrix
         return {
-            key: [
-                image.to(device=cell_matrix.device, dtype=cell_matrix.dtype)
-                @ cell_matrix
-                for image in images
-            ]
+            key: list(
+                (
+                    torch.stack(images).to(
+                        device=cell_matrix.device,
+                        dtype=cell_matrix.dtype,
+                    )
+                    @ cell_matrix
+                ).unbind(0)
+            )
             for key, images in self._pbc_images.items()
         }
 

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -25,9 +25,7 @@ directly.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import Any
 
 import torch
@@ -83,21 +81,17 @@ class ParticleHaloConfig:
     @property
     def pbc_shifts(
         self,
-    ) -> Mapping[tuple[int, int], tuple[torch.Tensor, ...]]:
-        """Materialize a compatibility snapshot of current Cartesian shifts.
-
-        The returned mapping and its value sequences are immutable.
-        """
+    ) -> dict[tuple[int, int], list[torch.Tensor]]:
+        """Materialize current Cartesian shifts from the cached lattice images."""
         cell_matrix = self.partitioner.cell_matrix
-        shifts = {
-            key: tuple(
+        return {
+            key: [
                 image.to(device=cell_matrix.device, dtype=cell_matrix.dtype)
                 @ cell_matrix
                 for image in images
-            )
+            ]
             for key, images in self._pbc_images.items()
         }
-        return MappingProxyType(shifts)
 
 
 def _compute_pbc_image_vectors(

--- a/nvalchemi/distributed/_core/particle_halo.py
+++ b/nvalchemi/distributed/_core/particle_halo.py
@@ -131,8 +131,8 @@ def _identify_ghosts_split(
 ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
     """Return ``(direct_mask, [(pbc_mask, cart_shift), ...])`` for one neighbor."""
     partitioner = config.partitioner
-    # Reuse the cached inverse; cell is fixed in NVT/NVE (see
-    # ``_ghost_width_fractional``).
+    # Reuse the inverse that ``SpatialPartitioner.update_cell`` refreshes
+    # whenever an NPT/NPH barostat changes the cell.
     inv_cell = partitioner._inv_cell.to(device=positions.device, dtype=positions.dtype)
 
     # cart = frac @ cell_matrix (rows of cell_matrix = lattice vectors a, b, c),
@@ -158,11 +158,13 @@ def _identify_ghosts_split(
     already_selected = direct_mask.clone()
     pbc_list: list[tuple[torch.Tensor, torch.Tensor]] = []
     shift_key = (config.rank, neighbor_rank)
-    if shift_key in config.pbc_shifts:
-        for cart_shift in config.pbc_shifts[shift_key]:
-            cart_shift = cart_shift.to(device=positions.device, dtype=positions.dtype)
-            # Same transpose fix as above: ``frac = cart @ inv(cell)``.
-            frac_shift = cart_shift @ inv_cell
+    if shift_key in config._pbc_images:
+        cell_matrix = partitioner.cell_matrix.to(
+            device=positions.device, dtype=positions.dtype
+        )
+        for frac_shift in config._pbc_images[shift_key]:
+            frac_shift = frac_shift.to(device=positions.device, dtype=positions.dtype)
+            cart_shift = frac_shift @ cell_matrix
             frac_pos_shifted = frac_pos + frac_shift
             mask = _check_halo_region(frac_pos_shifted, frac_lo, frac_hi, gw_frac)
             mask = mask & ~already_selected

--- a/nvalchemi/distributed/particle_halo.py
+++ b/nvalchemi/distributed/particle_halo.py
@@ -103,6 +103,12 @@ def halo_exchange(
 
     device = padded_pos.device
     n_padded = padded_pos.shape[0]
+    cell = sharded.cell
+    if cell is not None and cell.ndim == 2:
+        cell = cell.unsqueeze(0)
+    pbc = sharded.pbc
+    if pbc is not None and pbc.ndim == 1:
+        pbc = pbc.unsqueeze(0)
 
     # Every per-atom field scattered onto the ShardedBatch rides through.
     # positions has already been padded (autograd-aware); forces is
@@ -131,12 +137,34 @@ def halo_exchange(
     # ``neighbor_matrix`` / ``num_neighbors`` / ``neighbor_list`` etc.)
     # untouched — that's the whole point of the in-place path.
     existing = sharded.padded_batch
+    system = existing._system_group if existing is not None else None
+
+    def _system_field_compatible(name: str, current: torch.Tensor | None) -> bool:
+        if current is None:
+            return system is None or name not in system
+        if system is None or name not in system:
+            return False
+        cached = system[name]
+        return (
+            cached.shape == current.shape
+            and cached.dtype == current.dtype
+            and cached.device == current.device
+        )
+
     if (
         existing is not None
         and sharded.halo_meta is not None
         and sharded.halo_meta.n_owned == meta.n_owned
         and sharded.halo_meta.n_padded == meta.n_padded
+        and _system_field_compatible("cell", cell)
+        and _system_field_compatible("pbc", pbc)
     ):
+        with torch.no_grad():
+            if cell is not None:
+                system["cell"].copy_(cell)
+            if pbc is not None:
+                system["pbc"].copy_(pbc)
+
         atoms = existing._atoms_group
         for name, shard in atom_fields.items():
             if name == "forces" and "forces" in atoms:
@@ -157,14 +185,10 @@ def halo_exchange(
             padded_kwargs[required] = _build_padded_field(
                 required, atom_fields[required]
             )
-    if sharded.cell is not None:
-        padded_kwargs["cell"] = (
-            sharded.cell if sharded.cell.ndim == 3 else sharded.cell.unsqueeze(0)
-        )
-    if sharded.pbc is not None:
-        padded_kwargs["pbc"] = (
-            sharded.pbc if sharded.pbc.ndim == 2 else sharded.pbc.unsqueeze(0)
-        )
+    if cell is not None:
+        padded_kwargs["cell"] = cell
+    if pbc is not None:
+        padded_kwargs["pbc"] = pbc
 
     padded_data = AtomicData(**padded_kwargs)
     for name, shard in atom_fields.items():

--- a/nvalchemi/distributed/particle_halo.py
+++ b/nvalchemi/distributed/particle_halo.py
@@ -104,11 +104,7 @@ def halo_exchange(
     device = padded_pos.device
     n_padded = padded_pos.shape[0]
     cell = sharded.cell
-    if cell is not None and cell.ndim == 2:
-        cell = cell.unsqueeze(0)
     pbc = sharded.pbc
-    if pbc is not None and pbc.ndim == 1:
-        pbc = pbc.unsqueeze(0)
 
     # Every per-atom field scattered onto the ShardedBatch rides through.
     # positions has already been padded (autograd-aware); forces is
@@ -137,33 +133,16 @@ def halo_exchange(
     # ``neighbor_matrix`` / ``num_neighbors`` / ``neighbor_list`` etc.)
     # untouched — that's the whole point of the in-place path.
     existing = sharded.padded_batch
-    system = existing._system_group if existing is not None else None
-
-    def _system_field_compatible(name: str, current: torch.Tensor | None) -> bool:
-        if current is None:
-            return system is None or name not in system
-        if system is None or name not in system:
-            return False
-        cached = system[name]
-        return (
-            cached.shape == current.shape
-            and cached.dtype == current.dtype
-            and cached.device == current.device
-        )
-
     if (
         existing is not None
         and sharded.halo_meta is not None
         and sharded.halo_meta.n_owned == meta.n_owned
         and sharded.halo_meta.n_padded == meta.n_padded
-        and _system_field_compatible("cell", cell)
-        and _system_field_compatible("pbc", pbc)
     ):
+        system = existing._system_group
         with torch.no_grad():
-            if cell is not None:
-                system["cell"].copy_(cell)
-            if pbc is not None:
-                system["pbc"].copy_(pbc)
+            system["cell"].copy_(cell)
+            system["pbc"].copy_(pbc)
 
         atoms = existing._atoms_group
         for name, shard in atom_fields.items():
@@ -185,10 +164,8 @@ def halo_exchange(
             padded_kwargs[required] = _build_padded_field(
                 required, atom_fields[required]
             )
-    if cell is not None:
-        padded_kwargs["cell"] = cell
-    if pbc is not None:
-        padded_kwargs["pbc"] = pbc
+    padded_kwargs["cell"] = cell
+    padded_kwargs["pbc"] = pbc
 
     padded_data = AtomicData(**padded_kwargs)
     for name, shard in atom_fields.items():

--- a/test/distributed/_core/test_halo_primitives_roundtrip.py
+++ b/test/distributed/_core/test_halo_primitives_roundtrip.py
@@ -297,6 +297,66 @@ def _worker_halo_forward_reverse_roundtrip(
     )
 
 
+def _worker_pbc_halo_tracks_current_cell(rank: int, world_size: int) -> None:
+    """PBC images exchanged after a cell update use the new lattice vectors."""
+    assert world_size == 2
+    dtype = torch.float64
+    mesh = _MockMesh(rank, world_size)
+    pbc = torch.ones(3, dtype=torch.bool)
+    old_cell = torch.eye(3, dtype=dtype) * 10.0
+    domain_config = DomainConfig(cutoff=2.0, mesh=mesh)
+    partitioner = SpatialPartitioner(
+        config=domain_config,
+        cell_matrix=old_cell.unsqueeze(0),
+        pbc=pbc.unsqueeze(0),
+    )
+    halo_config = ParticleHaloConfig(
+        ghost_width=2.0,
+        partitioner=partitioner,
+        mesh=mesh,
+    )
+
+    split_dims = [dim for dim, ranks in enumerate(partitioner.rank_grid) if ranks > 1]
+    assert len(split_dims) == 1
+    split_dim = split_dims[0]
+
+    local_frac = torch.full((1, 3), 0.5, dtype=dtype)
+    local_frac[0, split_dim] = 0.02 if rank == 0 else 0.98
+    remote_frac = torch.full((1, 3), 0.5, dtype=dtype)
+    remote_frac[0, split_dim] = 0.98 if rank == 0 else 0.02
+    image_offset = torch.zeros((1, 3), dtype=dtype)
+    image_offset[0, split_dim] = -1.0 if rank == 0 else 1.0
+
+    # Establish that the original geometry produces the expected one-image
+    # layout before changing the partitioner's cell.
+    old_positions = local_frac @ old_cell
+    old_padded, old_meta = particle_halo_padding(old_positions, halo_config)
+    assert old_meta.n_owned == 1
+    assert old_meta.n_padded == 2
+    torch.testing.assert_close(
+        old_padded[1:],
+        (remote_frac + image_offset) @ old_cell,
+    )
+
+    # Change both the length and direction of the split-axis lattice vector.
+    # A cache of Cartesian shifts from ``old_cell`` maps the periodic image into
+    # the receiver's core and causes it to be omitted.  Deriving the image from
+    # the current cell yields the expected halo row.
+    new_cell = old_cell.clone()
+    new_cell[split_dim, split_dim] = 12.0
+    new_cell[split_dim, (split_dim + 1) % 3] = 1.5
+    partitioner.update_cell(new_cell)
+
+    new_positions = local_frac @ new_cell
+    new_padded, new_meta = particle_halo_padding(new_positions, halo_config)
+    assert new_meta.n_owned == 1
+    assert new_meta.n_padded == 2
+    torch.testing.assert_close(
+        new_padded[1:],
+        (remote_frac + image_offset) @ new_cell,
+    )
+
+
 # ======================================================================
 # Tests.
 # ======================================================================
@@ -389,3 +449,8 @@ class TestHaloForwardReverseRoundtrip:
             4,
             True,
         )
+
+
+def test_pbc_halo_tracks_current_cell_after_update() -> None:
+    """A long-lived halo config must not retain the partition-time PBC shift."""
+    _spawn(2, "29840", "_worker_pbc_halo_tracks_current_cell")

--- a/test/distributed/_core/test_particle_halo.py
+++ b/test/distributed/_core/test_particle_halo.py
@@ -30,7 +30,7 @@ import torch
 from nvalchemi.distributed._core.halo_types import (
     ParticleHaloConfig,
     ParticleHaloMetadata,
-    _compute_pbc_shift_vectors,
+    _compute_pbc_image_vectors,
 )
 from nvalchemi.distributed._core.particle_halo import (
     _check_halo_region,
@@ -88,35 +88,31 @@ def _make_halo_config(
 
 
 # ======================================================================
-# PBC shift vector tests
+# PBC image-vector tests
 # ======================================================================
 
 
-class TestComputePBCShiftVectors:
-    """Test precomputation of PBC shift vectors."""
+class TestComputePBCImageVectors:
+    """Test precomputation of cell-independent PBC image vectors."""
 
-    def test_shifts_exist_for_wrapping_pair(self):
+    def test_images_exist_for_wrapping_pair(self):
         part = _make_partitioner(world_size=2)
-        shifts = _compute_pbc_shift_vectors(part)
-        # With 2 ranks along one dim and PBC, there should be shifts.
-        assert len(shifts) > 0
+        images = _compute_pbc_image_vectors(part)
+        # With 2 ranks along one dim and PBC, there should be images.
+        assert len(images) > 0
 
-    def test_no_shifts_without_pbc(self):
+    def test_no_images_without_pbc(self):
         part = _make_partitioner(pbc=(False, False, False), world_size=2)
-        shifts = _compute_pbc_shift_vectors(part)
-        assert len(shifts) == 0
+        images = _compute_pbc_image_vectors(part)
+        assert len(images) == 0
 
-    def test_shift_magnitude_equals_box_length(self):
-        box = 30.0
-        part = _make_partitioner(box_length=box, world_size=2)
-        shifts = _compute_pbc_shift_vectors(part)
-        for (sender, receiver), shift_list in shifts.items():  # noqa: PERF102
-            for shift in shift_list:
-                # Each shift component should be 0 or ±box_length.
-                for d in range(3):
-                    assert shift[d].abs().item() == pytest.approx(0.0) or shift[
-                        d
-                    ].abs().item() == pytest.approx(box, abs=0.01)
+    def test_image_components_are_integer_lattice_offsets(self):
+        part = _make_partitioner(world_size=2)
+        images = _compute_pbc_image_vectors(part)
+        for image_list in images.values():
+            for image in image_list:
+                assert set(image.tolist()) <= {-1.0, 0.0, 1.0}
+                assert torch.count_nonzero(image) > 0
 
 
 # ======================================================================
@@ -316,16 +312,10 @@ class TestParticleHaloConfig:
         config.partitioner.update_cell(new_cell)
         new_shifts = config.pbc_shifts
 
-        expected = _compute_pbc_shift_vectors(config.partitioner)
-        assert new_shifts.keys() == expected.keys()
-        assert any(
-            not torch.equal(old_shift, new_shift)
-            for key, shifts in new_shifts.items()
-            for old_shift, new_shift in zip(old_shifts[key], shifts, strict=True)
-        )
+        assert new_shifts.keys() == old_shifts.keys()
         for key, shifts in new_shifts.items():
-            for shift, expected_shift in zip(shifts, expected[key], strict=True):
-                torch.testing.assert_close(shift, expected_shift)
+            for old_shift, new_shift in zip(old_shifts[key], shifts, strict=True):
+                torch.testing.assert_close(new_shift, old_shift * 1.2)
 
 
 # Multi-GPU tests live in test/distributed/test_multigpu.py

--- a/test/distributed/_core/test_particle_halo.py
+++ b/test/distributed/_core/test_particle_halo.py
@@ -21,6 +21,7 @@ exchange via indexed_all_to_all_v (skipped without multiple GPUs).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -299,7 +300,32 @@ class TestParticleHaloConfig:
 
     def test_computes_pbc_shifts(self):
         config = _make_halo_config(world_size=2)
-        assert isinstance(config.pbc_shifts, dict)
+        shifts = config.pbc_shifts
+        assert isinstance(shifts, Mapping)
+        key = next(iter(shifts))
+        with pytest.raises(TypeError):
+            shifts[key] = ()  # type: ignore[index]
+        with pytest.raises(AttributeError):
+            shifts[key].append(torch.zeros(3))  # type: ignore[attr-defined]
+
+    def test_pbc_shifts_follow_cell_updates(self):
+        config = _make_halo_config(world_size=2)
+        old_shifts = config.pbc_shifts
+
+        new_cell = config.partitioner.cell_matrix * 1.2
+        config.partitioner.update_cell(new_cell)
+        new_shifts = config.pbc_shifts
+
+        expected = _compute_pbc_shift_vectors(config.partitioner)
+        assert new_shifts.keys() == expected.keys()
+        assert any(
+            not torch.equal(old_shift, new_shift)
+            for key, shifts in new_shifts.items()
+            for old_shift, new_shift in zip(old_shifts[key], shifts, strict=True)
+        )
+        for key, shifts in new_shifts.items():
+            for shift, expected_shift in zip(shifts, expected[key], strict=True):
+                torch.testing.assert_close(shift, expected_shift)
 
 
 # Multi-GPU tests live in test/distributed/test_multigpu.py

--- a/test/distributed/_core/test_particle_halo.py
+++ b/test/distributed/_core/test_particle_halo.py
@@ -21,7 +21,6 @@ exchange via indexed_all_to_all_v (skipped without multiple GPUs).
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -297,12 +296,8 @@ class TestParticleHaloConfig:
     def test_computes_pbc_shifts(self):
         config = _make_halo_config(world_size=2)
         shifts = config.pbc_shifts
-        assert isinstance(shifts, Mapping)
-        key = next(iter(shifts))
-        with pytest.raises(TypeError):
-            shifts[key] = ()  # type: ignore[index]
-        with pytest.raises(AttributeError):
-            shifts[key].append(torch.zeros(3))  # type: ignore[attr-defined]
+        assert isinstance(shifts, dict)
+        assert all(isinstance(values, list) for values in shifts.values())
 
     def test_pbc_shifts_follow_cell_updates(self):
         config = _make_halo_config(world_size=2)

--- a/test/distributed/test_particle_halo_orchestration.py
+++ b/test/distributed/test_particle_halo_orchestration.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the chemistry-level particle-halo orchestration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+import nvalchemi.distributed.particle_halo as particle_halo_module
+from nvalchemi.distributed._core.halo_types import ParticleHaloMetadata
+
+
+class _LocalShard:
+    """Minimal shard stand-in used by :func:`halo_exchange`."""
+
+    def __init__(self, local: torch.Tensor) -> None:
+        self.local = local
+
+    def to_local(self) -> torch.Tensor:
+        return self.local
+
+
+def test_halo_exchange_reuse_refreshes_cell_and_pbc(monkeypatch: Any) -> None:
+    """A reused padded Batch must see the current system-level geometry.
+
+    NPT/NPH update the owned batch's cell without necessarily changing the
+    owned or halo atom counts.  That takes ``halo_exchange`` through its
+    shape-compatible reuse branch, where stale ``cell`` / ``pbc`` values would
+    otherwise survive from the first model call.
+    """
+    positions = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32)
+    fields = {
+        "positions": _LocalShard(positions),
+        "atomic_numbers": _LocalShard(torch.tensor([6, 8], dtype=torch.int64)),
+        "atomic_masses": _LocalShard(torch.tensor([12.0, 16.0])),
+    }
+    old_cell = torch.eye(3).unsqueeze(0) * 10.0
+    old_pbc = torch.tensor([[True, True, True]])
+    state = SimpleNamespace(
+        positions=fields["positions"],
+        cell=old_cell,
+        pbc=old_pbc,
+        padded_batch=None,
+        halo_meta=None,
+        atom_fields=lambda: dict(fields),
+    )
+
+    # Keep this test focused on Batch reuse rather than communication.  The
+    # low-level routing is covered by the multi-rank tests in
+    # ``_core/test_halo_primitives_roundtrip.py``.
+    def _identity_padding(
+        local_positions: torch.Tensor, _config: Any
+    ) -> tuple[torch.Tensor, ParticleHaloMetadata]:
+        n = local_positions.shape[0]
+        return local_positions, ParticleHaloMetadata(
+            n_owned=n,
+            n_padded=n,
+            send_indices=[],
+            send_sizes=[],
+            recv_sizes=[],
+        )
+
+    monkeypatch.setattr(
+        particle_halo_module, "particle_halo_padding", _identity_padding
+    )
+    monkeypatch.setattr(
+        particle_halo_module,
+        "pad_field",
+        lambda shard, _meta, _config: shard.to_local(),
+    )
+
+    particle_halo_module.halo_exchange(state, SimpleNamespace())
+    padded = state.padded_batch
+    assert padded is not None
+    torch.testing.assert_close(padded.cell, old_cell)
+    torch.testing.assert_close(padded.pbc, old_pbc)
+    cell_ptr = padded.cell.data_ptr()
+    pbc_ptr = padded.pbc.data_ptr()
+    padded.pbc.zero_()
+
+    # Include shear so the assertion checks the whole lattice matrix, not just
+    # a scalar box length.
+    new_cell = torch.tensor(
+        [[[10.5, 0.0, 0.0], [0.0, 11.0, 0.0], [1.25, 0.0, 12.0]]],
+    )
+    state.cell = new_cell
+
+    particle_halo_module.halo_exchange(state, SimpleNamespace())
+
+    # Prove that the shape-compatible reuse path ran, then check that it did
+    # not leave system metadata from the previous step behind.
+    assert state.padded_batch is padded
+    assert padded.cell.data_ptr() == cell_ptr
+    assert padded.pbc.data_ptr() == pbc_ptr
+    torch.testing.assert_close(padded.cell, new_cell)
+    torch.testing.assert_close(padded.pbc, old_pbc)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

During distributed NPT, the partitioner's cell was updated, but two reused
values could remain from an earlier step:

- The padded Batch kept its previous `cell` and `pbc`.
- Periodic halo translations remained Cartesian vectors calculated from the
  initial cell.

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- `nvalchemi/distributed/particle_halo.py` Updates cell and pbc when reusing a padded Batch.

- `nvalchemi/distributed/_core/halo_types.py` Stores periodic wrapping as lattice images and provides current Cartesian shifts.

- `nvalchemi/distributed/_core/particle_halo.py` Selects periodic ghosts using fractional images and translates them using the current cell.

- `test/distributed/test_particle_halo_orchestration.py` Tests reused padded-batch cell/PBC updates.

- `test/distributed/_core/test_particle_halo.py` Tests current-cell pbc_shifts and immutability.

- `test/distributed/_core/test_halo_primitives_roundtrip.py` Tests a real two-rank exchange after cell scaling and shear.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
