### PR TITLE
docs: update README for 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,90 @@
 
 NVIDIA ALCHEMI Toolkit is a GPU-first Python framework for building, running, and
 deploying AI-driven atomic simulation workflows. It provides a unified interface for
-machine-learned interatomic potentials (MLIPs), batched molecular dynamics, and
-composable multi-stage simulation pipelines: all designed for high throughput on
-NVIDIA GPUs.
+machine-learned interatomic potentials (MLIPs), batched molecular dynamics,
+composable multi-stage simulation pipelines, and model training and fine-tuning:
+all designed for high throughput on NVIDIA GPUs.
 
 ### Key Features
 
-- **Bring your own model** &mdash; wrap any MLIP (MACE, AIMNet2, or your own) with
-  a standard `BaseModelMixin` that handles input/output adaptation, capability
-  negotiation, and runtime control via `ModelConfig`
-- **Graph-structured data** &mdash; `AtomicData` and `Batch` provide Pydantic-backed,
-  GPU-resident graph representations with built-in serialization to Zarr
-- **Composable dynamics** &mdash; subclass `BaseDynamics` for custom integrators;
-  compose stages with `+` (single-GPU `FusedStage`) or `|` (multi-GPU
-  `DistributedPipeline`)
-- **Pluggable hook system** &mdash; nine insertion points per step for logging,
-  safety checks, enhanced sampling, profiling, and convergence detection
-- **Inflight batching** &mdash; `SizeAwareSampler` replaces graduated samples
-  on the fly, maximizing GPU utilization across long-running pipelines
-- **High-performance primitives** &mdash; built on
-  [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
-  for GPU-optimized neighbor lists, dispersion, and electrostatics via
-  NVIDIA `warp-lang`
-- Agents as first-class citizens; includes a core skills library that
-  teaches agents how to use `nvalchemi` efficiently in agentic workflows
+- **Batched GPU simulation**:
+  - many systems batched together in one pass on a single GPU
+  - molecular dynamics: NVE, NVT with Langevin or Nosé-Hoover chain
+    thermostats, NPT and NPH
+  - geometry relaxation: FIRE and FIRE2, with optional cell relaxation
+  - `+` fuses stages so a relax-then-MD workflow costs one forward pass per
+    step (`FusedStage`)
+  - `SizeAwareSampler` swaps in new samples as others converge, keeping the
+    GPU full on long runs
+
+- **Training and fine-tuning** ([guide](docs/userguide/training.md)):
+  - composable energy, force and stress losses with weight schedules
+  - validation and restartable checkpoints
+  - EMA and DDP hooks
+
+- **Multi-GPU scaling** ([guide](docs/userguide/distributed.md)):
+  - spatial domain decomposition splits one large system across ranks via
+    `DomainParallel` and `ShardTensor`, with automatic halo exchange
+  - `|` distributes pipeline stages across ranks (`DistributedPipeline`)
+
+- **Interatomic potentials**:
+  - wrappers for MACE, AIMNet2 and UMA
+  - your own model via `BaseModelMixin`
+
+- **Interaction terms**:
+  - Ewald and particle mesh Ewald electrostatics, which read the per-atom
+    charges an MLIP such as AIMNet2 predicts
+  - DFT-D3(BJ) dispersion
+  - Lennard-Jones, usable on its own as a lightweight potential
+
+- **Data at scale**:
+  - `AtomicData` and `Batch`, Pydantic-backed and GPU-resident
+  - Zarr serialization for trajectories and datasets
+  - `MultiDataset` mixes several datasets with balanced sampling;
+    `InMemoryDataset` keeps a hot dataset resident
+  - per-sample and per-batch transforms, CUDA-stream prefetching
+
+- **Extensible by design**:
+  - one `BaseModelMixin` wrapper, with capabilities declared through
+    `ModelConfig`, works unchanged in dynamics, training and multi-GPU runs
+  - custom integrators and optimizers by subclassing `BaseDynamics`
+  - custom loss functions by subclassing `BaseLossFunction`, and custom
+    training steps through `training_fn`
+  - custom storage backends by subclassing `Reader`
+  - your own hooks at nine per-step insertion points, for logging, safety
+    checks, enhanced sampling, profiling and convergence detection
+  - stack interaction terms onto a potential with `PipelineModelWrapper`,
+    wiring outputs between steps so AIMNet2 supplies the charges Ewald reads
+
+- **Agent skills**: task-specific API guides under `.claude/skills/`
   (see [Using with AI coding agents](#using-with-ai-coding-agents))
+
+Built on [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
+for GPU-optimized neighbor lists and interaction kernels via NVIDIA `warp-lang`.
+
+Upgrading from 0.1.0? See [CHANGELOG.md](CHANGELOG.md) for breaking changes and
+migration snippets.
+
+### Roadmap
+
+Features planned for upcoming releases:
+
+- **Generative models**: model-agnostic abstraction of generative models for
+  the ALCHEMI Toolkit simulation pipeline
+- **Crystal structure prediction (CSP) primitives**: composable, batched
+  building blocks for molecular CSP workflows
+- **Enhanced sampling**: GPU-resident collective variables and biasing methods
+- **Model distillation**: pipeline for distilling large, accurate potentials
+  into compact models for fast production inference
+- **LoRA adapters**: parameter-efficient fine-tuning that maintains many
+  specialized variants of one base potential without duplicating its weights
+- **Hessians and phonons**: analytical second derivatives through automatic
+  differentiation for vibrational and thermodynamic property prediction
+- **Domain decomposition optimization**: continued performance improvement of
+  spatial domain decomposition
+- **Kernel improvements** at the
+  [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
+  level
 
 ### Using with AI coding agents
 
@@ -88,15 +147,34 @@ print(outputs["forces"].shape)    # [7, 3] &mdash; one force vector per atom
 <summary>Geometry optimization with convergence detection</summary>
 
 ```python
+import torch
+from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics import DemoDynamics, ConvergenceHook
 from nvalchemi.dynamics.hooks import LoggingHook, NaNDetectorHook
+
+
+# Dynamics reads and writes these per-step buffers, so allocate them up front.
+def system(n_atoms: int, z: int) -> AtomicData:
+    return AtomicData(
+        positions=torch.randn(n_atoms, 3),
+        atomic_numbers=torch.full((n_atoms,), z, dtype=torch.long),
+        forces=torch.zeros(n_atoms, 3),
+        energy=torch.zeros(1, 1),
+        velocities=torch.zeros(n_atoms, 3),
+    )
+
+
+batch = Batch.from_data_list([system(4, 6), system(3, 8)])
 
 dynamics = DemoDynamics(
     model=model,
     n_steps=10_000,
     dt=0.5,
     convergence_hook=ConvergenceHook.from_fmax(0.05),
-    hooks=[LoggingHook(frequency=100), NaNDetectorHook()],
+    hooks=[
+        LoggingHook(backend="csv", log_path="run.csv", frequency=100),
+        NaNDetectorHook(),
+    ],
 )
 with dynamics:
     result = dynamics.run(batch)
@@ -110,8 +188,8 @@ with dynamics:
 ```python
 from nvalchemi.dynamics import DemoDynamics
 
-optimizer = DemoDynamics(model=model, dt=0.5)
-md = DemoDynamics(model=model, dt=1.0)
+optimizer = DemoDynamics(model=model, n_steps=500, dt=0.5)
+md = DemoDynamics(model=model, n_steps=1_000, dt=1.0)
 
 # + fuses stages: one forward pass, masked updates per sub-stage
 fused = optimizer + md
@@ -128,14 +206,104 @@ with fused:
 # Launch with: torchrun --nproc_per_node=2 my_pipeline.py
 from nvalchemi.dynamics import DemoDynamics
 
-optimizer = DemoDynamics(model=model, dt=0.5)
-md = DemoDynamics(model=model, dt=1.0)
+optimizer = DemoDynamics(model=model, n_steps=500, dt=0.5)
+md = DemoDynamics(model=model, n_steps=1_000, dt=1.0)
 
 # | distributes stages: one dynamics per GPU rank
 pipeline = optimizer | md
 with pipeline:
     pipeline.run()
 ```
+
+</details>
+
+<details>
+<summary>Train a model with validation and checkpointing</summary>
+
+```python
+import torch
+from nvalchemi.training import (
+    EnergyMSELoss,
+    ForceMSELoss,
+    OptimizerConfig,
+    TrainingStrategy,
+    ValidationConfig,
+    default_training_fn,
+)
+
+# Assumes `model` is a BaseModelMixin wrapper and `train_loader` /
+# `val_loader` are nvalchemi DataLoaders (see the data pipeline guide).
+device = torch.device("cuda")
+
+# Compose an objective: weighted energy + force terms
+loss_fn = 1.0 * EnergyMSELoss() + 10.0 * ForceMSELoss()
+
+strategy = TrainingStrategy(
+    models=model,
+    optimizer_configs=OptimizerConfig(
+        optimizer_cls=torch.optim.AdamW,
+        optimizer_kwargs={"lr": 1e-3},
+    ),
+    num_steps=10_000,
+    training_fn=default_training_fn,
+    loss_fn=loss_fn,
+    devices=[device],
+    validation_config=ValidationConfig(
+        validation_data=val_loader,
+        validation_fn=default_training_fn,
+        loss_fn=loss_fn,
+        every_n_steps=500,
+    ),
+)
+strategy.run(train_loader)
+print(strategy.last_validation)
+```
+
+For a complete runnable script, see
+[`examples/advanced/10_mace_training.py`](examples/advanced/10_mace_training.py).
+
+</details>
+
+<details>
+<summary>Split one large system across GPUs (domain decomposition)</summary>
+
+```python
+# Launch with: torchrun --nproc_per_node=2 my_dd_run.py
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from nvalchemi.distributed import DomainConfig, DomainParallel
+from nvalchemi.dynamics import NVTLangevin
+from nvalchemi.models.mace import MACEWrapper
+
+dist.init_process_group(backend="nccl")
+device = torch.device(f"cuda:{dist.get_rank()}")
+torch.cuda.set_device(device)
+mesh = DeviceMesh(
+    "cuda", list(range(dist.get_world_size())), mesh_dim_names=("domain",)
+)
+
+# The wrapper and the integrator are the same objects you would use on a
+# single GPU; `batch` is the full system, built on rank 0 only.
+wrapper = MACEWrapper.from_checkpoint("medium-0b2", device=device).eval()
+integrator = NVTLangevin(
+    model=wrapper, dt=0.5, temperature=300.0, friction=0.01, n_steps=200
+)
+
+# One DomainConfig + one wrap is the entire user-facing addition. Atoms are
+# partitioned spatially; halo exchange and cross-rank reductions are automatic.
+domain_cfg = DomainConfig(cutoff=float(wrapper.cutoff), skin=0.5, mesh=mesh)
+dynamics = DomainParallel(dynamics=integrator, config=domain_cfg, n_steps=200)
+
+owned = dynamics.partition(batch if dist.get_rank() == 0 else None)
+dynamics.run(owned)
+dynamics.close()
+```
+
+For complete runnable scripts, see
+[`examples/distributed/`](examples/distributed/) and the
+[distributed guide](docs/userguide/distributed.md).
 
 </details>
 
@@ -183,6 +351,9 @@ pip install \
   --extra-index-url https://pypi.nvidia.com \
   'nvalchemi-toolkit[cu12,mace]'          # MACE model support, CUDA 12
 ```
+
+The `uma` extra is mutually exclusive with `mace` and the CUDA extras
+(incompatible `e3nn` / `torch` pins) and resolves into its own environment.
 
 See the [Installation Guide](docs/userguide/about/install.md) for
 detailed setup instructions.

--- a/README.md
+++ b/README.md
@@ -7,109 +7,40 @@
 [![codecov](https://codecov.io/gh/NVIDIA/nvalchemi-toolkit/branch/main/graph/badge.svg)](https://codecov.io/gh/NVIDIA/nvalchemi-toolkit)
 [![Documentation](https://img.shields.io/badge/docs-github%20pages-blue)](https://nvidia.github.io/nvalchemi-toolkit/)
 
-## High-performance deep-learning framework for atomic simulations
+## High-throughput AI atomic simulation on NVIDIA GPUs
 
-NVIDIA ALCHEMI Toolkit is a GPU-first Python framework for building, running, and
-deploying AI-driven atomic simulation workflows. It provides a unified interface for
-machine-learned interatomic potentials (MLIPs), batched molecular dynamics,
-composable multi-stage simulation pipelines, and model training and fine-tuning:
-all designed for high throughput on NVIDIA GPUs.
+NVIDIA ALCHEMI Toolkit is a GPU-first Python framework for AI atomic simulations.
+Run batched molecular dynamics (MD) and relaxation, train or fine-tune
+machine-learned interatomic potentials (MLIPs), and scale the same composable
+workflows from one GPU to multi-GPU systems.
 
 ### Key Features
 
-- **Batched GPU simulation**:
-  - many systems batched together in one pass on a single GPU
-  - molecular dynamics: NVE, NVT with Langevin or Nosé-Hoover chain
-    thermostats, NPT and NPH
-  - geometry relaxation: FIRE and FIRE2, with optional cell relaxation
-  - `+` fuses stages so a relax-then-MD workflow costs one forward pass per
-    step (`FusedStage`)
-  - `SizeAwareSampler` swaps in new samples as others converge, keeping the
-    GPU full on long runs
-
-- **Training and fine-tuning** ([guide](docs/userguide/training.md)):
-  - composable energy, force and stress losses with weight schedules
-  - validation and restartable checkpoints
-  - EMA and DDP hooks
-
-- **Multi-GPU scaling** ([guide](docs/userguide/distributed.md)):
-  - spatial domain decomposition splits one large system across ranks via
-    `DomainParallel` and `ShardTensor`, with automatic halo exchange
-  - `|` distributes pipeline stages across ranks (`DistributedPipeline`)
-
-- **Interatomic potentials**:
-  - wrappers for MACE, AIMNet2 and UMA
-  - your own model via `BaseModelMixin`
-
-- **Interaction terms**:
-  - Ewald and particle mesh Ewald electrostatics, which read the per-atom
-    charges an MLIP such as AIMNet2 predicts
-  - DFT-D3(BJ) dispersion
-  - Lennard-Jones, usable on its own as a lightweight potential
-
-- **Data at scale**:
-  - `AtomicData` and `Batch`, Pydantic-backed and GPU-resident
-  - Zarr serialization for trajectories and datasets
-  - `MultiDataset` mixes several datasets with balanced sampling;
-    `InMemoryDataset` keeps a hot dataset resident
-  - per-sample and per-batch transforms, CUDA-stream prefetching
-
-- **Extensible by design**:
-  - one `BaseModelMixin` wrapper, with capabilities declared through
-    `ModelConfig`, works unchanged in dynamics, training and multi-GPU runs
-  - custom integrators and optimizers by subclassing `BaseDynamics`
-  - custom loss functions by subclassing `BaseLossFunction`, and custom
-    training steps through `training_fn`
-  - custom storage backends by subclassing `Reader`
-  - your own hooks at nine per-step insertion points, for logging, safety
-    checks, enhanced sampling, profiling and convergence detection
-  - stack interaction terms onto a potential with `PipelineModelWrapper`,
-    wiring outputs between steps so AIMNet2 supplies the charges Ewald reads
-
-- **Agent skills**: task-specific API guides under `.claude/skills/`
-  (see [Using with AI coding agents](#using-with-ai-coding-agents))
+- **Batched GPU simulation**: run many MD or geometry relaxation jobs in one
+  model pass; inflight batching keeps the GPU occupied as systems finish.
+- **Bring your own model**: use MACE, AIMNet2 or UMA, or wrap another MLIP with
+  `BaseModelMixin`; add Ewald/PME electrostatics or DFT-D3(BJ) dispersion.
+- **Training and fine-tuning**: combine energy, force and stress objectives
+  with validation, restartable checkpoints, exponential moving averages and
+  distributed data-parallel training.
+- **Multi-GPU scaling**: split one large atomic system across GPUs with spatial
+  domain decomposition.
+- **Data at scale**: use GPU-resident `AtomicData` and `Batch`, Zarr storage,
+  balanced dataset mixing, transforms and CUDA-stream prefetching.
+- **Composable dynamics and hooks**: create custom integrators, chain simulation
+  stages with `+` or `|`, and attach logging, safety, sampling, profiling or
+  convergence logic at nine points per step.
+- **Agent-ready guidance**: task-specific skills and `AGENTS.md` teach coding
+  agents the toolkit APIs and repository conventions.
 
 Built on [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
 for GPU-optimized neighbor lists and interaction kernels via NVIDIA `warp-lang`.
 
-Upgrading from 0.1.0? See [CHANGELOG.md](CHANGELOG.md) for breaking changes and
-migration snippets.
-
-### Roadmap
-
-Features planned for upcoming releases:
-
-- **Generative models**: model-agnostic abstraction of generative models for
-  the ALCHEMI Toolkit simulation pipeline
-- **Crystal structure prediction (CSP) primitives**: composable, batched
-  building blocks for molecular CSP workflows
-- **Enhanced sampling**: GPU-resident collective variables and biasing methods
-- **Model distillation**: pipeline for distilling large, accurate potentials
-  into compact models for fast production inference
-- **LoRA adapters**: parameter-efficient fine-tuning that maintains many
-  specialized variants of one base potential without duplicating its weights
-- **Hessians and phonons**: analytical second derivatives through automatic
-  differentiation for vibrational and thermodynamic property prediction
-- **Domain decomposition optimization**: continued performance improvement of
-  spatial domain decomposition
-- **Kernel improvements** at the
-  [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
-  level
-
 ### Using with AI coding agents
 
-The repository ships agent-facing guidance at two levels:
+  **Skills** — task-specific API guides under .claude/skills/. Claude Code discovers them automatically when working inside a clone; for other platforms (e.g. Cursor, OpenCode), or to use them outside this repository, copy the folder contents into your project's or home skills directory.
 
-- **Skills** — task-specific API guides under `.claude/skills/`. Claude Code
-  discovers them automatically when working inside a clone; other platforms
-  are routed to the right `SKILL.md` by the table in `AGENTS.md`. To use
-  them outside this repository, copy the folder contents into your
-  project's or home skills directory.
-- **`AGENTS.md`** — repository-wide guidance (setup, conventions, gotchas,
-  and the skill routing table). Agents that follow the `AGENTS.md`
-  convention (e.g. Codex, Cursor, OpenCode, GitHub Copilot) load it
-  natively; the repository also ships a `CLAUDE.md` that imports it, so
-  Claude Code gets the same guidance automatically.
+  **AGENTS.md** — repository-wide guidance (setup, conventions, gotchas). Agents that follow the AGENTS.md convention (e.g. Codex, Cursor, OpenCode) load it natively. Claude Code auto-loads CLAUDE.md instead: to get the same guidance there, add a CLAUDE.md to your clone containing the single line @AGENTS.md (an import), or symlink it (ln -s AGENTS.md CLAUDE.md).
 
 ### Example Snippets
 
@@ -218,7 +149,7 @@ with pipeline:
 </details>
 
 <details>
-<summary>Train a model with validation and checkpointing</summary>
+<summary>Train a model with validation</summary>
 
 ```python
 import torch
@@ -270,18 +201,16 @@ For a complete runnable script, see
 ```python
 # Launch with: torchrun --nproc_per_node=2 my_dd_run.py
 import torch
-import torch.distributed as dist
-from torch.distributed.device_mesh import DeviceMesh
 
-from nvalchemi.distributed import DomainConfig, DomainParallel
+from nvalchemi.distributed import DistributedManager, DomainConfig, DomainParallel
 from nvalchemi.dynamics import NVTLangevin
 from nvalchemi.models.mace import MACEWrapper
 
-dist.init_process_group(backend="nccl")
-device = torch.device(f"cuda:{dist.get_rank()}")
-torch.cuda.set_device(device)
-mesh = DeviceMesh(
-    "cuda", list(range(dist.get_world_size())), mesh_dim_names=("domain",)
+DistributedManager.initialize()
+dm = DistributedManager()
+device = torch.device(dm.device)
+mesh = dm.initialize_mesh(
+  mesh_shape=(dm.world_size,), mesh_dim_names=("domain",)
 )
 
 # The wrapper and the integrator are the same objects you would use on a
@@ -294,11 +223,13 @@ integrator = NVTLangevin(
 # One DomainConfig + one wrap is the entire user-facing addition. Atoms are
 # partitioned spatially; halo exchange and cross-rank reductions are automatic.
 domain_cfg = DomainConfig(cutoff=float(wrapper.cutoff), skin=0.5, mesh=mesh)
-dynamics = DomainParallel(dynamics=integrator, config=domain_cfg, n_steps=200)
+with DomainParallel(
+  dynamics=integrator, config=domain_cfg, n_steps=200
+) as dynamics:
+  owned = dynamics.partition(batch if dm.rank == 0 else None)
+  dynamics.run(owned)
 
-owned = dynamics.partition(batch if dist.get_rank() == 0 else None)
-dynamics.run(owned)
-dynamics.close()
+DistributedManager.cleanup()
 ```
 
 For complete runnable scripts, see
@@ -357,6 +288,27 @@ The `uma` extra is mutually exclusive with `mace` and the CUDA extras
 
 See the [Installation Guide](docs/userguide/about/install.md) for
 detailed setup instructions.
+
+### Roadmap
+
+Features planned for upcoming releases:
+
+- **Generative models**: model-agnostic abstraction of generative models for
+  the ALCHEMI Toolkit simulation pipeline
+- **Crystal structure prediction (CSP) primitives**: composable, batched
+  building blocks for molecular CSP workflows
+- **Enhanced sampling**: GPU-resident collective variables and biasing methods
+- **Model distillation**: pipeline for distilling large, accurate potentials
+  into compact models for fast production inference
+- **LoRA adapters**: parameter-efficient fine-tuning that maintains many
+  specialized variants of one base potential without duplicating its weights
+- **Hessians and phonons**: analytical second derivatives through automatic
+  differentiation for vibrational and thermodynamic property prediction
+- **Domain decomposition optimization**: continued performance improvement of
+  spatial domain decomposition
+- **Kernel improvements** at the
+  [`nvalchemi-toolkit-ops`](https://github.com/NVIDIA/nvalchemi-toolkit-ops)
+  level
 
 ## Contributions & Disclaimers
 


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Brings `README.md` up to date for the 0.2.0 release. Adds the subsystems
that landed during this cycle, training (`nvalchemi.training`) and spatial
domain decomposition (`nvalchemi.distributed`), along with the UMA wrapper
and `MultiDataset` composition. Key Features is restructured so the
list leads with what the toolkit does.

Also fixes three example snippets that do not run against the current API.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

Coordination note: does not overlap with #146 ("Exp docs 0.2.0 preview"),
which touches 100 files under `docs/` but neither `README.md` nor
`CHANGELOG.md`.

## Changes Made

- Restructured **Key Features** to lead with capabilities rather than
  architecture, with batched GPU simulation first.
- Added coverage for 0.2 features: training and fine-tuning, multi-GPU spatial
  domain decomposition, the UMA wrapper, and `MultiDataset` /
  `InMemoryDataset` and transforms.
- Split model listings into **Interatomic potentials** (MACE, AIMNet2, UMA,
  bring-your-own) and **Interaction terms** (Ewald/PME, DFT-D3, Lennard-Jones),
  since Ewald and PME read charges an MLIP predicts and cannot stand in for a
  potential.
- Clarified the `|` operator as stage-parallel, so it reads distinctly from the
  new intra-system spatial decomposition.
- Added a **Roadmap** section following the format used in
  `nvalchemi-toolkit-ops`.
- Replaced the inline breaking-changes paragraph with a pointer to
  `CHANGELOG.md`, which already carried all five items.
- Added two example snippets: training with validation and checkpointing, and
  splitting one system across GPUs with `DomainParallel`.
- **Fixed three example snippets that do not run against the current API:**
  - `LoggingHook(frequency=100)` raised `TypeError`; `backend` is a required
    positional argument (`"csv"` also needs `log_path`).
  - `DemoDynamics.run(batch)` raised `AttributeError: 'Batch' has no attribute
    'forces'`. Dynamics needs `forces`, `energy` and `velocities` pre-allocated
    on `AtomicData`, as `examples/basic/02_geometry_optimization.py` does.
  - `DemoDynamics(model=model, dt=0.5)` raised `TypeError`; `n_steps` is
    required. Affected two snippets.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

`make lint` exits 0, and the repo's `markdownlint` pre-commit hook passes on
`README.md`.

`make pytest` was not run: this PR changes no source under `nvalchemi/`, so
there is no behavior to regress.

Example snippets were verified by execution rather than inspection, in a
`uv sync --extra cu13` environment on an RTX 4000 SFF Ada (CUDA 13.2):

- Snippets 1-3 (forward pass, geometry optimization, `+` fused stage) were
  extracted verbatim from `README.md` and run to completion. Snippet 1 printed
  `torch.Size([2, 1])` and `torch.Size([7, 3])`, matching its comments; snippet
  2 wrote a CSV with `step,graph_idx,status,energy,fmax,temperature` rows.
- Snippets 4-6 (`|` pipeline, training, domain decomposition) need two ranks
  and a single GPU was available, so their API calls were confirmed instead:
  `|` builds a `DistributedPipeline`, the loss expression yields a
  `ComposedLossFunction`, and `TrainingStrategy`, `ValidationConfig`,
  `NVTLangevin`, `DomainConfig` and `DomainParallel` all bind their keyword
  arguments. **These three have not been executed end to end.**

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

`CHANGELOG.md` is deliberately untouched. It does need attention before
release, but as separate commits rather than folded into a README change:

- No `Added` entry for `nvalchemi.distributed`, the largest feature in the
  release (~30.8k lines across 70 files). It currently appears only under
  `Fixed`.
- The `Unreleased` heading needs to become `0.2.0` with a date.
- Unlisted: slab correction in electrostatics wrappers (#103), trainable
  `PipelineModelWrapper` (#99), MACE wrapper training support (#97),
  the `torch>=2.8` floor (#85), and the toolkit-ops 0.4.0 pin (#120).
- The isotropic MTK NPT barostat mass change (`W` 3x smaller) is filed under
  `Fixed`. It silently changes existing NPT runs, so it may belong under
  `Breaking Changes`.

## Additional Notes

Two items worth a reviewer's judgement:

1. **The Roadmap section is new.** Its format follows
   `nvalchemi-toolkit-ops`, and it carries no dates. Whether a public roadmap
   is wanted here at all is a maintainer call.
2. **README snippets are not currently exercised by CI.** A doctest-style
   check over fenced `python` blocks would catch this class of drift early.
