### PR TITLE
fix(distributed): correct AIMNet2 stress reduction

### DIFF
--- a/nvalchemi/models/aimnet2.py
+++ b/nvalchemi/models/aimnet2.py
@@ -129,6 +129,7 @@ def _aimnet2_halo_spec() -> Any:
     )
     _AIMNET2_HALO_SPEC_CACHE = replace(
         SPEC_MPNN_HALO,
+        all_reduce_outputs=SPEC_MPNN_HALO.all_reduce_outputs | frozenset({"stress"}),
         distribution=replace(
             SPEC_MPNN_HALO.distribution,
             adapters=helpers,
@@ -143,6 +144,7 @@ def _aimnet2_halo_spec() -> Any:
             static_shapes=True,
             force_strategy=ForceStrategy.FRAMEWORK_FROM_GLOBAL_ENERGY,
             graph_padder=DenseBatchPadder(),
+            stress_via_strain=True,
         ),
     )
     return _AIMNET2_HALO_SPEC_CACHE

--- a/test/distributed/model/test_aimnet2_compile_recompile_gate.py
+++ b/test/distributed/model/test_aimnet2_compile_recompile_gate.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""AIMNet2 halo + ``torch.compile`` DD gate: force equivalence AND zero
+"""AIMNet2 halo + ``torch.compile`` DD gate: force/stress equivalence AND zero
 steady-state recompiles.
 
 AIMNet2's distributed halo path under ``compile_model=True`` is owned entirely
@@ -28,9 +28,10 @@ validator
 steady-state recompile count:
 
 * **Equivalence** (step 0, unjittered): an *eager*-DD reference vs the compiled
-  DD forward, on the same partition — each rank's owned forces must match. (A
-  single-GPU reference can't be used: a bare ``AIMNet2Wrapper(Batch)`` forward
-  needs aimnet's 2-D neighbor-mode layout that only the DD input path builds.)
+  DD forward, on the same partition — each rank's owned forces and the global
+  stress must match. (A single-GPU reference can't be used: a bare
+  ``AIMNet2Wrapper(Batch)`` forward needs aimnet's 2-D neighbor-mode layout that
+  only the DD input path builds.)
 * **Recompiles** (jittered MD loop): after warmup, the number of unique compiled
   graphs (``torch._dynamo.utils.counters["stats"]["unique_graphs"]``) must not
   grow — the dense fixed-shape caps must hold the graph stable across steps.
@@ -116,17 +117,14 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
     # only the DD input path builds. Same partition -> owned forces align. ----
     eager = AIMNet2Wrapper.from_checkpoint("aimnet2", device=device)
     eager.eval()
-    eager.model_config.active_outputs = {"energy", "forces"}
+    eager.model_config.active_outputs = {"energy", "forces", "stress"}
     cfg = DomainConfig(cutoff=float(eager._cutoff), skin=0.5, mesh=mesh)
     with DistributedModel(eager, cfg) as eager_model:
-        f_eager_owned = (
-            eager_model(ShardedBatch.from_batch(_batch(positions0), mesh, cfg, 0))[
-                "forces"
-            ]
-            .detach()
-            .float()
-            .cpu()
+        eager_out = eager_model(
+            ShardedBatch.from_batch(_batch(positions0), mesh, cfg, 0)
         )
+        f_eager_owned = eager_out["forces"].detach().float().cpu()
+        stress_eager = eager_out["stress"].detach().float().cpu()
     del eager, eager_model
 
     # ---- compiled DD model: the wrapper is eager (compile_model is the
@@ -134,7 +132,7 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
     # DistributedModel, which owns the compiled energy-autograd forward. ----
     wrapper = AIMNet2Wrapper.from_checkpoint("aimnet2", device=device)
     wrapper.eval()
-    wrapper.model_config.active_outputs = {"energy", "forces"}
+    wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
 
     gen = torch.Generator(device="cpu").manual_seed(7)
     graphs_after_warmup = [0]
@@ -152,6 +150,7 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
             sharded = ShardedBatch.from_batch(_batch(pos), mesh, cfg, 0)
             out = dist_model(sharded)
             f_owned = out["forces"].detach().float()
+            stress = out["stress"].detach().float()
 
             if step == 0:
                 # Equivalence: compiled DD == eager DD on the same partition.
@@ -162,7 +161,14 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
                     atol=3e-3,
                     msg=f"rank {rank}: compiled DD forces != eager DD reference",
                 )
-            _ = f_owned.sum().item()
+                torch.testing.assert_close(
+                    stress.cpu(),
+                    stress_eager,
+                    rtol=3e-3,
+                    atol=1e-5,
+                    msg=f"rank {rank}: compiled DD stress != eager DD reference",
+                )
+            _ = (f_owned.sum() + stress.sum()).item()
             n_graphs = counters["stats"].get("unique_graphs", 0)
             if step == WARMUP_STEPS - 1:
                 graphs_after_warmup[0] = n_graphs
@@ -184,9 +190,9 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
 
 @_skip
 def test_aimnet2_compile_dd_equivalence_and_zero_recompiles_2ranks():
-    """AIMNet2 halo + compile under DD: owned forces match a single-GPU
-    reference, and a jittered MD loop produces zero steady-state recompiles.
-    Guards the dense-nbmat fixed-shape padding (the DensePadder path)."""
+    """AIMNet2 halo + compile under DD: owned forces and global stress match
+    eager DD, and a jittered MD loop produces zero steady-state recompiles.
+    Guards the dense-nbmat fixed-shape padding and strain-stress paths."""
     pytest.importorskip("aimnet", reason="aimnet not installed")
     mp.spawn(
         _worker,

--- a/test/distributed/model/test_distributed_models.py
+++ b/test/distributed/model/test_distributed_models.py
@@ -1044,6 +1044,8 @@ def test_aimnet2_wrapper_declares_halo_spec() -> None:
     # ghost-refresh (ConvSV / Coulomb heads) + owned-only mol_sum reduce.
     spec = wrapper.distribution_spec()
     assert isinstance(spec.distribution.policy, HaloStoragePolicy)
+    assert "stress" in spec.all_reduce_outputs
+    assert spec.compile is not None and spec.compile.stress_via_strain
     # The halo refresh/reduce adapters ride third_party_helpers (mol_sum +
     # ConvSV + LRCoulomb + SRCoulomb), with no gather custom_ops.
     assert spec.distribution.custom_ops == ()

--- a/test/distributed/validate/test_validate_cuda.py
+++ b/test/distributed/validate/test_validate_cuda.py
@@ -596,9 +596,9 @@ def test_aimnet2_methane_pbc_passes():
     """3-D methane packing with full PBC. Exercises the multi-rank halo
     energy/force/stress path under PBC that the (non-PBC) carbon-chain
     sample doesn't — owned forces, stress, and energy must all match the
-    single-process reference. Stress rides the autograd /world_size
-    consolidation and is only meaningful under PBC, so this is the gate
-    that covers it for AIMNet2 under DD."""
+    single-process reference. Stress rides the autograd /world_size plus
+    cross-rank sum consolidation and is only meaningful under PBC, so this
+    is the gate that covers it for AIMNet2 under DD."""
     pytest.importorskip("aimnet")
     from nvalchemi.distributed.validate import trace_and_validate
 
@@ -614,7 +614,7 @@ def test_aimnet2_methane_pbc_passes():
         device="cuda:0",
         atol=1e-5,
         rtol=1e-4,
-        auto_fix=True,
+        auto_fix=False,
     )
     assert report.ok, report.next_action
     ph = report.attempts[-1].partition_health


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

AIMNet2 produced only rank-local stress contributions under eager domain decomposition, and compiled DD did not calculate stress.

This change:

- Sums AIMNet2 stress contributions across DD ranks.
- Enables strain-based stress for compiled DD.
- Makes the existing stress validator run without `auto_fix`.
- Adds assertions for the eager and compiled stress settings.

Energy and force behavior is unchanged.

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- `nvalchemi/models/aimnet2.py`
- `test/distributed/model/test_distributed_models.py`
- `test/distributed/validate/test_validate_cuda.py`

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
