### PR TITLE
fix: reject undersized domain ghost widths

### DIFF
--- a/nvalchemi/distributed/config.py
+++ b/nvalchemi/distributed/config.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class StrategyKind(str, Enum):
@@ -79,6 +79,7 @@ class DomainConfig(BaseModel):
     ghost_width : float | None
         Width of the ghost (halo) region. When ``None``, the effective
         width defaults to ``cutoff + skin`` via :meth:`effective_ghost_width`.
+        An explicit value must be at least ``cutoff + skin``.
     mesh : DeviceMesh | None
         Optional ``torch.distributed.device_mesh.DeviceMesh`` describing the
         rank topology. ``None`` for single-rank runs.
@@ -135,6 +136,16 @@ class DomainConfig(BaseModel):
         if v is not None and any(d < 1 for d in v):
             raise ValueError(f"grid_dims entries must be >= 1, got {v}")
         return v
+
+    @model_validator(mode="after")
+    def _ghost_width_covers_cutoff_and_skin(self) -> DomainConfig:
+        required_width = self.cutoff + self.skin
+        if self.ghost_width is not None and self.ghost_width < required_width:
+            raise ValueError(
+                f"ghost_width ({self.ghost_width}) must be >= cutoff + skin "
+                f"({required_width})"
+            )
+        return self
 
     def effective_migration_hysteresis(self) -> float:
         """Migration-hysteresis margin (angstrom). Defaults to ``skin/2``.

--- a/test/distributed/test_config.py
+++ b/test/distributed/test_config.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from nvalchemi.distributed.config import DomainConfig, HookScope
 
 
@@ -53,6 +55,16 @@ class TestDomainConfig:
     def test_effective_ghost_width_explicit_overrides(self):
         cfg = DomainConfig(cutoff=5.0, skin=0.5, ghost_width=7.0)
         assert cfg.effective_ghost_width() == 7.0
+
+    def test_explicit_ghost_width_cannot_be_smaller_than_cutoff_plus_skin(self):
+        with pytest.raises(
+            ValueError, match=r"ghost_width \(5.0\) must be >= cutoff \+ skin \(5.5\)"
+        ):
+            DomainConfig(cutoff=5.0, skin=0.5, ghost_width=5.0)
+
+    def test_explicit_ghost_width_can_equal_cutoff_plus_skin(self):
+        cfg = DomainConfig(cutoff=5.0, skin=0.5, ghost_width=5.5)
+        assert cfg.effective_ghost_width() == 5.5
 
 
 class TestHookScope:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

An explicit `ghost_width` could be smaller than `cutoff + skin`. This can exclude atoms still required by the neighbor list and produce incorrect energies or forces.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Reject explicit `ghost_width < cutoff + skin`.
- Keep `ghost_width=None` defaulting to `cutoff + skin`.
- Allow exact equality.
- Add tests for rejected and valid boundary values.

- `nvalchemi/distributed/config.py`
- `test/distributed/test_config.py`

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
