### PR TITLE
fix(distributed): Fix UMA graph-parallel stress reduction

### DIFF
--- a/nvalchemi/distributed/distributed_model.py
+++ b/nvalchemi/distributed/distributed_model.py
@@ -1246,6 +1246,21 @@ class DistributedModel:
         if e_handle is not None:
             e_handle.wait()
 
+        # Other spec-declared rank partials (currently UMA stress) follow the
+        # same owned-energy algebra as energy: a raw SUM, with no /world. Mark
+        # them already global so sharded consolidation does not apply its normal
+        # replicated-energy autograd /world correction.
+        already_global_outputs = {"energy", "forces"}
+        for key in sorted(self._spec.all_reduce_outputs - already_global_outputs):
+            value = output.get(key)
+            if not isinstance(value, torch.Tensor):
+                continue
+            value = value.clone()
+            if grp is not None:
+                dist.all_reduce(value, op=dist.ReduceOp.SUM, group=grp)
+            output[key] = value
+            already_global_outputs.add(key)
+
         self._dist_ctx.gather_meta = None
         self._dist_ctx.owned_offset = 0
         _mark("reduce_outputs")
@@ -1254,7 +1269,7 @@ class DistributedModel:
             output,
             model_config=self._wrapper.model_config,
             world_size=self._world_size,
-            owned_only_outputs=frozenset({"energy", "forces"}),
+            owned_only_outputs=frozenset(already_global_outputs),
             all_reduce_outputs=frozenset(),
             halo_config=SimpleNamespace(mesh=mesh),
         )

--- a/test/distributed/model/test_uma_gp_partition_multigpu.py
+++ b/test/distributed/model/test_uma_gp_partition_multigpu.py
@@ -22,8 +22,8 @@ LOCAL owned partials. The framework's node-partition internal path SUM-reduces
 the per-rank energy and forces across ranks (no ``/world``: the feature
 all-gather's reduce-scatter backward distributed each node's gradient to its
 owner once) and returns this rank's owned forces. We reassemble the global
-forces from the disjoint owned blocks and compare both to the single-process
-reference. Stress (omat) is not asserted — node-partition stress is a follow-on.
+forces from the disjoint owned blocks and compare energy, forces, and each
+rank's per-system stress to the single-process reference.
 """
 
 from __future__ import annotations
@@ -96,6 +96,7 @@ def _worker(rank: int, world_size: int) -> None:
         # Single-GPU reference (rank 0) on its own eager wrapper.
         e_ref = torch.zeros(1, dtype=dtype, device=device)
         f_ref = torch.zeros(n_global, 3, dtype=dtype, device=device)
+        s_ref = torch.zeros(1, 3, 3, dtype=dtype, device=device)
         if rank == 0:
             ref_wrapper = UMAWrapper.from_checkpoint(
                 _CKPT, task_name=_TASK, device=device, inference_settings="default"
@@ -103,9 +104,11 @@ def _worker(rank: int, world_size: int) -> None:
             ro = ref_wrapper(_mk())
             e_ref = ro["energy"].sum().detach().view(1)
             f_ref = ro["forces"].detach()
+            s_ref = ro["stress"].detach().clone()
             del ro, ref_wrapper
         dist.broadcast(e_ref, src=0)
         dist.broadcast(f_ref, src=0)
+        dist.broadcast(s_ref, src=0)
 
         # Node-partition runs the backbone on owned atoms; the unmerged MoLE
         # head masks per-dataset over the FULL atom set (mismatching the owned
@@ -141,6 +144,9 @@ def _worker(rank: int, world_size: int) -> None:
 
         # Energy is global (all-reduced) on every rank.
         e_gp = out["energy"].sum().detach().view(1)
+        s_gp = out["stress"].detach().clone()
+        stresses_by_rank = [torch.empty_like(s_gp) for _ in range(world_size)]
+        dist.all_gather(stresses_by_rank, s_gp)
         # Forces come back as this rank's OWNED block; reassemble the global
         # [N, 3] from the disjoint contiguous blocks (a SUM all-reduce of each
         # rank's zero-padded slice).
@@ -158,16 +164,28 @@ def _worker(rank: int, world_size: int) -> None:
             e_abs = (e_gp - e_ref).abs().item()
             e_rel = e_abs / (e_ref.abs().item() + 1e-9)
             fd = (f_gp - f_ref.double()).abs()
+            sd = torch.stack(
+                [(stress - s_ref).abs().max() for stress in stresses_by_rank]
+            )
             print(
                 f"[uma-gp-part w={world_size}] dE_abs={e_abs:.4f} dE_rel={e_rel:.4e} "
                 f"e_ref={e_ref.item():.2f} | f_max_abs={fd.max().item():.4e} "
                 f"f_ref_max={f_ref.abs().max().item():.4e} "
-                f"f_mean_abs={fd.mean().item():.4e}",
+                f"f_mean_abs={fd.mean().item():.4e} | "
+                f"stress_max_abs_by_rank={sd.tolist()} | "
+                f"stress_ref={s_ref.cpu().tolist()} | "
+                f"stress_by_rank={[stress.cpu().tolist() for stress in stresses_by_rank]}",
                 flush=True,
             )
         torch.testing.assert_close(f_gp, f_ref.double(), rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(e_gp.double(), e_ref.double(), rtol=1e-3, atol=1e-3)
-        dist.barrier()
+        if rank == 0:
+            assert s_ref.abs().max().item() > 1e-3
+            assert torch.isfinite(torch.stack(stresses_by_rank)).all()
+            for stress in stresses_by_rank:
+                torch.testing.assert_close(
+                    stress.double(), s_ref.double(), rtol=1e-3, atol=1e-5
+                )
     finally:
         dist.destroy_process_group()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

In UMA graph-partition execution, each rank calculates a local contribution
to the system stress.

Energy and forces were reduced across ranks, but stress was not. Instead,
stress entered the generic output-consolidation logic, which divided this
local contribution by the number of ranks without first summing the
contributions.

This caused each rank to return an incomplete stress tensor.

## Bug example

Using `uma-s-1p1` with the `omat` task on two H100 GPUs:

- Single-GPU `stress[0, 0]`: `0.01203544`
- Rank 0 before the fix: `0.00298884`
- Rank 1 before the fix: `0.00302888`
- Maximum stress error: approximately `9.2e-03`

Neither rank returned the correct system stress.

## Fix

In the internal graph-partition path:

1. SUM-reduce spec-declared graph outputs, currently UMA stress, over the
   domain process group.
2. Mark the reduced outputs as already global.
3. Pass them through output consolidation without applying the usual
   autograd `/world_size` correction.

After the all-reduce, every rank receives the complete system stress.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- `nvalchemi/distributed/distributed_model.py`
  - SUM-reduces UMA stress and prevents later division by `world_size`.

- `test/distributed/model/test_uma_gp_partition_multigpu.py`
  - Adds single-GPU versus two-rank stress comparisons.

## Testing

<!-- Describe the tests you ran to verify your changes -->

Extended the real UMA graph-partition multi-GPU test to:

- Calculate a single-GPU reference.
- Run the same structure with two graph-partition ranks.
- Compare energy and gathered forces.
- Compare the complete stress returned by each rank with the single-GPU
  reference.

The test passed on two H100 GPUs:

- Stress error on both ranks: `2.96e-08`


- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
