### PR TITLE
Omnibus Domain Decomposition Bug Fixes

### DIFF
--- a/.claude/skills/nvalchemi-distributed/SKILL.md
+++ b/.claude/skills/nvalchemi-distributed/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: nvalchemi-distributed
+description: How to run domain-decomposed (multi-GPU) MLIP simulations with DomainParallel — choose between the halo and graph-partition strategies, author a distribution_spec so a bring-your-own model runs under domain decomposition, and write a custom dynamics integrator that stays correct across ranks.
+---
+
+# nvalchemi Distributed (Domain Decomposition)
+
+## Overview
+
+Domain decomposition (DD) splits *one* atomic system across several GPUs so a
+simulation that doesn't fit — or doesn't run fast enough — on a single card can
+scale out. The **same** model wrapper, hooks, and integrators you use
+single-process run unchanged; you add one wrapper around each.
+
+- {class}`~nvalchemi.distributed.DomainParallel` wraps any
+  {class}`~nvalchemi.dynamics.base.BaseDynamics` integrator/optimizer and drives
+  it across the mesh.
+- Under the hood it wraps the model in a `DistributedModel`, which reads the
+  model's `distribution_spec` to know how to shard/gather each field.
+
+```python
+from nvalchemi.distributed import (
+    DistributedManager, DomainConfig, DomainParallel, HookScope,
+)
+```
+
+Launch with **torchrun** (or SLURM): DD is one process per GPU.
+
+```bash
+torchrun --nproc_per_node=4 my_distributed_md.py
+```
+
+There are four things you may need to do. Pick the section you need:
+
+1. **Run a shipped model under DD** → §1
+2. **Choose halo vs graph-partition** → §2
+3. **Make your own model run under DD** (author a `distribution_spec`) → §3
+4. **Write a custom integrator that stays correct under DD** → §4
+
+---
+
+## 1. Run a domain-decomposed model
+
+Bootstrap the process group + mesh with `DistributedManager`, wrap the model as
+usual, then wrap the integrator in `DomainParallel`. Build the full system on
+rank 0, `partition()` it, and `run()`.
+
+```python
+import torch
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.distributed import (
+    DistributedManager, DomainConfig, DomainParallel, HookScope,
+)
+from nvalchemi.dynamics import NVTLangevin, HostMemory
+from nvalchemi.dynamics.hooks import SnapshotHook
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.hooks import NeighborListHook
+from nvalchemi.models.mace import MACEWrapper
+
+# 1. Bootstrap (reads RANK / WORLD_SIZE / LOCAL_RANK from torchrun).
+DistributedManager.initialize()
+dm = DistributedManager()
+mesh = dm.initialize_mesh(mesh_shape=(dm.world_size,), mesh_dim_names=("domain",))
+device = torch.device(dm.device)
+
+# 2. Wrap the model — identical to single-process.
+wrapper = MACEWrapper.from_checkpoint("medium-mpa-0", device=device).eval()
+
+# 3. Build the inner integrator (its NeighborListHook is an INNER hook).
+integrator = NVTLangevin(
+    model=wrapper, dt=1.0, temperature=300.0, friction=0.01, n_steps=200,
+    hooks=[NeighborListHook(wrapper.model_config.neighbor_config, skin=0.5,
+                            stage=DynamicsStage.BEFORE_COMPUTE)],
+)
+
+# 4. Trajectory snapshot: gather to rank 0 (an OUTER hook).
+snapshot = SnapshotHook(sink=HostMemory(capacity=201), frequency=10)
+snapshot.scope = HookScope.RANK_ZERO
+
+# 5. Wrap + run. cutoff = wrapper.cutoff makes the halo width exact.
+domain_cfg = DomainConfig(cutoff=float(wrapper.cutoff), skin=0.5, mesh=mesh)
+with DomainParallel(dynamics=integrator, config=domain_cfg,
+                    n_steps=200, hooks=[snapshot]) as dynamics:
+    full_batch = build_full_system(device) if dm.rank == 0 else None
+    owned = dynamics.partition(full_batch)   # returns THIS rank's owned atoms
+    dynamics.run(owned)
+
+DistributedManager.cleanup()
+```
+
+Key points:
+
+- `partition()` takes the full system on **rank 0** (`None` elsewhere) and returns
+  each rank's owned `Batch`. `run()` loops `step()` for `n_steps`.
+- `with DomainParallel(...)` makes teardown exception-safe; keep the process-group
+  lifecycle (`initialize` / `cleanup`) at launcher scope.
+- **The initial system** (`build_full_system`, built on rank 0) is a `Batch` whose
+  per-atom fields must include everything the integrator reads. For MD that means
+  `positions`, `atomic_numbers`, `atomic_masses`, `cell`, `pbc`, **and
+  `velocities`**. Masses/positions/cell/pbc are `AtomicData(...)` constructor args,
+  but **velocities are attached separately** — `data.add_node_property("velocities",
+  v)` — then `Batch.from_data_list([data])`. `NVTLangevin` / `NVE` read
+  `batch.velocities` + `batch.atomic_masses` and crash at step 0 if they're absent:
+
+  ```python
+  data = AtomicData(positions=pos, atomic_numbers=z, atomic_masses=m,
+                    cell=box.unsqueeze(0), pbc=pbc)     # (masses in the ctor)
+  data.add_node_property("velocities", v)               # velocities added after
+  full = Batch.from_data_list([data], device=device)
+  ```
+
+- **Hook placement:** neighbor-list / compute hooks go on the **inner** integrator
+  (they fire on the padded compute view); trajectory/logging hooks go on the
+  **outer** `DomainParallel` with `HookScope.RANK_ZERO` (gather to rank 0) or
+  `HookScope.GLOBAL` (gather to every rank).
+
+Runnable references: `examples/distributed/03_mace_nvt_distributed.py` (NVT),
+`06_mace_npt_distributed.py` (NPT), `07_fire_nvt_dd.py` (FIRE + 2-D pipeline×DD).
+
+---
+
+## 2. Choose the strategy: halo vs graph-partition
+
+Two strategies ship, selected with `DomainConfig.strategy`
+({class}`~nvalchemi.distributed.config.StrategyKind`). The default is halo.
+
+| | **Halo** (default) | **Graph-partition** |
+|---|---|---|
+| Split by | space (spatial domains) | atom index (balanced node blocks) |
+| Each rank holds | owned atoms + a ghost halo | the **full geometry** (replicated) + owns a node slice |
+| Best for | models with a bounded cutoff you can hand a padded view (MACE, NequIP, LJ, Ewald, PME) | models that build their own neighbour list inside `forward` (UMA / eSCN-family) |
+| Comms | one halo exchange per step | per-layer feature all-gather + reduce-scatter |
+| Cell / migration | cell load-bearing; atoms migrate | cell is a plain input; no migration |
+
+```python
+from nvalchemi.distributed.config import StrategyKind
+
+# Halo (default):
+cfg = DomainConfig(cutoff=wrapper.cutoff, skin=0.5, mesh=mesh)
+# Graph-partition:
+cfg = DomainConfig(cutoff=wrapper.cutoff, skin=0.5, mesh=mesh,
+                   strategy=StrategyKind.GRAPH_PARTITION)
+```
+
+**Rule of thumb:** use **halo** for a short-range MPNN with a real cutoff (it
+scales to large N as a capacity play); use **graph-partition** for a model that
+rebuilds its own graph and can't take a pre-padded view, or to fit a single
+system past one GPU's memory.
+
+**Shipped presets** (from `nvalchemi.distributed.spec`) — a wrapper declares one
+of these as its `distribution_spec` (§3):
+
+| Preset | Strategy |
+|---|---|
+| `SPEC_MPNN_HALO` | halo — scatter-heavy MPNNs (MACE, NequIP, generic) **and any differentiable, autograd-force model** (incl. a BYO pure-PyTorch pair potential) |
+| `SPEC_LJ_HALO` | halo — the *shipped* Lennard-Jones wrapper's **opaque Warp kernel** (carries `OpAdapter`s) |
+| `SPEC_UMA_HALO` | halo — UMA/eSCN (local scatter) |
+| `SPEC_EWALD_HALO` / `SPEC_PME_HALO` | halo — long-range electrostatics |
+| `SPEC_DFTD3_HALO` | halo — DFTD3 dispersion |
+| `SPEC_MPNN_GP` | graph-partition — MPNNs under node partition |
+
+Note: `SPEC_LJ_HALO` is for the shipped LJ's opaque kernel, **not** a BYO pair
+potential — if you write a differentiable pair potential in plain PyTorch, its
+forces come from autograd and the correct preset is `SPEC_MPNN_HALO`.
+
+**Compiled runs:** add `compile=True` to the `DomainConfig`. The forward is
+fixed-shape (padded to per-rank caps), so after a short warm-up the trajectory
+runs recompile-free — MD-ready. Supported by the MACE (incl. cuEquivariance),
+AIMNet2, and UMA wrappers.
+
+---
+
+## 3. Add a `distribution_spec` (bring your own model)
+
+To make an arbitrary wrapped model (see `nvalchemi-model-wrapping`) run under DD,
+give it a `distribution_spec` that returns an
+{class}`~nvalchemi.distributed.spec.MLIPSpec`. The framework reads it — the
+wrapper's `forward` stays free of any distributed code. Four steps:
+
+**(1) Wrap** your model with `BaseModelMixin` as usual.
+
+**(2) Declare a spec.** If your model is a scatter-heavy MPNN with autograd
+forces, return a preset:
+
+```python
+from nvalchemi.distributed.spec import SPEC_MPNN_HALO
+
+class MyWrapper(nn.Module, BaseModelMixin):
+    def distribution_spec(self, strategy=None):
+        return SPEC_MPNN_HALO
+```
+
+**Getting the wrapper right under halo.** For an autograd/scatter model that
+returns `SPEC_MPNN_HALO`, four things in your `forward` / `adapt_input` decide
+correctness — miss them and you get *silently wrong* energies, not a crash:
+
+- **Emit per-atom energies over ALL local atoms (owned + ghost).** Return an
+  `(n_local,)` atomic-energy tensor and let the framework reduce ghost rows; don't
+  pre-slice to owned.
+- **Rebind in-place scatters:** write `ae = ae.scatter_add_(0, recv, e_edge)` and
+  use the *returned* tensor — under DD the dispatch returns a new, cross-rank
+  halo-corrected tensor; the pre-rebind value is wrong.
+- **Filter neighbor-list sentinels in `adapt_input`:** halo padding can leave
+  receiver indices ≥ `n_atoms`; drop them with
+  `valid = (edge_index[0] < n) & (edge_index[1] < n)`.
+- **Periodic systems:** compute displacements with the minimum-image convention
+  from the cell (`frac = rij @ inv_cell; frac -= frac.round(); rij = frac @ cell`).
+  It is a no-op on halo ghost edges (the ghost already sits at its image) and
+  correct single-process, so no explicit shift vectors are needed.
+
+Your wrapper's `ModelConfig` should declare forces as autograd —
+`autograd_outputs=frozenset({"forces"})`, `autograd_inputs=frozenset({"positions"})`,
+`neighbor_config=NeighborConfig(cutoff=…, format=NeighborListFormat.COO)`. See
+`nvalchemi-model-wrapping` and `examples/distributed/04_byo_pytorch_mpnn.py` for the
+full wrapper.
+
+If the model calls a **custom op** (a Warp/Triton kernel, a fused scatter) the
+tracer can't see through, build the spec explicitly and declare per-op behaviour
+with an adapter:
+
+```python
+import torch
+from nvalchemi.distributed.ops import HaloStoragePolicy, ScatterOutputs
+from nvalchemi.distributed.spec import (
+    DistributionSpec, MLIPSpec, OpAdapter, OutputKind,
+)
+
+def _build_spec():
+    return MLIPSpec(
+        distribution=DistributionSpec(
+            policy=HaloStoragePolicy(),        # halo layout
+            custom_ops=(                       # one OpAdapter per opaque kernel
+                OpAdapter(
+                    op=torch.ops.mypkg.my_energy_op.default,
+                    arg_transforms={},                       # inputs already halo-padded
+                    output_transforms={0: ScatterOutputs()}, # halo-correct output 0
+                ),
+            ),
+        ),
+        output_kinds={"energy": OutputKind.PER_GRAPH,
+                      "forces": OutputKind.PER_NODE},
+    )
+```
+
+- **`policy`** — storage layout: `HaloStoragePolicy` (halo) or
+  `GraphParallelPolicy` (node-partition). `output_kinds` tags each named output's
+  shape (`PER_NODE`, `PER_GRAPH`, `GLOBAL`) so consolidation knows whether to
+  halo-reverse, all-reduce, or pass it through.
+- **Adapters** declare how a black-box op distributes. `OpAdapter(op=,
+  arg_transforms={i: …}, output_transforms={i: …})` goes in
+  `DistributionSpec.custom_ops`; `MethodAdapter` (swap a third-party module
+  method) and `PythonAdapter` / `JitAdapter` (replace a helper) go in
+  `third_party_helpers`. Transforms — `ScatterOutputs` / `GatherInputs` /
+  `SliceOwned` / `AllReduceSum` — say what to do per arg/output.
+
+**(3) Validate.** `trace_and_validate` runs the model under a simulated 2-rank
+mesh, checks force-equivalence vs single-process, and — when a bare op needs an
+adapter — tells you which one to add:
+
+```python
+from nvalchemi.distributed.validate import trace_and_validate
+
+report = trace_and_validate(MyWrapper(model), world_size=2)
+assert report.ok, report.next_action   # e.g. "add OpAdapter(..., ScatterOutputs())"
+```
+
+**(4) Persist.** `MLIPSpec.save(path)` / `MLIPSpec.load(path)` round-trip the spec
+so production runs skip re-discovery.
+
+Full walkthroughs: `examples/distributed/04_byo_pytorch_mpnn.py` (autograd MPNN,
+no custom op) and `05_byo_graph_transformer.py` (a custom-op kernel needing an
+`OpAdapter`). Deep reference: the *Bring Your Own Model* user guide.
+
+---
+
+## 4. Bring your own dynamics under DD
+
+A custom {class}`~nvalchemi.dynamics.base.BaseDynamics` integrator (see
+`nvalchemi-dynamics-implementation`) runs under `DomainParallel` **unchanged as
+long as every operation is per-atom.** The one rule:
+
+> Under DD each rank's `pre_update` / `post_update` sees **only its owned
+> atoms**. Per-atom math is correct as-is; any **global** reduction is not.
+
+**Safe locally (no change needed):** position/velocity integration, per-atom
+Langevin friction + noise, applying forces. `NVE` and `NVTLangevin` are exact
+under DD for exactly this reason. Reading `batch.energy` is also fine — the
+forward already reduces + replicates it globally.
+
+**Must be globalized (a shard `.sum()` / `.max()` / `.dot()` is WRONG):** total
+kinetic energy, temperature, degrees of freedom, FIRE dot-products (`v·f`,
+`v·v`, `f·f`), a global convergence test, barostat pressure.
+
+For the shipped ensembles this is automatic: Nosé–Hoover, `NPT`, `NPH`, and
+`FIRE` declare their global quantities as intent and `DomainParallel`'s
+coordinator reduces them — **prefer reusing them.** For a genuinely custom global
+scalar, compute it in a `HookScope.GLOBAL` hook, which sees the full gathered
+system on every rank:
+
+```python
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.distributed import HookScope
+
+class GlobalKineticEnergyHook:
+    stage = DynamicsStage.BEFORE_STEP
+    scope = HookScope.GLOBAL       # gather the FULL system to every rank first
+    frequency = 1
+    def __init__(self, integrator):
+        self._integrator = integrator
+    def __call__(self, ctx, stage):
+        b = ctx.batch              # full system, identical on every rank
+        self._integrator.global_ke = 0.5 * (
+            b.atomic_masses * (b.velocities**2).sum(-1)
+        ).sum()
+
+# Register on the OUTER DomainParallel; the integrator reads self.global_ke.
+dynamics = DomainParallel(dynamics=my_integrator, config=cfg, n_steps=n,
+                          hooks=[GlobalKineticEnergyHook(my_integrator)])
+```
+
+Because every rank computed the same value from the same gathered system, the
+integrator stays in lockstep.
+
+**Don'ts:**
+
+- Don't hand-roll `torch.distributed.all_reduce` over the world group — route
+  reductions through a shipped ensemble or a `GLOBAL` hook so they stay correct
+  under a replicated layout (where every rank holds the full data).
+- Don't read owned + ghost atoms inside `pre_update` / `post_update` — you only
+  ever get owned atoms.
+- Don't make a per-rank control-flow decision (like "converged") from a local
+  scalar — `DomainParallel` already reduces convergence mesh-wide; a divergent
+  local decision desyncs collectives.
+
+---
+
+## Reference: key imports
+
+| Symbol | Import from | Role |
+|---|---|---|
+| `DistributedManager` | `nvalchemi.distributed` | Process-group + mesh bootstrap |
+| `DomainParallel` | `nvalchemi.distributed` | Wrap an integrator to run across the mesh |
+| `DomainConfig` | `nvalchemi.distributed` | `cutoff` / `skin` / `mesh` / `strategy` / `compile` |
+| `StrategyKind` | `nvalchemi.distributed.config` | `HALO` (default) vs `GRAPH_PARTITION` |
+| `HookScope` | `nvalchemi.distributed` | `LOCAL` / `GLOBAL` / `RANK_ZERO` hook gather |
+| `MLIPSpec` / `DistributionSpec` | `nvalchemi.distributed.spec` | The `distribution_spec` a BYO model returns |
+| `HaloStoragePolicy` / `GraphParallelPolicy` | `nvalchemi.distributed.ops` / `.spec` | Per-field storage layout (the two strategies' policies) |
+| `OpAdapter` / `MethodAdapter` / `PythonAdapter` | `nvalchemi.distributed` | Declare how a black-box op/method/helper distributes |
+| `OutputKind`, `ScatterOutputs`, `GatherInputs` | `nvalchemi.distributed` (`.ops`) | Output shape tags + per-arg/output transforms |
+| `CompilePolicy` | `nvalchemi.distributed` | Opt a BYO model into a compiled DD forward |
+| `trace_and_validate` | `nvalchemi.distributed.validate` | Simulate a 2-rank mesh + check force-equivalence |
+| `SPEC_MPNN_HALO`, `SPEC_MPNN_GP`, … | `nvalchemi.distributed.spec` | Shipped presets |
+
+## See also
+
+- User guide: *Overview: Domain Decomposition*, *Bring Your Own Model*,
+  *ShardTensor*, and the *Architecture & design* deep dive.
+- Examples: `examples/distributed/03`–`07`.
+- Related skills: `nvalchemi-model-wrapping` (wrap a model),
+  `nvalchemi-dynamics-implementation` (write an integrator),
+  `nvalchemi-dynamics-hooks` (hooks), `nvalchemi-dynamics-api` (run/scale).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- Domain decomposition for distributed inference and dynamics: a spatial halo
+  strategy and a graph-parallel strategy, both driven by a declarative
+  `MLIPSpec` a model wrapper publishes as `distribution_spec`. Ewald, PME,
+  MACE, AIMNet2 and UMA ship specs; composed pipelines decompose per stage.
+  Energy, forces and stress agree with a single-GPU reference to fp32 rounding
+  under both strategies, eager and compiled. `nvalchemi.distributed.pin_fp32`
+  pins full-precision fp32 for runs that must match a reference, since TF32
+  makes distributed and single-process results diverge well beyond fp32 noise.
+
 - MACE training example for end-to-end model training workflows.
 - `EMAHook._build_averaged_model` override seam, so a caller that owns
   model sharding can supply a pre-built `AveragedModel` instead of the
@@ -84,6 +93,14 @@
 
 ### Fixed
 
+- **Ewald charge gradients and cell derivatives** — the reciprocal term was only
+  ever differentiated with respect to positions and charges, so a non-hybrid
+  Ewald returned a wrong `dE/dq`, and strain-autograd through the detached
+  Green's function gave a wrong stress. Work needing a cell derivative now
+  routes to the staged reciprocal.
+- **Ewald / PME strain cache** — cached k-vectors were rebuilt from the strained
+  cell, so a second stress evaluation reused the first call's autograd graph.
+
 - **Distributed dynamics lifecycle** — keep per-system integrator state aligned
   when pipeline receives and graduates systems, clear reusable communication
   buffers before every send without shrinking their segmented capacity, and run
@@ -126,6 +143,12 @@
   will be removed in a future release.
 
 ### Breaking Changes
+
+- `EwaldModelWrapper` and `PMEModelWrapper` now default to `hybrid_forces=False`.
+  The analytic direct-output path (`hybrid_forces=True`) does not produce
+  consistent gradients and is not supported under domain decomposition, where
+  `distribution_spec` rejects it. Forces and stress now come from autograd over
+  the energy; pass `hybrid_forces=True` explicitly to keep the old path.
 
 - Dataset-level explicit batch reads now use `load_batches(...)`. The raw
   `read_many(...)` API remains on readers, where storage backends can optimize

--- a/benchmark/distributed/README.md
+++ b/benchmark/distributed/README.md
@@ -6,7 +6,7 @@ model; a model is selected with `--config <model>.yaml`.
 
 | Runner | What it measures |
 | --- | --- |
-| `benchmark_dd_model_forward.py` | Single-GPU vs multi-GPU forward time, peak memory, and a single-vs-multi **force-equivalence** gate. |
+| `benchmark_dd_model_forward.py` | Single-GPU vs multi-GPU forward time, peak memory, and a single-vs-multi **energy / force / stress equivalence** gate. |
 | `benchmark_dd_nvt.py` | End-to-end NVT (`NVTLangevin`) step time across `world ∈ {0, 1, 2}`. |
 
 Shared timing, system builders, force-gathering, and the sweep drivers
@@ -25,6 +25,22 @@ the per-mode distribution knobs. Shipped configs:
 | `mace.yaml` | α-quartz SiO₂ supercell | ✓ | ✓ |
 | `aimnet2.yaml` | Methane (CH₄) packing | ✓ | ✓ |
 | `uma.yaml` | bcc iron supercell | ✓ | ✓ |
+| `pipeline_aimnet2_pme.yaml` | Methane packing, AIMNet2 → PME composed | ✓ | |
+
+### Equivalence gate
+
+Every config sets `forward.has_stress: true`, so the multi-GPU gate compares
+**energy, forces and stress** against the single-rank reference; all three must
+agree within `--tolerance`. Stress is the term most sensitive to a reduction
+bug — it is per-system, so an incorrectly reduced partial does not average out
+the way per-atom forces can.
+
+`pipeline_aimnet2_pme.yaml` runs a composed model through
+`DistributedPipelineModel` instead of `DistributedModel`. PME's energy depends
+on the charges AIMNet2 predicts, so the two share one autograd graph (a *wired*
+group) and the stress carries a cross-model chain term that a wiring bug drops
+silently. Add a composed benchmark by giving `loader.kind: pipeline` a list of
+ordinary loader specs under `loader.steps`.
 
 Override any config value for a one-off run with `--set` (dotted keys),
 no new file needed:
@@ -57,8 +73,10 @@ pools clean between modes):
 
 ```bash
 # world=0 (raw integrator)         python ... benchmark_dd_nvt.py --config ...
-# world=1 (DD wrapper, single rank) torchrun --nproc_per_node=1 ... benchmark_dd_nvt.py --config ...
-# world=2 (full DD)                 torchrun --nproc_per_node=2 ... benchmark_dd_nvt.py --config ...
+# world=1 (DD wrapper, single rank)
+#   torchrun --nproc_per_node=1 ... benchmark_dd_nvt.py --config ...
+# world=2 (full DD)
+#   torchrun --nproc_per_node=2 ... benchmark_dd_nvt.py --config ...
 python benchmark/distributed/benchmark_dd_nvt.py \
     --config benchmark/distributed/configs/aimnet2.yaml --sizes 500 2000
 ```

--- a/benchmark/distributed/_benchmark_common.py
+++ b/benchmark/distributed/_benchmark_common.py
@@ -688,8 +688,8 @@ def compare_forces(
     ``|ΔF|_max < tolerance``.
 
     Optional stress inputs report ``|Δσ|_max`` and ``|Δσ|_rms`` (in the
-    stress tensor's native units, typically eV/Å³). Stress diff does
-    not gate pass-fail — it's diagnostic-only.
+    stress tensor's native units, typically eV/Å³) and, when present,
+    gate pass-fail alongside forces and energy.
     """
     import math  # noqa: PLC0415
 
@@ -1981,12 +1981,43 @@ def _load_uma(device: torch.device, dtype: torch.dtype, lc: dict, **_: Any) -> A
     )
 
 
+def _load_pipeline(
+    device: torch.device, dtype: torch.dtype, lc: dict, *, compile_model: bool = False
+) -> Any:
+    """Compose ``loader.steps`` into a :class:`PipelineModelWrapper`.
+
+    Each step is an ordinary loader spec (its own ``kind``), so a composed
+    benchmark reuses the single-model loaders verbatim. ``active_outputs`` on a
+    step overrides that sub-model's outputs — the producer in a wired pipeline
+    has to emit the field the consumer reads (e.g. AIMNet2's ``charges`` feeding
+    PME). One group with ``use_autograd`` couples the steps.
+    """
+    from nvalchemi.models.pipeline import PipelineGroup, PipelineModelWrapper
+
+    steps = []
+    for step_cfg in lc["steps"]:
+        sub = LOADERS[step_cfg["kind"]](
+            device, dtype, step_cfg, compile_model=compile_model
+        )
+        if step_cfg.get("active_outputs"):
+            sub.model_config.active_outputs = set(step_cfg["active_outputs"])
+        steps.append(sub)
+
+    pipeline = PipelineModelWrapper(
+        groups=[PipelineGroup(steps=steps, use_autograd=lc.get("use_autograd", True))]
+    )
+    if lc.get("active_outputs"):
+        pipeline.model_config.active_outputs = set(lc["active_outputs"])
+    return pipeline
+
+
 LOADERS: dict[str, Callable[..., Any]] = {
     "lj": _load_lj,
     "electrostatic": _load_electrostatic,
     "mace": _load_mace,
     "aimnet2": _load_aimnet2,
     "uma": _load_uma,
+    "pipeline": _load_pipeline,
 }
 
 

--- a/benchmark/distributed/benchmark_dd_model_forward.py
+++ b/benchmark/distributed/benchmark_dd_model_forward.py
@@ -60,6 +60,7 @@ def make_forward_harness(cfg: BenchConfig, *, dd_compile: bool) -> Callable[...,
     """Build the ``build_harness`` callback for a forward benchmark config."""
     fwd = cfg.forward
     has_stress = fwd.get("has_stress", False)
+    is_pipeline = fwd.get("pipeline", False)
     upfront_halo = fwd.get("upfront_halo_exchange", True)
     dd_compile_capable = fwd.get("dd_compile_capable", False)
     cutoff_attr = fwd.get("cutoff_attr", "cutoff")
@@ -76,6 +77,12 @@ def make_forward_harness(cfg: BenchConfig, *, dd_compile: bool) -> Callable[...,
         mesh: Any = None,
     ) -> tuple[Callable, int, torch.Tensor, torch.Tensor, torch.Tensor, Any | None]:
         from nvalchemi.data import AtomicData, Batch
+
+        # ``has_stress`` gates the stress equivalence check, so the wrapper has to
+        # be asked for it.
+        if has_stress:
+            mc = wrapper.model_config
+            mc.active_outputs = set(mc.active_outputs) | {"stress"}
 
         system = build_system(cfg, n_atoms, dtype)
         n_actual = system.positions.shape[0]
@@ -130,10 +137,20 @@ def make_forward_harness(cfg: BenchConfig, *, dd_compile: bool) -> Callable[...,
         # ShardedBatch partition layout is kept consistent with it.
         strategy_kind, default_part_mode = resolve_strategy(cfg.system.strategy)
         domain_config = DomainConfig(cutoff=cutoff, mesh=mesh, strategy=strategy_kind)
-        # DD-compile (whole-forward compile over an eager model) is owned by
-        # DistributedModel and only offered by the compile-capable models.
-        dm_kwargs = {"compile": dd_compile} if dd_compile_capable else {}
-        dist_model = DistributedModel(wrapper, domain_config, **dm_kwargs)
+        if is_pipeline:
+            # A composed model decomposes over ONE shared owned partition built
+            # at the max sub-model cutoff; each sub-model then layers its own
+            # right-sized halo over it, so there is no single halo to pre-exchange.
+            from nvalchemi.distributed.distributed_pipeline import (
+                DistributedPipelineModel,
+            )
+
+            dist_model = DistributedPipelineModel(wrapper, domain_config)
+        else:
+            # DD-compile (whole-forward compile over an eager model) is owned by
+            # DistributedModel and only offered by the compile-capable models.
+            dm_kwargs = {"compile": dd_compile} if dd_compile_capable else {}
+            dist_model = DistributedModel(wrapper, domain_config, **dm_kwargs)
 
         full_batch = (
             Batch.from_data_list([_data(device)], device=device) if rank == 0 else None
@@ -145,8 +162,8 @@ def make_forward_harness(cfg: BenchConfig, *, dd_compile: bool) -> Callable[...,
             partition_mode=cfg.system.partition_mode or default_part_mode,
         )
         dist_model(sharded)  # warm lazy global-NL metadata
-        halo_cfg = dist_model._halo_config
-        needs_forces = dist_model._needs_forces()
+        halo_cfg = None if is_pipeline else dist_model._halo_config
+        needs_forces = False if is_pipeline else dist_model._needs_forces()
 
         def step_dist() -> tuple:
             # Halo-storage models that don't refresh internally need an upfront

--- a/benchmark/distributed/configs/aimnet2.yaml
+++ b/benchmark/distributed/configs/aimnet2.yaml
@@ -23,6 +23,7 @@ forward:
   upfront_halo_exchange: false   # per-layer ghost refresh happens inside the forward
   charge_zero: true              # neutral-molecule scalar charge
   dd_compile_capable: true
+  has_stress: true
 
 nvt:
   cutoff_attr: _cutoff

--- a/benchmark/distributed/configs/ewald.yaml
+++ b/benchmark/distributed/configs/ewald.yaml
@@ -21,3 +21,4 @@ forward:
   cutoff_attr: cutoff
   upfront_halo_exchange: true
   seed_force_energy: true
+  has_stress: true

--- a/benchmark/distributed/configs/lj.yaml
+++ b/benchmark/distributed/configs/lj.yaml
@@ -19,3 +19,4 @@ loader:
 forward:
   cutoff_attr: cutoff
   upfront_halo_exchange: true
+  has_stress: true

--- a/benchmark/distributed/configs/mace.yaml
+++ b/benchmark/distributed/configs/mace.yaml
@@ -25,6 +25,7 @@ forward:
   cutoff_attr: cutoff
   upfront_halo_exchange: true
   dd_compile_capable: true
+  has_stress: true
 
 nvt:
   cutoff_attr: cutoff

--- a/benchmark/distributed/configs/pipeline_aimnet2_pme.yaml
+++ b/benchmark/distributed/configs/pipeline_aimnet2_pme.yaml
@@ -1,0 +1,47 @@
+# AIMNet2 -> PME composed model under DistributedPipelineModel.
+#
+# The wired case: PME's energy depends on the charges AIMNet2 predicts, so the
+# two share one autograd graph and cannot run independently. The equivalence
+# gate covers energy, forces AND stress — stress is the term that carries the
+# cross-model chain (dE_pme/dq)(dq/d strain), so it is the one a wiring bug
+# silently drops.
+#
+# AIMNet2's warp kernels are float32-only, so the whole run is fp32. Methane
+# packing keeps the system organic (AIMNet2 is C/H/N/O) and charge-neutral.
+model: AIMNet2+PME
+dtype: fp32
+default_sizes: [500, 2000]
+
+system:
+  builder: build_methane_packing
+  sizing: null
+  pbc: true
+  charges: false
+  compute_neighbors: true
+
+loader:
+  kind: pipeline
+  use_autograd: true            # coupled group: PME consumes AIMNet2's charges
+  active_outputs: [energy, forces, stress]
+  steps:
+    - kind: aimnet2
+      checkpoint: aimnet2
+      compile: false
+      # ``charges`` is the wired field PME reads; stress must be active so the
+      # composite derives it.
+      active_outputs: [energy, forces, stress, charges]
+    - kind: electrostatic
+      module: nvalchemi.models.pme
+      class: PMEModelWrapper
+      cutoff: 6.0
+      hybrid_forces: false
+      active_outputs: [energy, forces, stress]
+
+forward:
+  pipeline: true
+  # The synthesized pipeline neighbor plan carries the max sub-model cutoff, so
+  # the one shared partition holds every sub-model's ghost layer.
+  cutoff_attr: model_config.neighbor_config.cutoff
+  upfront_halo_exchange: false   # each sub-model builds its own halo
+  charge_zero: true              # neutral-molecule scalar charge
+  has_stress: true

--- a/benchmark/distributed/configs/pme.yaml
+++ b/benchmark/distributed/configs/pme.yaml
@@ -21,3 +21,4 @@ forward:
   cutoff_attr: cutoff
   upfront_halo_exchange: true
   seed_force_energy: true
+  has_stress: true

--- a/docs/userguide/distributed.md
+++ b/docs/userguide/distributed.md
@@ -168,7 +168,7 @@ The strategy is declared on the model's
 | `SPEC_EWALD_HALO` | halo, with custom-op adapters for reciprocal-space | Ewald |
 | `SPEC_PME_HALO` | halo, with custom-op adapters for charge spreading | PME |
 | `SPEC_DFTD3_HALO` | halo, standard energy/force outputs | DFTD3 dispersion |
-| `SPEC_MPNN_GP` | graph-partition (node partition + per-layer feature all-gather) | MACE / generic MPNN, graph-parallel |
+| `SPEC_MPNN_GP` | graph-partition (node partition + per-layer feature all-gather) | generic MPNN, graph-parallel |
 
 If your model fits one of these patterns, the preset is a one-line
 declaration on your wrapper's `distribution_spec` property. If it
@@ -337,6 +337,41 @@ cuEquivariance), AIMNet2, and UMA wrappers all support it; a BYO model
 opts in by declaring a
 {py:class}`~nvalchemi.distributed.CompilePolicy` on its spec (see
 {doc}`distributed_byo`).
+
+## Matching a single-process reference
+
+A distributed forward and a single-process one do the same arithmetic on
+differently shaped tensors: the distributed one carries ghost rows, and under
+compile it pads to fixed capacities. On Ampere and newer, fp32 matmul and
+convolution may run on the reduced-precision tensor-core path (TF32), and the
+backend can select a reduced-precision kernel for one shape and a
+full-precision kernel for the other. The two results then separate by much more
+than fp32 rounding, and the gap is largest for matmul-heavy models.
+
+This is not specific to decomposition: two single-process runs with different
+batch padding diverge the same way. Decomposition is simply where it becomes
+visible, because it always changes the shapes.
+
+The framework does not change the precision regime for you — reduced precision
+is a deliberate speed/accuracy trade, and worth keeping when a run does not need
+to reproduce a reference. It does warn once when a distributed scope opens with
+reduced precision in force. When a run *does* have to agree with a
+single-process reference, or with a different rank count, pin it before building
+models:
+
+```python
+from nvalchemi.distributed import pin_fp32
+
+pin_fp32()  # before constructing models, and before any CUDA context exists
+```
+
+`pin_fp32` also sets `NVIDIA_TF32_OVERRIDE=0`, which is what reaches ranks
+started by `torchrun` or `mp.spawn`: those re-import torch with default settings
+but inherit the environment. Note that neither pinning nor anything else makes
+distributed and single-process results bitwise identical — cross-rank reduction
+order differs — so equivalence is always to a tolerance, and pinning is what
+keeps that tolerance at the fp32 noise floor rather than orders of magnitude
+above it.
 
 ## Distributed dynamics
 

--- a/nvalchemi/data/batch.py
+++ b/nvalchemi/data/batch.py
@@ -179,6 +179,34 @@ def _build_batch_storage(
     return storage, tracked_keys
 
 
+def set_transient(batch: "Batch", name: str, value: torch.Tensor) -> None:
+    """Overlay *value* on *batch* for the duration of a computation.
+
+    :meth:`Batch.__setattr__` routes a tensor into the batch's storage, which is
+    what ``.to()``, gathering and any rebuild of the batch read back. That is the
+    wrong lifetime for a value a single forward should see and no later reader
+    should inherit — an affine strain applied for one autograd pass, say, which
+    a rebuild would otherwise apply a second time on top of the first.
+
+    This writes an instance attribute instead, which shadows the storage
+    delegation for attribute reads while leaving the stored tensor untouched.
+
+    Parameters
+    ----------
+    batch : Batch
+        Batch to overlay.
+    name : str
+        Attribute the computation will read.
+    value : torch.Tensor
+        Value to expose.
+
+    Returns
+    -------
+    None
+    """
+    object.__setattr__(batch, name, value)
+
+
 class Batch(DataMixin):
     """Graph-aware batch built on :class:`MultiLevelStorage`.
 

--- a/nvalchemi/distributed/__init__.py
+++ b/nvalchemi/distributed/__init__.py
@@ -109,6 +109,7 @@ def __getattr__(name: str):  # noqa: ANN201
             "SpatialPartitioner",
         ),
         "DomainParallel": ("nvalchemi.distributed.domain_parallel", "DomainParallel"),
+        "pin_fp32": ("nvalchemi.distributed._runtime", "pin_fp32"),
         "DistributedModel": (
             "nvalchemi.distributed.distributed_model",
             "DistributedModel",
@@ -230,6 +231,7 @@ __all__ = [
     "OutputKind",
     "OutputSpec",
     "ParticleHaloConfig",
+    "pin_fp32",
     "PythonAdapter",
     "Reduce",
     "Scope",

--- a/nvalchemi/distributed/_core/adapter.py
+++ b/nvalchemi/distributed/_core/adapter.py
@@ -549,38 +549,49 @@ _OUTPUT_TRANSFORM_REGISTRY: dict[str, type] = {
 }
 
 
-def _arg_transform_to_dict(t: ArgTransform) -> dict[str, Any]:
-    for kind, cls in _ARG_TRANSFORM_REGISTRY.items():
+def _transform_to_dict(t: Any, registry: dict[str, type], label: str) -> dict[str, Any]:
+    """Encode a transform as its registry name plus its dataclass fields.
+
+    The fields are carried generically rather than per-class: a transform field
+    that changes behaviour — an adjoint rule, say — would otherwise revert to its
+    default on the far side of a process boundary while the name still matched.
+    """
+    import dataclasses  # noqa: PLC0415
+
+    for kind, cls in registry.items():
         if isinstance(t, cls):
-            return {"type": kind}
-    raise TypeError(f"unknown ArgTransform: {type(t).__name__}")
+            encoded = {"type": kind}
+            encoded.update(dataclasses.asdict(t))
+            return encoded
+    raise TypeError(f"unknown {label}: {type(t).__name__}")
+
+
+def _transform_from_dict(
+    d: dict[str, Any], registry: dict[str, type], label: str
+) -> Any:
+    """Inverse of :func:`_transform_to_dict`."""
+    cls = registry.get(d.get("type"))
+    if cls is None:
+        raise ValueError(
+            f"unknown {label} type {d.get('type')!r}; expected one of {list(registry)}."
+        )
+    return cls(**{k: v for k, v in d.items() if k != "type"})
+
+
+def _arg_transform_to_dict(t: ArgTransform) -> dict[str, Any]:
+    return _transform_to_dict(t, _ARG_TRANSFORM_REGISTRY, "ArgTransform")
 
 
 def _arg_transform_from_dict(d: dict[str, Any]) -> ArgTransform:
-    cls = _ARG_TRANSFORM_REGISTRY.get(d.get("type"))
-    if cls is None:
-        raise ValueError(
-            f"unknown ArgTransform type {d.get('type')!r}; expected one of "
-            f"{list(_ARG_TRANSFORM_REGISTRY)}."
-        )
-    return cls()
+    return _transform_from_dict(d, _ARG_TRANSFORM_REGISTRY, "ArgTransform")
 
 
 def _output_transform_to_dict(t: OutputTransform) -> dict[str, Any]:
-    for kind, cls in _OUTPUT_TRANSFORM_REGISTRY.items():
-        if isinstance(t, cls):
-            return {"type": kind}
-    raise TypeError(f"unknown OutputTransform: {type(t).__name__}")
+    return _transform_to_dict(t, _OUTPUT_TRANSFORM_REGISTRY, "OutputTransform")
 
 
 def _output_transform_from_dict(d: dict[str, Any]) -> OutputTransform:
-    cls = _OUTPUT_TRANSFORM_REGISTRY.get(d.get("type"))
-    if cls is None:
-        raise ValueError(
-            f"unknown OutputTransform type {d.get('type')!r}; expected one of "
-            f"{list(_OUTPUT_TRANSFORM_REGISTRY)}."
-        )
-    return cls()
+    return _transform_from_dict(d, _OUTPUT_TRANSFORM_REGISTRY, "OutputTransform")
 
 
 # ----------------------------------------------------------------------

--- a/nvalchemi/distributed/_core/adapter.py
+++ b/nvalchemi/distributed/_core/adapter.py
@@ -119,6 +119,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, Sequence
 
@@ -360,6 +361,19 @@ class OpAdapter:
         )
 
     @property
+    def all_reduce_replicated_outputs(self) -> tuple[int, ...]:
+        """Subset of :attr:`all_reduce_outputs` whose reduced value feeds a
+        replicated whole-system computation, so the adjoint passes the incoming
+        gradient through instead of reducing it again."""
+        return tuple(
+            sorted(
+                p
+                for p, t in self.output_transforms.items()
+                if isinstance(t, AllReduceSum) and t.replicated_consumer
+            )
+        )
+
+    @property
     def slice_outputs_owned(self) -> tuple[int, ...]:
         return tuple(
             sorted(
@@ -404,6 +418,7 @@ class OpAdapter:
             scatter_outputs=self.scatter_outputs,
             owned_slice_inputs=self.owned_slice_inputs,
             all_reduce_outputs=self.all_reduce_outputs,
+            all_reduce_replicated_outputs=self.all_reduce_replicated_outputs,
             gather_inputs_full=self.gather_inputs_full,
             slice_outputs_owned=self.slice_outputs_owned,
         )
@@ -1278,24 +1293,39 @@ def _replacement_qualname(fn: Callable | None) -> str | None:
 
 def _resolve_replacement(qualname: str | None) -> Callable | None:
     """Inverse of :func:`_replacement_qualname`. Best-effort: returns
-    ``None`` if the qualname doesn't resolve."""
-    if not qualname or ":" not in qualname:
-        return None
-    import importlib  # noqa: PLC0415
+    ``None`` if the qualname doesn't resolve.
 
-    mod_path, qual = qualname.split(":", 1)
-    try:
-        mod = importlib.import_module(mod_path)
-    except Exception:
+    An unresolved replacement installs as a no-op, so the model silently runs
+    uncorrected; that case warns and the caller is expected to rebind from a
+    live spec.
+    """
+    if not qualname:
         return None
-    obj: Any = mod
-    for part in qual.split("."):
-        if part.startswith("<"):
-            return None
-        obj = getattr(obj, part, None)
-        if obj is None:
-            return None
-    return obj
+    resolved = None
+    if ":" in qualname:
+        import importlib  # noqa: PLC0415
+
+        mod_path, qual = qualname.split(":", 1)
+        try:
+            obj: Any = importlib.import_module(mod_path)
+        except Exception:
+            obj = None
+        for part in qual.split(".") if obj is not None else ():
+            if part.startswith("<"):
+                obj = None
+                break
+            obj = getattr(obj, part, None)
+            if obj is None:
+                break
+        resolved = obj
+    if resolved is None:
+        warnings.warn(
+            f"Adapter replacement {qualname!r} did not resolve; the adapter will "
+            "install as a no-op. Rebind it from a live spec before use.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return resolved
 
 
 # Registry mapping serialized "kind" → adapter class. Subclasses that

--- a/nvalchemi/distributed/_core/escape_hatches.py
+++ b/nvalchemi/distributed/_core/escape_hatches.py
@@ -168,6 +168,7 @@ def wrap_custom_op(
     scatter_outputs: Sequence[int] = (),
     owned_slice_inputs: Sequence[int] = (),
     all_reduce_outputs: Sequence[int] = (),
+    all_reduce_replicated_outputs: Sequence[int] = (),
     gather_inputs_full: Sequence[int] = (),
     slice_outputs_owned: Sequence[int] = (),
 ) -> None:
@@ -190,7 +191,8 @@ def wrap_custom_op(
        rows hold owner values.
     5. ``all_reduce_outputs``: all-reduce each per-rank partial across
        the domain mesh into a globally-summed tensor replicated on every
-       rank. Backward is symmetric.
+       rank. Backward is symmetric unless the index is also listed in
+       ``all_reduce_replicated_outputs``.
 
     Sharded storage (source has ``_gather_meta``):
 
@@ -228,6 +230,13 @@ def wrap_custom_op(
         Halo storage. Positional indices of return values that are
         per-rank partials needing a global SUM all-reduce across the
         domain mesh.
+    all_reduce_replicated_outputs
+        Subset of ``all_reduce_outputs`` whose reduced value feeds a
+        computation every rank runs identically over the whole system, so
+        the gradient arriving in backward is already global. Their adjoint
+        passes that gradient through; the rest keep the symmetric adjoint,
+        which is what a value folded into each rank's own owned-atom
+        expression needs.
     gather_inputs_full
         Sharded storage. Positional indices of ``[n_owned + 1, *F]``
         ShardTensor args whose contents must be made globally available
@@ -510,6 +519,7 @@ def wrap_custom_op(
                 distributed_all_reduce,
             )
 
+            replicated = frozenset(all_reduce_replicated_outputs)
             for idx in all_reduce_outputs:
                 partial = result_list[idx]
                 if not isinstance(partial, torch.Tensor):
@@ -517,7 +527,9 @@ def wrap_custom_op(
                         f"wrap_custom_op all_reduce_output at index {idx} is "
                         f"{type(partial).__name__}, expected Tensor."
                     )
-                result_list[idx] = distributed_all_reduce(partial, config)
+                result_list[idx] = distributed_all_reduce(
+                    partial, config, identity_adjoint=idx in replicated
+                )
 
         if is_tracing():
             branches = []

--- a/nvalchemi/distributed/_core/gather_primitives.py
+++ b/nvalchemi/distributed/_core/gather_primitives.py
@@ -1458,6 +1458,7 @@ class _DistributedAllReduceSum(torch.autograd.Function):
     def forward(  # type: ignore[override]
         tensor: torch.Tensor,
         config: "ParticleHaloConfig",
+        identity_adjoint: bool = False,
     ) -> torch.Tensor:
         # Separate forward + setup_context (no ctx) for AOT-traceability.
         if dist.is_initialized():
@@ -1466,23 +1467,31 @@ class _DistributedAllReduceSum(torch.autograd.Function):
 
     @staticmethod
     def setup_context(ctx: Any, inputs: tuple, output: torch.Tensor) -> None:
-        _tensor, config = inputs
+        _tensor, config, identity_adjoint = inputs
         ctx.config = config
+        ctx.identity_adjoint = identity_adjoint
 
     @staticmethod
     def backward(ctx: Any, grad_out: torch.Tensor) -> tuple[Any, ...]:
+        if ctx.identity_adjoint:
+            # The symmetric adjoint is only correct when ``grad_out`` is this
+            # rank's own downstream partial. When the output feeds a consumer
+            # that is itself all-reduced, ``grad_out`` already holds every
+            # rank's contribution and reducing again multiplies by world size.
+            return grad_out.contiguous().clone(), None, None
         if dist.is_initialized():
             grad = funcol_all_reduce(grad_out.contiguous(), ctx.config.mesh)
         else:
             grad = grad_out.contiguous().clone()
-        # (tensor, config)
-        return grad, None
+        # (tensor, config, identity_adjoint)
+        return grad, None, None
 
 
 def distributed_all_reduce(
     tensor: torch.Tensor,
     config: "ParticleHaloConfig",
     op: dist.ReduceOp = dist.ReduceOp.SUM,
+    identity_adjoint: bool = False,
 ) -> torch.Tensor:
     """Autograd-aware SUM all-reduce across ``config.mesh``.
 
@@ -1523,4 +1532,25 @@ def distributed_all_reduce(
             f"distributed_all_reduce op={op} not implemented; only SUM is "
             "currently wired."
         )
-    return _DistributedAllReduceSum.apply(tensor, config)
+    return _DistributedAllReduceSum.apply(tensor, config, identity_adjoint)
+
+
+def all_reduce_sum_over_mesh(tensor: Any, mesh: Any) -> Any:
+    """Sum *tensor* across *mesh*'s process group, in place.
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        Per-rank partial to reduce.
+    mesh : DeviceMesh
+        Mesh whose group the reduction runs on.
+
+    Returns
+    -------
+    torch.Tensor
+        *tensor*, reduced across the group (unchanged single-process).
+    """
+    if not dist.is_initialized():
+        return tensor
+    dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=mesh_group(mesh))
+    return tensor

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -62,23 +62,47 @@ class ParticleHaloConfig:
     partitioner: Any  # SpatialPartitioner at runtime
     mesh: Any  # DeviceMesh at runtime
 
-    # Computed in __post_init__
+    # Computed on demand; see the topology properties below.
     rank: int = field(init=False)
-    neighbor_ranks: list[int] = field(init=False)
-    _pbc_images: dict[tuple[int, int], list[torch.Tensor]] = field(
-        init=False, repr=False
-    )
+    _topology: dict[str, Any] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         try:
             self.rank = self.mesh.get_local_rank()
         except Exception:
             self.rank = 0
+        self._topology = {}
 
-        self.neighbor_ranks = [
-            r for r in self.partitioner.get_neighbor_ranks(self.rank) if r != self.rank
-        ]
-        self._pbc_images = _compute_pbc_image_vectors(self.partitioner)
+    def _current_topology(self) -> dict[str, Any]:
+        """Peer list and lattice images for the partitioner's current geometry.
+
+        Derived rather than stored: a barostat contraction narrows every domain,
+        which can widen the ghost shell onto ranks further away, and a copy taken
+        at construction would keep exchanging with the old peers. Recomputed only
+        when the partitioner reports a new topology.
+        """
+        version = self.partitioner.topology_version
+        if self._topology.get("version") != version:
+            self._topology = {
+                "version": version,
+                "neighbor_ranks": [
+                    r
+                    for r in self.partitioner.get_neighbor_ranks(self.rank)
+                    if r != self.rank
+                ],
+                "pbc_images": _compute_pbc_image_vectors(self.partitioner),
+            }
+        return self._topology
+
+    @property
+    def neighbor_ranks(self) -> list[int]:
+        """Ranks this one exchanges ghosts with, for the current geometry."""
+        return self._current_topology()["neighbor_ranks"]
+
+    @property
+    def _pbc_images(self) -> dict[tuple[int, int], list[torch.Tensor]]:
+        """Lattice images offered per rank pair, for the current geometry."""
+        return self._current_topology()["pbc_images"]
 
     @property
     def pbc_shifts(

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -119,7 +119,10 @@ def _compute_pbc_image_vectors(
     cell_matrix = partitioner.cell_matrix
     pbc = partitioner.pbc
     grid = partitioner.rank_grid
-    span = getattr(partitioner, "neighbor_span", lambda: (1, 1, 1))()
+    # No fallback: a partitioner without a span cannot describe how far its
+    # ghost shell reaches, and silently assuming one domain is the very
+    # under-send this function exists to prevent.
+    span = partitioner.neighbor_span()
 
     total_ranks = grid[0] * grid[1] * grid[2]
     for sender_rank in range(total_ranks):

--- a/nvalchemi/distributed/_core/halo_types.py
+++ b/nvalchemi/distributed/_core/halo_types.py
@@ -25,6 +25,7 @@ directly.
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -106,13 +107,19 @@ def _compute_pbc_image_vectors(
 
     Returns ``{(sender, receiver): [image_1, image_2, ...]}`` where each
     ``(3,)`` image contains integer-valued fractional lattice coefficients.
-    For a diagonal neighbor crossing D periodic boundaries there are
-    ``2^D - 1`` independent images (all non-empty subsets of crossed dims).
+
+    A ghost shell wider than one domain reaches the same neighbor from both
+    sides of a periodic axis, and the two sides are different lattice images of
+    that neighbor holding different atoms. The offsets the shell actually spans
+    are therefore enumerated per axis rather than only the outermost pair; an
+    offset that needs no wrap is the direct (unshifted) copy the caller handles
+    separately, so only wrapping offsets appear here.
     """
     images: dict[tuple[int, int], list[torch.Tensor]] = {}
     cell_matrix = partitioner.cell_matrix
     pbc = partitioner.pbc
     grid = partitioner.rank_grid
+    span = getattr(partitioner, "neighbor_span", lambda: (1, 1, 1))()
 
     total_ranks = grid[0] * grid[1] * grid[2]
     for sender_rank in range(total_ranks):
@@ -120,36 +127,42 @@ def _compute_pbc_image_vectors(
         for receiver_rank in partitioner.get_neighbor_ranks(sender_rank):
             receiver_coords = partitioner.rank_to_grid_coords(receiver_rank)
 
-            per_dim_images: list[torch.Tensor] = []
+            # Per axis: which lattice translations reach this receiver at all.
+            axis_choices: list[tuple[int, list[int]]] = []
             for dim in range(3):
                 if not pbc[dim] or grid[dim] <= 1:
                     continue
-                dim_image = torch.zeros(
-                    3, device=cell_matrix.device, dtype=cell_matrix.dtype
-                )
-                if sender_coords[dim] == grid[dim] - 1 and receiver_coords[dim] == 0:
-                    dim_image[dim] = -1
-                elif sender_coords[dim] == 0 and receiver_coords[dim] == grid[dim] - 1:
-                    dim_image[dim] = 1
-                else:
-                    continue
-                per_dim_images.append(dim_image)
+                coefficients: set[int] = set()
+                for offset in range(-int(span[dim]), int(span[dim]) + 1):
+                    stepped = sender_coords[dim] + offset
+                    if stepped % grid[dim] != receiver_coords[dim]:
+                        continue
+                    # Exact: ``stepped - receiver`` is a whole number of grids.
+                    crossings = (stepped - receiver_coords[dim]) // grid[dim]
+                    if crossings != 0:
+                        coefficients.add(-crossings)
+                if coefficients:
+                    axis_choices.append((dim, sorted(coefficients)))
 
-            if not per_dim_images:
+            if not axis_choices:
                 continue
 
-            n = len(per_dim_images)
+            # A neighbor across several axes needs every combination of their
+            # translations; the all-zero one is the direct copy.
             combo_images: list[torch.Tensor] = []
-            for mask in range(1, 1 << n):
+            dims = [dim for dim, _ in axis_choices]
+            for choice in itertools.product(*([0, *c] for _, c in axis_choices)):
+                if not any(choice):
+                    continue
                 combo = torch.zeros(
                     3, device=cell_matrix.device, dtype=cell_matrix.dtype
                 )
-                for bit in range(n):
-                    if mask & (1 << bit):
-                        combo = combo + per_dim_images[bit]
+                for dim, coefficient in zip(dims, choice):
+                    combo[dim] = coefficient
                 combo_images.append(combo)
 
-            images[(sender_rank, receiver_rank)] = combo_images
+            if combo_images:
+                images[(sender_rank, receiver_rank)] = combo_images
 
     return images
 

--- a/nvalchemi/distributed/_core/op_transforms.py
+++ b/nvalchemi/distributed/_core/op_transforms.py
@@ -105,11 +105,28 @@ class AllReduceSum:
     """Sum the output's per-rank partial across the mesh via
     :func:`distributed_all_reduce`.
 
-    Backward is symmetric (the all-reduce is its own adjoint), so this
-    plugs cleanly into autograd. Pair with :class:`SliceOwned` on the
-    input side — slice ensures each atom contributes once locally;
-    AllReduceSum collects partials into a globally-correct result.
+    Pair with :class:`SliceOwned` on the input side — slice ensures each
+    atom contributes once locally; AllReduceSum collects partials into a
+    globally-correct result.
+
+    Parameters
+    ----------
+    replicated_consumer : bool, default False
+        Whether the gradient arriving at this node in backward is already the
+        global sum. ``False`` (the default) means it is this rank's partial and
+        the adjoint sums across ranks — the all-reduce is its own adjoint.
+        ``True`` means every rank already holds the same gradient, so reducing
+        again would multiply it by the world size.
+
+        This is a property of how the reduced value is consumed downstream, and
+        it is measurable: capture ``grad_out`` in
+        ``_DistributedAllReduceSum.backward`` and compare it across ranks. On
+        PME's eager path the charge mesh's incoming gradient is bit-identical on
+        every rank (hence ``True`` there), while the total charge's differs
+        (hence the default). Do not infer it — measure it.
     """
+
+    replicated_consumer: bool = False
 
 
 @dataclass(frozen=True)

--- a/nvalchemi/distributed/_runtime.py
+++ b/nvalchemi/distributed/_runtime.py
@@ -16,9 +16,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import warnings
+from collections.abc import Iterator
+from typing import Any
 
 import torch
 from physicsnemo.distributed import (
@@ -109,10 +112,58 @@ def pin_fp32() -> None:
             try:
                 holder.fp32_precision = "ieee"
             except Exception:  # pragma: no cover - varies by torch version
-                logger.debug("could not set fp32_precision", exc_info=True)
+                # Non-fatal: the primary flags above already pin precision, and
+                # this attribute only exists on some torch versions.
+                logger.warning("could not set fp32_precision", exc_info=True)
 
 
-def _is_reduced_precision(device: "Any" = None) -> bool:
+@contextlib.contextmanager
+def pinned_fp32() -> Iterator[None]:
+    """Pin full-precision fp32 for the duration of the block, then restore.
+
+    The scoped counterpart to :func:`pin_fp32`, for callers that need one
+    comparison at full precision without changing the rest of the process.
+    Prefer :func:`pin_fp32` for a whole run: it also sets the environment
+    variable that ``mp.spawn`` / ``torchrun`` workers inherit, and restoring
+    that on exit would unpin the workers.
+
+    Yields
+    ------
+    None
+    """
+    saved: list[tuple[Any, str, Any]] = [
+        (
+            torch.backends.cuda.matmul,
+            "allow_tf32",
+            torch.backends.cuda.matmul.allow_tf32,
+        ),
+        (torch.backends.cudnn, "allow_tf32", torch.backends.cudnn.allow_tf32),
+    ]
+    saved.extend(
+        (holder, "fp32_precision", holder.fp32_precision)
+        for holder in (torch.backends.cuda.matmul, torch.backends.cudnn)
+        if hasattr(holder, "fp32_precision")
+    )
+    # Reading the global precision raises once legacy (``allow_tf32``) and new
+    # (``fp32_precision``) APIs have both been written, which ``pin_fp32`` does.
+    try:
+        saved_precision = torch.get_float32_matmul_precision()
+    except RuntimeError:  # pragma: no cover - depends on prior calls
+        saved_precision = None
+    try:
+        pin_fp32()
+        yield
+    finally:
+        for holder, attr, value in saved:
+            try:
+                setattr(holder, attr, value)
+            except Exception:  # pragma: no cover - varies by torch version
+                logger.warning("could not restore %s", attr, exc_info=True)
+        if saved_precision is not None:
+            torch.set_float32_matmul_precision(saved_precision)
+
+
+def _is_reduced_precision(device: str | torch.device | None = None) -> bool:
     """Whether fp32 matmul currently runs on the reduced-precision path.
 
     Measured rather than read off the backend flags: which kernel runs depends on
@@ -132,7 +183,9 @@ def _is_reduced_precision(device: "Any" = None) -> bool:
     return err > _REDUCED_PRECISION_THRESHOLD
 
 
-def warn_if_reduced_precision(device: "Any" = None) -> None:
+def warn_if_reduced_precision(
+    device: str | torch.device | None = None,
+) -> None:
     """Warn once per process if reduced-precision fp32 is in force."""
     global _warned_reduced_precision
     if _warned_reduced_precision or not torch.cuda.is_available():

--- a/nvalchemi/distributed/_runtime.py
+++ b/nvalchemi/distributed/_runtime.py
@@ -16,7 +16,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import warnings
 
 import torch
 from physicsnemo.distributed import (
@@ -24,6 +26,8 @@ from physicsnemo.distributed import (
     PhysicsNeMoUninitializedDistributedManagerWarning,
 )
 from torch import distributed as dist
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "DistributedManager",
@@ -75,3 +79,72 @@ def collective_device(fallback: torch.device | str = "cpu") -> torch.device:
     if device.type == "cuda" and not torch.cuda.is_available():
         return torch.device("cpu")
     return device
+
+
+# Full-precision fp32 lands far below this; reduced precision far above.
+_REDUCED_PRECISION_THRESHOLD = 1e-5
+_warned_reduced_precision = False
+
+
+def pin_fp32() -> None:
+    """Force full-precision fp32 matmul and convolution.
+
+    A distributed forward pads to different shapes than a single-process one, so
+    under reduced-precision fp32 (TF32) the backend can pick a different kernel
+    for each and the results separate by far more than fp32 rounding. Also sets
+    ``NVIDIA_TF32_OVERRIDE``, which is what reaches ``mp.spawn`` / ``torchrun``
+    workers — they inherit the environment, not the torch flags. Call before the
+    process builds a CUDA context.
+
+    Returns
+    -------
+    None
+    """
+    os.environ.setdefault("NVIDIA_TF32_OVERRIDE", "0")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    torch.set_float32_matmul_precision("highest")
+    for holder in (torch.backends.cuda.matmul, torch.backends.cudnn):
+        if hasattr(holder, "fp32_precision"):
+            try:
+                holder.fp32_precision = "ieee"
+            except Exception:  # pragma: no cover - varies by torch version
+                logger.debug("could not set fp32_precision", exc_info=True)
+
+
+def _is_reduced_precision(device: "Any" = None) -> bool:
+    """Whether fp32 matmul currently runs on the reduced-precision path.
+
+    Measured rather than read off the backend flags: which kernel runs depends on
+    torch version, backend and shape.
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        gen = torch.Generator(device="cpu").manual_seed(0)
+        a = torch.randn(512, 512, generator=gen).to(device or "cuda")
+        b = torch.randn(512, 512, generator=gen).to(device or "cuda")
+        ref = a.double() @ b.double()
+        err = (((a @ b).double() - ref).abs().max() / ref.abs().max()).item()
+    except Exception:  # pragma: no cover - a probe must not break a forward
+        logger.debug("fp32 precision probe failed", exc_info=True)
+        return False
+    return err > _REDUCED_PRECISION_THRESHOLD
+
+
+def warn_if_reduced_precision(device: "Any" = None) -> None:
+    """Warn once per process if reduced-precision fp32 is in force."""
+    global _warned_reduced_precision
+    if _warned_reduced_precision or not torch.cuda.is_available():
+        return
+    _warned_reduced_precision = True
+    if not _is_reduced_precision(device):
+        return
+    warnings.warn(
+        "Reduced-precision fp32 (TF32) is enabled; distributed and "
+        "single-process results can then differ by much more than fp32 rounding. "
+        "Call nvalchemi.distributed.pin_fp32() before building models if this "
+        "run must match a reference.",
+        UserWarning,
+        stacklevel=3,
+    )

--- a/nvalchemi/distributed/compile_bridge.py
+++ b/nvalchemi/distributed/compile_bridge.py
@@ -248,6 +248,11 @@ def _consolidate_node_energy(node_e: Any, batch: Any, n_graphs: int) -> Any:
     node_e_local = node_e.to_local() if hasattr(node_e, "to_local") else node_e
     ctx = current_dd_context()
     if ctx.is_halo and node_e_local.shape[0] > ctx.n_owned:
-        return system_sum(node_e_local, batch, n_graphs, scope=Scope.OWNED)
-    energy = torch.zeros(n_graphs, dtype=node_e_local.dtype, device=node_e_local.device)
-    return energy.index_add_(0, batch, node_e_local)
+        energy = system_sum(node_e_local, batch, n_graphs, scope=Scope.OWNED)
+    else:
+        energy = torch.zeros(
+            n_graphs, dtype=node_e_local.dtype, device=node_e_local.device
+        ).index_add_(0, batch, node_e_local)
+    # Wrappers emit per-system energy as ``[B, 1]``; match it so a distributed
+    # result is shaped like a single-process one.
+    return energy.reshape(n_graphs, 1)

--- a/nvalchemi/distributed/distributed_model.py
+++ b/nvalchemi/distributed/distributed_model.py
@@ -51,8 +51,8 @@ from nvalchemi.neighbors import compute_neighbors
 
 if TYPE_CHECKING:
     from nvalchemi.distributed.sharded_batch import ShardedBatch
-    from nvalchemi.models.base import BaseModelMixin
-
+from nvalchemi.models._utils import prepare_strain
+from nvalchemi.models.base import BaseModelMixin
 
 __all__ = ["DistributedModel", "DistributionError"]
 
@@ -165,6 +165,12 @@ def _prepare_dd_compile(spec: "Any", compile_kwargs: "dict | None") -> dict:
         import torch._functorch.config as _fcfg  # noqa: PLC0415
 
         _fcfg.activation_memory_budget = float(_actb)
+    # A wired consumer backwards through this graph twice; AOT's donated-buffer
+    # optimisation frees buffers the second pass needs.
+    import torch._functorch.config as _fcfg2  # noqa: PLC0415
+
+    _fcfg2.donated_buffer = False
+
     ck = dict(compile_kwargs or {})
     ck.setdefault("dynamic", False)
     return ck
@@ -182,19 +188,42 @@ def _wrapper_is_precompiled(wrapper: "Any") -> bool:
     the message-passing ops sealed inside the loader's compiled graph, so every
     rank returns an uncorrected owned-only forward.
     """
-    modules = getattr(wrapper, "modules", None)
-    if not callable(modules):
-        return False
     try:
         from torch._dynamo.eval_frame import OptimizedModule  # noqa: PLC0415
     except Exception:  # pragma: no cover - torch internal layout changed
         OptimizedModule = None
-    for m in modules():
-        if OptimizedModule is not None and isinstance(m, OptimizedModule):
+
+    def _is_optimized(obj: "Any") -> bool:
+        if OptimizedModule is not None and isinstance(obj, OptimizedModule):
             return True
-        if type(m).__name__ == "OptimizedModule":
-            return True
-    return False
+        return type(obj).__name__ == "OptimizedModule"
+
+    modules = getattr(wrapper, "modules", None)
+    if callable(modules):
+        for m in modules():
+            if _is_optimized(m):
+                return True
+    # The compiled module need not sit in the ``nn.Module`` tree — a wrapper may
+    # hold it on a plain helper object — so also scan non-Module attributes.
+    seen: set[int] = set()
+
+    def _scan(obj: "Any", depth: int) -> bool:
+        if depth < 0 or id(obj) in seen:
+            return False
+        seen.add(id(obj))
+        state = getattr(obj, "__dict__", None)
+        if not isinstance(state, dict):
+            return False
+        for value in state.values():
+            if _is_optimized(value):
+                return True
+            if isinstance(value, torch.nn.Module):
+                continue  # already covered by the tree walk
+            if hasattr(value, "__dict__") and _scan(value, depth - 1):
+                return True
+        return False
+
+    return _scan(wrapper, 2)
 
 
 def _partition_health_verdict(
@@ -567,6 +596,12 @@ class DistributedModel:
         # recompiles under DD and needs the raised ceiling + cross-rank-safe caches
         # (see :func:`_configure_dd_dynamo`). A no-op when nothing compiles.
         _configure_dd_dynamo()
+        # Reduced-precision fp32 breaks DD/single-process agreement; say so once.
+        from nvalchemi.distributed._runtime import (
+            warn_if_reduced_precision,  # noqa: PLC0415
+        )
+
+        warn_if_reduced_precision()
         # Fixed-shape graph padder for the compiled halo path. A model may
         # declare a custom padder via its CompilePolicy; the default is the
         # generic COO ``edge_index`` padder, so a standard MPNN declares nothing.
@@ -1019,6 +1054,19 @@ class DistributedModel:
         pos = atoms["positions"].detach().requires_grad_(True)
         atoms["positions"] = pos
 
+        # Strained before the neighbour build so the whole forward sees it.
+        want_stress = "stress" in self._wrapper.model_config.active_outputs
+        strain = cell_local = None
+        if want_stress:
+            cell_local = full.cell
+            cell_local = (
+                cell_local.to_local() if hasattr(cell_local, "to_local") else cell_local
+            )
+            atoms["positions"], strained_cell, strain = prepare_strain(
+                pos, cell_local, full.batch_idx.long()
+            )
+            object.__setattr__(full, "cell", strained_cell)
+
         assignment = sharded.rank_assignment.to(pos.device)
         counts_t = torch.bincount(assignment, minlength=world)
         counts = [int(c) for c in counts_t.tolist()]
@@ -1079,22 +1127,44 @@ class DistributedModel:
             if grp is not None
             else None
         )
-        if self._needs_forces():
-            (grad,) = torch.autograd.grad(
-                [e_partial.sum()], [pos], create_graph=False, allow_unused=True
+        want_forces = self._needs_forces()
+        if want_forces or want_stress:
+            grad_inputs = ([pos] if want_forces else []) + (
+                [strain] if want_stress else []
             )
-            f = torch.zeros_like(pos) if grad is None else -grad
-            out["forces"] = _reduce_scatter_owned(f, counts, rank, nlo, nhi, grp)
+            grads = torch.autograd.grad(
+                [e_partial.sum()],
+                grad_inputs,
+                create_graph=False,
+                allow_unused=True,
+            )
+            if want_forces:
+                grad = grads[0]
+                f = torch.zeros_like(pos) if grad is None else -grad
+                out["forces"] = _reduce_scatter_owned(f, counts, rank, nlo, nhi, grp)
+            if want_stress:
+                # Each rank's owned energy is a distinct partial, so the virials
+                # sum (no replication to divide out).
+                virial = grads[-1]
+                if virial is None:
+                    virial = torch.zeros(
+                        sharded.num_graphs, 3, 3, dtype=pos.dtype, device=pos.device
+                    )
+                virial = virial.detach()
+                if grp is not None:
+                    dist.all_reduce(virial, op=dist.ReduceOp.SUM, group=grp)
+                out["stress"] = virial / torch.det(cell_local).abs().reshape(-1, 1, 1)
         if e_handle is not None:
             e_handle.wait()
         out["energy"] = e_global
 
         self._dist_ctx.gather_meta = None
+        # Every value here is already global, so consolidation must not touch them.
         return consolidate_sharded_outputs(
             output=out,
             model_config=self._wrapper.model_config,
             world_size=self._world_size,
-            owned_only_outputs=frozenset({"energy", "forces"}),
+            owned_only_outputs=frozenset({"energy", "forces", "stress"}),
             all_reduce_outputs=frozenset(),
             halo_config=SimpleNamespace(mesh=mesh),
         )
@@ -1315,6 +1385,8 @@ class DistributedModel:
         from nvalchemi.distributed.helpers import system_sum, to_local  # noqa: PLC0415
 
         node_e = to_local(output.pop(node_energy_key))
+        # A wired consumer differentiates its own owned share, not the
+        # all-reduced total, whose backward is amplified across ranks.
         reduced = system_sum(
             node_e,
             to_local(padded_batch.batch_idx).to(torch.long),
@@ -1324,6 +1396,8 @@ class DistributedModel:
         ref = output.get("energy")
         if ref is not None:
             reduced = reduced.to(ref.dtype).reshape(ref.shape)
+        elif reduced.dim() == 1:
+            reduced = reduced.unsqueeze(-1)
         output["energy"] = reduced
         return output
 
@@ -1345,6 +1419,22 @@ class DistributedModel:
         tensile-positive Cauchy stress ``-W/V`` using the cell volume, and
         overrides the wrapper's all-local ``"stress"``. Must run inside an active
         DD context.
+
+        Parameters
+        ----------
+        output : dict[str, Any]
+            The wrapper's raw output dict; the virial key is consumed.
+        node_virial_key : str
+            Key of the per-node virial ``(n_nodes, 3, 3)``.
+        padded_batch : Batch
+            This rank's padded view, supplying ``batch_idx`` and ``cell``.
+        num_graphs : int
+            Number of systems in the batch.
+
+        Returns
+        -------
+        dict[str, Any]
+            *output* with ``"stress"`` replaced by the decomposition-correct value.
         """
         from nvalchemi.distributed._core.enums import Scope  # noqa: PLC0415
         from nvalchemi.distributed.helpers import system_sum, to_local  # noqa: PLC0415
@@ -1369,8 +1459,8 @@ class DistributedModel:
     # Compiled energy-autograd path (framework-owned)
     # ------------------------------------------------------------------
 
-    def _dd_compiled_region(self) -> Any:
-        """Build (once, cached) the compiled energy-only region.
+    def _dd_compiled_region(self, eager: bool = False) -> Any:
+        """Build (once, cached) the energy-only region.
 
         The region publishes the halo routing — carried as tensor attributes on
         the batch — so the wrapper's per-layer halo-refresh adapters fire inside
@@ -1378,7 +1468,8 @@ class DistributedModel:
         is read from the batch so Dynamo lifts it to graph inputs (it drifts per
         step and can't be baked); ``world_size`` is static and bakes in.
         """
-        region = getattr(self, "_dd_region", None)
+        attr = "_dd_region_eager" if eager else "_dd_region"
+        region = getattr(self, attr, None)
         if region is not None:
             return region
 
@@ -1403,6 +1494,17 @@ class DistributedModel:
                 )
             return wrapper.forward(batch)
 
+        if eager:
+            # Same region uncompiled, so eager and compiled cannot drift.
+            def eager_runner(batch: Any) -> Any:
+                try:
+                    return _region(batch)
+                finally:
+                    clear_compile_routing()
+
+            self._dd_region_eager = eager_runner
+            return eager_runner
+
         compiled = torch.compile(_region, backend=backend, **ck)
 
         def runner(batch: Any) -> Any:
@@ -1417,7 +1519,13 @@ class DistributedModel:
         return runner
 
     def _compiled_energy_autograd_forward(
-        self, padded_batch: "Batch", meta: Any, n_graphs: int
+        self,
+        padded_batch: "Batch",
+        meta: Any,
+        n_graphs: int,
+        eager: bool = False,
+        extra_grad_inputs: "list[Any] | None" = None,
+        retain_graph: bool = False,
     ) -> dict[str, Any]:
         """Compiled energy + autograd-force forward.
 
@@ -1441,8 +1549,10 @@ class DistributedModel:
         pos = atoms["positions"]
         pos_plain = pos.to_local() if hasattr(pos, "to_local") else pos
         # Fresh leaf so autograd.grad (outside compile) differentiates the
-        # compiled output w.r.t. it.
-        pos_plain = pos_plain.detach().requires_grad_(True)
+        # compiled output w.r.t. it, unless the caller pinned its own leaf that
+        # this padded view descends from — detaching would orphan it.
+        if not (retain_graph and pos_plain.requires_grad):
+            pos_plain = pos_plain.detach().requires_grad_(True)
 
         # Stress via the strain trick: perturb positions AND cell by a symmetric
         # per-system strain leaf, then virial = d(energy)/d(strain). Because we
@@ -1461,22 +1571,27 @@ class DistributedModel:
         if want_stress:
             _bidx = padded_batch.batch_idx
             _bidx = (_bidx.to_local() if hasattr(_bidx, "to_local") else _bidx).long()
-            strain = torch.zeros(
-                int(n_graphs), 3, 3, dtype=pos_plain.dtype, device=pos_plain.device
-            ).requires_grad_(True)
-            strain_sym = 0.5 * (strain + strain.transpose(-1, -2))
-            strain_atom = strain_sym.index_select(0, _bidx)  # [N, 3, 3]
-            pos_use = pos_plain + torch.einsum("nij,nj->ni", strain_atom, pos_plain)
             cell_orig = getattr(padded_batch, "cell", None)
-            if cell_orig is not None:
-                cell_local = (
+            cell_local = (
+                None
+                if cell_orig is None
+                else (
                     cell_orig.to_local()
                     if hasattr(cell_orig, "to_local")
                     else cell_orig
                 )
-                cell_use = cell_local + torch.einsum(
-                    "bij,bjk->bik", cell_local, strain_sym
+            )
+            # No cell (open boundary): strain the positions against a dummy so the
+            # leaf still exists and the virial is position-only.
+            _cell_in = (
+                cell_local
+                if cell_local is not None
+                else torch.zeros(
+                    int(n_graphs), 3, 3, dtype=pos_plain.dtype, device=pos_plain.device
                 )
+            )
+            pos_use, cell_use, strain = prepare_strain(pos_plain, _cell_in, _bidx)
+            if cell_local is not None:
                 object.__setattr__(padded_batch, "cell", cell_use)
             atoms["positions"] = pos_use
         else:
@@ -1509,13 +1624,14 @@ class DistributedModel:
         energy_key = _cp.energy_output
         consolidate = _cp.consolidate_node_energy
 
-        # Run energy-only through the compiled region, restoring the wrapper's
-        # active_outputs afterward.
+        # The framework owns energy / forces / stress; any other requested output
+        # is the model's own and still has to come out of the compiled region.
         mc = self._wrapper.model_config
         saved_active = mc.active_outputs
-        mc.active_outputs = {energy_key}
+        aux_keys = {k for k in saved_active if k not in ("energy", "forces", "stress")}
+        mc.active_outputs = {energy_key} | aux_keys
         try:
-            out = self._dd_compiled_region()(padded_batch)
+            out = self._dd_compiled_region(eager=eager)(padded_batch)
         finally:
             mc.active_outputs = saved_active
         e = out[energy_key]
@@ -1525,21 +1641,42 @@ class DistributedModel:
             energy = _consolidate_node_energy(
                 e, padded_batch.batch_idx.long(), int(n_graphs)
             )
+            # Wrappers accumulate in a wider dtype but return the total in the
+            # positions dtype; match that so DD and single-GPU agree.
+            if energy.dtype != pos_plain.dtype:
+                energy = energy.to(pos_plain.dtype)
         else:
             # Model self-consolidated the global per-system energy already.
             energy = e
         grad_inputs = [pos_plain] if not want_stress else [pos_plain, strain]
+        # The graph is freed here, so a wired consumer's dE/dfield must come
+        # out of this same backward.
+        n_core = len(grad_inputs)
+        if extra_grad_inputs:
+            grad_inputs = grad_inputs + list(extra_grad_inputs)
         grads = torch.autograd.grad(
             [energy],
             grad_inputs,
             grad_outputs=[torch.ones_like(energy)],
             create_graph=False,
-            retain_graph=False,
+            # A wired consumer's graph descends from the producer's, and a
+            # pinned leaf means the caller backwards through this again.
+            retain_graph=bool(extra_grad_inputs) or retain_graph,
             allow_unused=True,
         )
         grad = grads[0]
         forces = torch.zeros_like(pos_plain) if grad is None else -grad
         result: dict[str, Any] = {"energy": energy, "forces": forces}
+        for _k in aux_keys:
+            _v = out.get(_k)
+            if _v is None:
+                continue
+            # Strip the cap padding: consolidation expects the real padded view.
+            if isinstance(_v, torch.Tensor) and _v.shape[:1] == pos_plain.shape[:1]:
+                _v = _v[: int(meta.n_padded)]
+            result[_k] = _v
+        if extra_grad_inputs:
+            result["_extra_grads"] = list(grads[n_core:])
         if want_stress:
             virial = grads[1]  # d(energy)/d(strain): this rank's partial virial
             if virial is None or cell_local is None:
@@ -1555,4 +1692,9 @@ class DistributedModel:
                 result["stress"] = virial / vol
             if cell_orig is not None:
                 object.__setattr__(padded_batch, "cell", cell_orig)
-        return self._wrapper.adapt_output(result, padded_batch)
+        adapted = self._wrapper.adapt_output(result, padded_batch)
+        if "_extra_grads" in result:
+            # ``adapt_output`` would drop this, but a wired caller needs the
+            # dE/dfield from the same backward that produced the forces.
+            adapted["_extra_grads"] = result["_extra_grads"]
+        return adapted

--- a/nvalchemi/distributed/distributed_pipeline.py
+++ b/nvalchemi/distributed/distributed_pipeline.py
@@ -151,9 +151,6 @@ class DistributedPipelineModel:
 
     def _make_dist_model(self, step: Any, cfg: "DomainConfig") -> Any:
         """Build a (possibly compiled) persistent :class:`DistributedModel`."""
-        from nvalchemi.distributed.distributed_model import (  # noqa: PLC0415
-            DistributedModel,
-        )
 
         compiled = self._compile and self._compile_capable(step)
         return DistributedModel(
@@ -219,6 +216,13 @@ class DistributedPipelineModel:
             mc = step.model.model_config
             grad_fields |= set(mc.autograd_inputs) | set(mc.gradient_keys)
         grad_fields -= {field, out_key, "cell"}
+        # Built once and retained, like the per-step path: a model rebuilt each
+        # forward loses its grown shape caps and its compiled-region cache, so a
+        # compiled wired run would recompile every step.
+        producer_cfg = self._model_cfg(producer)
+        consumer_cfg = self._model_cfg(consumer)
+        producer_dm, _ = self._make_dist_model(producer, producer_cfg)
+        consumer_dm, consumer_compiled = self._make_dist_model(consumer, consumer_cfg)
         return {
             "kind": "wired",
             "grad_fields": sorted(grad_fields),
@@ -226,8 +230,11 @@ class DistributedPipelineModel:
             "consumer": consumer,
             "producer_out_key": out_key,
             "field": field,
-            "producer_cfg": self._model_cfg(producer),
-            "consumer_cfg": self._model_cfg(consumer),
+            "producer_cfg": producer_cfg,
+            "consumer_cfg": consumer_cfg,
+            "producer_dm": producer_dm,
+            "consumer_dm": consumer_dm,
+            "consumer_compiled": consumer_compiled,
         }
 
     # ------------------------------------------------------------------
@@ -248,6 +255,10 @@ class DistributedPipelineModel:
         for plan in self._group_plans:
             for item in plan.get("steps", ()):
                 item["dm"].close()
+            for key in ("producer_dm", "consumer_dm"):
+                dm = plan.get(key)
+                if dm is not None:
+                    dm.close()
         self._closed = True
 
     def __del__(self) -> None:
@@ -349,9 +360,6 @@ class DistributedPipelineModel:
         """
         import torch  # noqa: PLC0415
 
-        from nvalchemi.distributed.distributed_model import (  # noqa: PLC0415
-            DistributedModel,
-        )
         from nvalchemi.distributed.helpers import to_local  # noqa: PLC0415
         from nvalchemi.distributed.particle_halo import (  # noqa: PLC0415
             halo_exchange,
@@ -371,139 +379,129 @@ class DistributedPipelineModel:
         pos_leaf_marked = False
         try:
             sharded.invalidate_padded_view()
-            with DistributedModel(producer, plan["producer_cfg"]) as pdm:
-                # Build the producer halo with grad-bearing positions so the
-                # energy / field graph reaches them, even though the producer
-                # emits no forces of its own.
-                pdm._ensure_initialized(sharded)
-                # Differentiate the owned positions, not the padded view: a
-                # halo refresh mints a fresh leaf and would orphan a padded one.
-                leaves: dict[str, Any] = {}
-                for name in plan["grad_fields"]:
-                    src = getattr(sharded, name, None)
-                    if src is None:
-                        raise ValueError(
-                            f"{name!r} is differentiated by a model in this wired "
-                            "group but is not a per-atom field on the batch, so no "
-                            "autograd leaf can be pinned for it."
+            pdm = plan["producer_dm"]
+            # Build the producer halo with grad-bearing positions so the
+            # energy / field graph reaches them, even though the producer
+            # emits no forces of its own.
+            pdm._ensure_initialized(sharded)
+            # Differentiate the owned positions, not the padded view: a
+            # halo refresh mints a fresh leaf and would orphan a padded one.
+            leaves: dict[str, Any] = {}
+            for name in plan["grad_fields"]:
+                src = getattr(sharded, name, None)
+                if src is None:
+                    raise ValueError(
+                        f"{name!r} is differentiated by a model in this wired "
+                        "group but is not a per-atom field on the batch, so no "
+                        "autograd leaf can be pinned for it."
+                    )
+                leaves[name] = to_local(src).detach().clone().requires_grad_(True)
+            pos_leaf = leaves["positions"]
+            sharded.grad_fields = leaves
+            pos_leaf_marked = True
+            if want_stress:
+                # Two leaves so the position and cell halves of the virial
+                # can be read separately; both are per-rank partials.
+                _shape = (int(sharded.num_graphs), 3, 3)
+                _kw = {"dtype": pos_leaf.dtype, "device": pos_leaf.device}
+                strain = torch.zeros(*_shape, requires_grad=True, **_kw)
+                strain_cell = torch.zeros(*_shape, requires_grad=True, **_kw)
+                sharded.grad_strain = (strain, strain_cell)
+            halo_exchange(sharded, pdm._halo_config, compute_forces=True)
+            prod_out = pdm(sharded)
+            e_prod = prod_out["energy"]
+            owned_field = prod_out[out_key]
+            prod_pos_leaf = pos_leaf
+            prod_halo_cfg = pdm._halo_config
+            world_size = pdm._world_size or 1
+
+            # Consumer: direct kernel force + energy differentiable in the
+            # wired field, whose ghost values are gathered (autograd-aware)
+            # from the producer's owned values.
+            sharded.invalidate_padded_view()
+            cons_mc = consumer.model_config
+            saved_cons = cons_mc.active_outputs
+            # The consumer's own strain-autograd virial is the fixed-field
+            # term this split needs, already consolidated by its output rule.
+            if want_stress and "stress" not in cons_mc.outputs:
+                raise NotImplementedError(
+                    f"{type(consumer).__name__} consumes the wired field "
+                    f"'{field}' but produces no stress, so the group's virial "
+                    "would silently omit its contribution. Drop 'stress' from "
+                    "the pipeline's active_outputs, or use a consumer that "
+                    "emits it."
+                )
+            cons_mc.active_outputs = (
+                {"energy", "forces", "stress"} if want_stress else {"energy", "forces"}
+            )
+            cons_stress = None
+            try:
+                # ``extra_grad_inputs`` keeps the graph alive for this
+                # group's backward.
+                cdm = plan["consumer_dm"]
+                cdm._ensure_initialized(sharded)
+                # Only the producer's leaf stays pinned; it carries the chain.
+                sharded.grad_strain = None
+                halo_exchange(sharded, cdm._halo_config, compute_forces=True)
+                cons_out = cdm(sharded, wired_fields={field: owned_field})
+                e_cons = cons_out["energy"]
+                f_cons_direct = cons_out.get("forces")
+                cons_stress = cons_out.get("stress")
+                # Either model may read a pinned field, so sum both backwards.
+                _extra = [n for n in plan["grad_fields"] if n != "positions"]
+                _fw = cons_out.get("_extra_grads")
+                if _fw:
+                    # Reuse the framework's dE/dfield: a second backward
+                    # through a compiled graph returns a wrong chain term.
+                    de_dfield = _fw[0]
+                    cons_extra_grads = {}
+                    if _extra:
+                        _extra_grads = torch.autograd.grad(
+                            [e_cons.sum()],
+                            [leaves[n] for n in _extra],
+                            retain_graph=True,
+                            allow_unused=True,
                         )
-                    leaves[name] = to_local(src).detach().clone().requires_grad_(True)
-                pos_leaf = leaves["positions"]
-                sharded.grad_fields = leaves
-                pos_leaf_marked = True
-                if want_stress:
-                    # Two leaves so the position and cell halves of the virial
-                    # can be read separately; both are per-rank partials.
-                    _shape = (int(sharded.num_graphs), 3, 3)
-                    _kw = {"dtype": pos_leaf.dtype, "device": pos_leaf.device}
-                    strain = torch.zeros(*_shape, requires_grad=True, **_kw)
-                    strain_cell = torch.zeros(*_shape, requires_grad=True, **_kw)
-                    sharded.grad_strain = (strain, strain_cell)
-                halo_exchange(sharded, pdm._halo_config, compute_forces=True)
-                prod_out = pdm(sharded)
-                e_prod = prod_out["energy"]
-                owned_field = prod_out[out_key]
-                prod_pos_leaf = pos_leaf
-                prod_halo_cfg = pdm._halo_config
-                world_size = pdm._world_size or 1
-
-                # Consumer: direct kernel force + energy differentiable in the
-                # wired field, whose ghost values are gathered (autograd-aware)
-                # from the producer's owned values.
-                sharded.invalidate_padded_view()
-                cons_mc = consumer.model_config
-                saved_cons = cons_mc.active_outputs
-                # The consumer's own strain-autograd virial is the fixed-field
-                # term this split needs, already consolidated by its output rule.
-                if want_stress and "stress" not in cons_mc.outputs:
-                    raise NotImplementedError(
-                        f"{type(consumer).__name__} consumes the wired field "
-                        f"'{field}' but produces no stress, so the group's virial "
-                        "would silently omit its contribution. Drop 'stress' from "
-                        "the pipeline's active_outputs, or use a consumer that "
-                        "emits it."
+                        cons_extra_grads = dict(zip(_extra, _extra_grads))
+                else:
+                    _cg = torch.autograd.grad(
+                        [e_cons.sum()],
+                        [owned_field] + [leaves[n] for n in _extra],
+                        retain_graph=True,
+                        allow_unused=True,
                     )
-                cons_mc.active_outputs = (
-                    {"energy", "forces", "stress"}
-                    if want_stress
-                    else {"energy", "forces"}
-                )
-                cons_stress = None
-                try:
-                    # ``extra_grad_inputs`` keeps the graph alive for this
-                    # group's backward.
-                    cons_compiled = self._compile and self._compile_capable(
-                        plan["consumer"]
-                    )
-                    with DistributedModel(
-                        consumer,
-                        plan["consumer_cfg"],
-                        compile=cons_compiled,
-                        compile_kwargs=self._compile_kwargs if cons_compiled else None,
-                    ) as cdm:
-                        cdm._ensure_initialized(sharded)
-                        # Only the producer's leaf stays pinned; it carries the chain.
-                        sharded.grad_strain = None
-                        halo_exchange(sharded, cdm._halo_config, compute_forces=True)
-                        cons_out = cdm(sharded, wired_fields={field: owned_field})
-                        e_cons = cons_out["energy"]
-                        f_cons_direct = cons_out.get("forces")
-                        cons_stress = cons_out.get("stress")
-                        # Either model may read a pinned field, so sum both backwards.
-                        _extra = [n for n in plan["grad_fields"] if n != "positions"]
-                        _fw = cons_out.get("_extra_grads")
-                        if _fw:
-                            # Reuse the framework's dE/dfield: a second backward
-                            # through a compiled graph returns a wrong chain term.
-                            de_dfield = _fw[0]
-                            cons_extra_grads = {}
-                            if _extra:
-                                _extra_grads = torch.autograd.grad(
-                                    [e_cons.sum()],
-                                    [leaves[n] for n in _extra],
-                                    retain_graph=True,
-                                    allow_unused=True,
-                                )
-                                cons_extra_grads = dict(zip(_extra, _extra_grads))
-                        else:
-                            _cg = torch.autograd.grad(
-                                [e_cons.sum()],
-                                [owned_field] + [leaves[n] for n in _extra],
-                                retain_graph=True,
-                                allow_unused=True,
-                            )
-                            de_dfield = _cg[0]
-                            cons_extra_grads = dict(zip(_extra, _cg[1:]))
-                finally:
-                    cons_mc.active_outputs = saved_cons
-                    sharded.grad_strain = (strain, strain_cell) if want_stress else None
+                    de_dfield = _cg[0]
+                    cons_extra_grads = dict(zip(_extra, _cg[1:]))
+            finally:
+                cons_mc.active_outputs = saved_cons
+                sharded.grad_strain = (strain, strain_cell) if want_stress else None
 
-                # One backward through the producer for -dE_prod/dr and the chain
-                # -(dE_cons/dfield)(dfield/dr) together.
-                extra_names = [n for n in plan["grad_fields"] if n != "positions"]
-                grad_inputs = [prod_pos_leaf]
-                if strain is not None:
-                    grad_inputs += [strain, strain_cell]
-                grad_inputs += [leaves[n] for n in extra_names]
-                surrogate = e_prod.sum()
-                if de_dfield is not None:
-                    surrogate = surrogate + (owned_field * de_dfield.detach()).sum()
-                grads = torch.autograd.grad(
-                    [surrogate],
-                    grad_inputs,
-                    retain_graph=False,
-                    allow_unused=True,
-                )
-                g_pos = grads[0]
-                g_strain = grads[1] if strain is not None else None
-                g_strain_cell = grads[2] if strain is not None else None
-                # The leaf is the owned tensor, so ghost gradients are already routed.
-                n_core = 1 if strain is None else 3
-                extra_grads = {}
-                for i, name in enumerate(extra_names):
-                    parts = [grads[n_core + i], cons_extra_grads.get(name)]
-                    live = [p for p in parts if p is not None]
-                    extra_grads[name] = None if not live else sum(live[1:], live[0])
+            # One backward through the producer for -dE_prod/dr and the chain
+            # -(dE_cons/dfield)(dfield/dr) together.
+            extra_names = [n for n in plan["grad_fields"] if n != "positions"]
+            grad_inputs = [prod_pos_leaf]
+            if strain is not None:
+                grad_inputs += [strain, strain_cell]
+            grad_inputs += [leaves[n] for n in extra_names]
+            surrogate = e_prod.sum()
+            if de_dfield is not None:
+                surrogate = surrogate + (owned_field * de_dfield.detach()).sum()
+            grads = torch.autograd.grad(
+                [surrogate],
+                grad_inputs,
+                retain_graph=False,
+                allow_unused=True,
+            )
+            g_pos = grads[0]
+            g_strain = grads[1] if strain is not None else None
+            g_strain_cell = grads[2] if strain is not None else None
+            # The leaf is the owned tensor, so ghost gradients are already routed.
+            n_core = 1 if strain is None else 3
+            extra_grads = {}
+            for i, name in enumerate(extra_names):
+                parts = [grads[n_core + i], cons_extra_grads.get(name)]
+                live = [p for p in parts if p is not None]
+                extra_grads[name] = None if not live else sum(live[1:], live[0])
         finally:
             prod_mc.active_outputs = saved_prod
             if pos_leaf_marked:

--- a/nvalchemi/distributed/distributed_pipeline.py
+++ b/nvalchemi/distributed/distributed_pipeline.py
@@ -151,6 +151,9 @@ class DistributedPipelineModel:
 
     def _make_dist_model(self, step: Any, cfg: "DomainConfig") -> Any:
         """Build a (possibly compiled) persistent :class:`DistributedModel`."""
+        from nvalchemi.distributed.distributed_model import (  # noqa: PLC0415
+            DistributedModel,
+        )
 
         compiled = self._compile and self._compile_capable(step)
         return DistributedModel(

--- a/nvalchemi/distributed/distributed_pipeline.py
+++ b/nvalchemi/distributed/distributed_pipeline.py
@@ -211,8 +211,17 @@ class DistributedPipelineModel:
                 f"{len(wired)} wired field(s) over {len(group.steps)} steps."
             )
         producer, out_key, consumer, field = wired[0]
+        # Pinned so the leaf survives each model's own halo refresh. The wired
+        # field and ``cell`` are excluded: the group differentiates the first
+        # explicitly, and the strain leaves carry the second.
+        grad_fields = {"positions"}
+        for step in (producer, consumer):
+            mc = step.model.model_config
+            grad_fields |= set(mc.autograd_inputs) | set(mc.gradient_keys)
+        grad_fields -= {field, out_key, "cell"}
         return {
             "kind": "wired",
+            "grad_fields": sorted(grad_fields),
             "producer": producer,
             "consumer": consumer,
             "producer_out_key": out_key,
@@ -311,24 +320,35 @@ class DistributedPipelineModel:
 
             F = -dE_prod/dr               (producer's own energy)
                 - (dE_cons/dfield)(dfield/dr)   (the cross-model chain)
-                - dE_cons/dr|_field        (consumer's direct kernel force)
+                - dE_cons/dr|_field        (consumer's own force, at fixed field)
 
         Realized as: run the producer for energy + field only (no forces, so its
         graph is retained), with grad-bearing positions via a
         ``compute_forces=True`` halo. Run the consumer with its ghost field
         gathered from the producer's owned values through the autograd-aware
-        ``wired_fields`` exchange, taking its direct kernel forces and the field
-        gradient ``dE_cons/dfield`` on the producer's owned atoms. One backward
+        ``wired_fields`` exchange, taking its own forces and the field gradient
+        ``dE_cons/dfield`` on the producer's owned atoms. One backward
         through the producer over ``E_prod + <field, dE_cons/dfield>`` yields the
         first two force terms; that gradient is sent back to the owning ranks and
         the per-rank replication from the two all-reduced energies is divided
         out; the consumer's owned kernel forces are then added.
+
+        Stress follows the same split. A symmetric per-system strain leaf pinned
+        on the ``ShardedBatch`` deforms the producer's padded geometry, so the
+        same surrogate backward yields ``dE_prod/d eps`` and the cross-model
+        chain ``(dE_cons/dfield)(dfield/d eps)``. The consumer's remaining
+        ``dE_cons/d eps`` at fixed field is its own stress output, consolidated
+        by its declared output rule.
+
+        Sub-models therefore emit their own derivatives here, where the
+        single-process pipeline would strip them and take one outer backward.
+        That is the same trade the non-wired shared-autograd group already makes
+        (see the module docstring): each model's validated eager / compile path
+        produces its owned-aligned share, and the composite adds only the one
+        term no single model can — the cross-model chain.
         """
         import torch  # noqa: PLC0415
 
-        from nvalchemi.distributed._core.particle_halo import (  # noqa: PLC0415
-            halo_reverse_exchange,
-        )
         from nvalchemi.distributed.distributed_model import (  # noqa: PLC0415
             DistributedModel,
         )
@@ -341,10 +361,14 @@ class DistributedPipelineModel:
         consumer = plan["consumer"].model
         out_key = plan["producer_out_key"]
         field = plan["field"]
+        want_stress = "stress" in self.pipeline.model_config.active_outputs
 
         prod_mc = producer.model_config
         saved_prod = prod_mc.active_outputs
         prod_mc.active_outputs = {"energy", out_key}
+        strain = None
+        strain_cell = None
+        pos_leaf_marked = False
         try:
             sharded.invalidate_padded_view()
             with DistributedModel(producer, plan["producer_cfg"]) as pdm:
@@ -352,12 +376,34 @@ class DistributedPipelineModel:
                 # energy / field graph reaches them, even though the producer
                 # emits no forces of its own.
                 pdm._ensure_initialized(sharded)
+                # Differentiate the owned positions, not the padded view: a
+                # halo refresh mints a fresh leaf and would orphan a padded one.
+                leaves: dict[str, Any] = {}
+                for name in plan["grad_fields"]:
+                    src = getattr(sharded, name, None)
+                    if src is None:
+                        raise ValueError(
+                            f"{name!r} is differentiated by a model in this wired "
+                            "group but is not a per-atom field on the batch, so no "
+                            "autograd leaf can be pinned for it."
+                        )
+                    leaves[name] = to_local(src).detach().clone().requires_grad_(True)
+                pos_leaf = leaves["positions"]
+                sharded.grad_fields = leaves
+                pos_leaf_marked = True
+                if want_stress:
+                    # Two leaves so the position and cell halves of the virial
+                    # can be read separately; both are per-rank partials.
+                    _shape = (int(sharded.num_graphs), 3, 3)
+                    _kw = {"dtype": pos_leaf.dtype, "device": pos_leaf.device}
+                    strain = torch.zeros(*_shape, requires_grad=True, **_kw)
+                    strain_cell = torch.zeros(*_shape, requires_grad=True, **_kw)
+                    sharded.grad_strain = (strain, strain_cell)
                 halo_exchange(sharded, pdm._halo_config, compute_forces=True)
                 prod_out = pdm(sharded)
                 e_prod = prod_out["energy"]
                 owned_field = prod_out[out_key]
-                prod_pos_leaf = sharded.padded_batch.positions
-                prod_meta = sharded.halo_meta
+                prod_pos_leaf = pos_leaf
                 prod_halo_cfg = pdm._halo_config
                 world_size = pdm._world_size or 1
 
@@ -367,48 +413,161 @@ class DistributedPipelineModel:
                 sharded.invalidate_padded_view()
                 cons_mc = consumer.model_config
                 saved_cons = cons_mc.active_outputs
-                cons_mc.active_outputs = {"energy", "forces"}
+                # The consumer's own strain-autograd virial is the fixed-field
+                # term this split needs, already consolidated by its output rule.
+                if want_stress and "stress" not in cons_mc.outputs:
+                    raise NotImplementedError(
+                        f"{type(consumer).__name__} consumes the wired field "
+                        f"'{field}' but produces no stress, so the group's virial "
+                        "would silently omit its contribution. Drop 'stress' from "
+                        "the pipeline's active_outputs, or use a consumer that "
+                        "emits it."
+                    )
+                cons_mc.active_outputs = (
+                    {"energy", "forces", "stress"}
+                    if want_stress
+                    else {"energy", "forces"}
+                )
+                cons_stress = None
                 try:
-                    with DistributedModel(consumer, plan["consumer_cfg"]) as cdm:
+                    # ``extra_grad_inputs`` keeps the graph alive for this
+                    # group's backward.
+                    cons_compiled = self._compile and self._compile_capable(
+                        plan["consumer"]
+                    )
+                    with DistributedModel(
+                        consumer,
+                        plan["consumer_cfg"],
+                        compile=cons_compiled,
+                        compile_kwargs=self._compile_kwargs if cons_compiled else None,
+                    ) as cdm:
+                        cdm._ensure_initialized(sharded)
+                        # Only the producer's leaf stays pinned; it carries the chain.
+                        sharded.grad_strain = None
+                        halo_exchange(sharded, cdm._halo_config, compute_forces=True)
                         cons_out = cdm(sharded, wired_fields={field: owned_field})
                         e_cons = cons_out["energy"]
                         f_cons_direct = cons_out.get("forces")
-                        (de_dfield,) = torch.autograd.grad(
-                            [e_cons.sum()],
-                            [owned_field],
-                            retain_graph=True,
-                            allow_unused=True,
-                        )
+                        cons_stress = cons_out.get("stress")
+                        # Either model may read a pinned field, so sum both backwards.
+                        _extra = [n for n in plan["grad_fields"] if n != "positions"]
+                        _fw = cons_out.get("_extra_grads")
+                        if _fw:
+                            # Reuse the framework's dE/dfield: a second backward
+                            # through a compiled graph returns a wrong chain term.
+                            de_dfield = _fw[0]
+                            cons_extra_grads = (
+                                dict(
+                                    zip(
+                                        _extra,
+                                        torch.autograd.grad(
+                                            [e_cons.sum()],
+                                            [leaves[n] for n in _extra],
+                                            retain_graph=True,
+                                            allow_unused=True,
+                                        ),
+                                    )
+                                )
+                                if _extra
+                                else {}
+                            )
+                        else:
+                            _cg = torch.autograd.grad(
+                                [e_cons.sum()],
+                                [owned_field] + [leaves[n] for n in _extra],
+                                retain_graph=True,
+                                allow_unused=True,
+                            )
+                            de_dfield = _cg[0]
+                            cons_extra_grads = dict(zip(_extra, _cg[1:]))
                 finally:
                     cons_mc.active_outputs = saved_cons
+                    sharded.grad_strain = (strain, strain_cell) if want_stress else None
 
                 # One backward through the producer for -dE_prod/dr and the chain
                 # -(dE_cons/dfield)(dfield/dr) together.
+                extra_names = [n for n in plan["grad_fields"] if n != "positions"]
+                grad_inputs = [prod_pos_leaf]
+                if strain is not None:
+                    grad_inputs += [strain, strain_cell]
+                grad_inputs += [leaves[n] for n in extra_names]
                 surrogate = e_prod.sum()
                 if de_dfield is not None:
                     surrogate = surrogate + (owned_field * de_dfield.detach()).sum()
-                (g_pos,) = torch.autograd.grad(
+                grads = torch.autograd.grad(
                     [surrogate],
-                    [prod_pos_leaf],
+                    grad_inputs,
                     retain_graph=False,
                     allow_unused=True,
                 )
+                g_pos = grads[0]
+                g_strain = grads[1] if strain is not None else None
+                g_strain_cell = grads[2] if strain is not None else None
+                # The leaf is the owned tensor, so ghost gradients are already routed.
+                n_core = 1 if strain is None else 3
+                extra_grads = {}
+                for i, name in enumerate(extra_names):
+                    parts = [grads[n_core + i], cons_extra_grads.get(name)]
+                    live = [p for p in parts if p is not None]
+                    extra_grads[name] = None if not live else sum(live[1:], live[0])
         finally:
             prod_mc.active_outputs = saved_prod
+            if pos_leaf_marked:
+                sharded.grad_fields = None
+                sharded.grad_strain = None
 
         forces = None
         if g_pos is not None:
-            owned_grad = halo_reverse_exchange(
-                to_local(g_pos), prod_meta, prod_halo_cfg
-            )
-            forces = -(owned_grad / world_size)
+            # Taken against the owned leaf, so the halo reverse has already run.
+            forces = -(to_local(g_pos) / world_size)
         if f_cons_direct is not None:
             forces = f_cons_direct if forces is None else forces + f_cons_direct
 
+        # The producer's leaf carries its own virial and the cross-model chain,
+        # both per-rank partials of the replicated group energy: divide out that
+        # replication, then sum across ranks. Every rank walks the term whether
+        # or not its own gradient came back populated, because the reduction is
+        # a collective. The consumer's virial arrives already consolidated.
+        #
+        # A strain leaf of ours for the consumer looks symmetric but is not.
+        # Measured against a single-process reference, its position terms
+        # consolidate at 1/world_size but PME's cell term does not, and no single
+        # coefficient fits: the cell reaches PME's energy both through the
+        # all-reduced charge mesh and directly through the reciprocal kernel each
+        # rank evaluates on that mesh, and those two routes do not share a
+        # cross-rank reduction.
+        stress = None
+        volume = torch.det(to_local(sharded.cell)).abs().reshape(-1, 1, 1)
+        if want_stress:
+            from nvalchemi.distributed._core.gather_primitives import (  # noqa: PLC0415
+                all_reduce_sum_over_mesh as _all_reduce_sum_over_mesh,
+            )
+
+            zeros = torch.zeros(
+                sharded.num_graphs, 3, 3, dtype=volume.dtype, device=volume.device
+            )
+            for g in (g_strain, g_strain_cell):
+                local = zeros if g is None else to_local(g).detach().reshape(-1, 3, 3)
+                term = (
+                    _all_reduce_sum_over_mesh(local / world_size, prod_halo_cfg.mesh)
+                    / volume
+                )
+                stress = term if stress is None else stress + term
+            if cons_stress is not None:
+                _cs = to_local(cons_stress).detach().reshape(-1, 3, 3)
+                stress = _cs if stress is None else stress + _cs
+
         out: dict[str, Any] = OrderedDict()
         out["energy"] = (e_prod + e_cons).detach()
+        for name, g in extra_grads.items():
+            if g is not None:
+                # d(group energy)/d(field), owned-aligned. The world-size divisor
+                # is the same replicated-energy factor the forces carry.
+                out[f"d_energy_d_{name}"] = (to_local(g) / world_size).detach()
         if forces is not None:
             out["forces"] = forces.detach()
+        if stress is not None:
+            out["stress"] = stress.detach()
         return out
 
     def _autograd_active_outputs(self, step: Any) -> set[str]:

--- a/nvalchemi/distributed/distributed_pipeline.py
+++ b/nvalchemi/distributed/distributed_pipeline.py
@@ -456,21 +456,15 @@ class DistributedPipelineModel:
                             # Reuse the framework's dE/dfield: a second backward
                             # through a compiled graph returns a wrong chain term.
                             de_dfield = _fw[0]
-                            cons_extra_grads = (
-                                dict(
-                                    zip(
-                                        _extra,
-                                        torch.autograd.grad(
-                                            [e_cons.sum()],
-                                            [leaves[n] for n in _extra],
-                                            retain_graph=True,
-                                            allow_unused=True,
-                                        ),
-                                    )
+                            cons_extra_grads = {}
+                            if _extra:
+                                _extra_grads = torch.autograd.grad(
+                                    [e_cons.sum()],
+                                    [leaves[n] for n in _extra],
+                                    retain_graph=True,
+                                    allow_unused=True,
                                 )
-                                if _extra
-                                else {}
-                            )
+                                cons_extra_grads = dict(zip(_extra, _extra_grads))
                         else:
                             _cg = torch.autograd.grad(
                                 [e_cons.sum()],

--- a/nvalchemi/distributed/particle_halo.py
+++ b/nvalchemi/distributed/particle_halo.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from nvalchemi.distributed._core.particle_halo import (
+    halo_forward_exchange,
     pad_field,
     particle_halo_padding,
     particle_halo_padding_autograd,
@@ -43,6 +44,34 @@ if TYPE_CHECKING:
     from nvalchemi.distributed._core.halo_types import ParticleHaloConfig
 
 __all__ = ["halo_exchange"]
+
+
+def _apply_shared_strain(sharded: Any) -> None:
+    """Apply ``sharded.grad_strain`` to the padded view, if one is pinned.
+
+    The strain must land on the padded geometry: a ghost row holds an absolute
+    position, so straining before the exchange leaves its periodic offset
+    unscaled. The cell is taken from the owned batch because the padded one
+    survives a refresh and would compound the strain each time.
+    """
+    strain = getattr(sharded, "grad_strain", None)
+    if strain is None:
+        return
+    from nvalchemi.models._utils import apply_strain  # noqa: PLC0415
+
+    strain_pos, strain_cell = strain
+    padded = sharded.padded_batch
+    atoms = padded._atoms_group
+    bidx = padded.batch_idx
+    bidx = (bidx.to_local() if hasattr(bidx, "to_local") else bidx).long()
+    cell = sharded.cell
+    cell = cell.to_local() if hasattr(cell, "to_local") else cell
+
+    scaled_pos, scaled_cell = apply_strain(
+        atoms["positions"], cell, bidx, strain_pos, strain_cell
+    )
+    atoms["positions"] = scaled_pos
+    object.__setattr__(padded, "cell", scaled_cell)
 
 
 def halo_exchange(
@@ -91,9 +120,18 @@ def halo_exchange(
     from nvalchemi.data.atomic_data import AtomicData
     from nvalchemi.data.batch import Batch as BatchCls
 
-    local_pos = sharded.positions.to_local()
-    if compute_forces and not local_pos.requires_grad:
-        local_pos = local_pos.clone().requires_grad_(True)
+    # A caller that builds several halos over one owned set (the wired pipeline
+    # group) pins its autograd leaves here so every halo shares one graph;
+    # otherwise each exchange mints a fresh leaf and the caller's differentiation
+    # target is orphaned the moment the model refreshes its own halo.
+    pinned: dict[str, torch.Tensor] = (
+        (getattr(sharded, "grad_fields", None) or {}) if compute_forces else {}
+    )
+    local_pos = pinned.get("positions")
+    if local_pos is None:
+        local_pos = sharded.positions.to_local()
+        if compute_forces and not local_pos.requires_grad:
+            local_pos = local_pos.clone().requires_grad_(True)
 
     if compute_forces:
         padded_pos, meta = particle_halo_padding_autograd(local_pos, config)
@@ -124,6 +162,12 @@ def halo_exchange(
                 dtype=local.dtype,
                 device=device,
             )
+        leaf = pinned.get(name)
+        if leaf is not None:
+            # Grad-bearing field: gather it through the autograd-aware
+            # primitive, so a ghost row's gradient reaches the rank that owns
+            # the atom. ``pad_field``'s plain collective would drop it.
+            return halo_forward_exchange(leaf, meta, config)
         return pad_field(shard, meta, config)
 
     # Try in-place update on existing padded_batch if shape-compatible.
@@ -152,7 +196,10 @@ def halo_exchange(
                 atoms["forces"].zero_()
                 continue
             atoms[name] = _build_padded_field(name, shard)
+        for name, tensor in getattr(sharded, "system_fields", {}).items():
+            system[name] = tensor
         sharded.halo_meta = meta
+        _apply_shared_strain(sharded)
         return
 
     # Fresh build — AtomicData's ctor only accepts its declared fields;
@@ -167,7 +214,22 @@ def halo_exchange(
     padded_kwargs["cell"] = cell
     padded_kwargs["pbc"] = pbc
 
+    # Replicated per-system inputs (total ``charge``, ``spin``, custom system
+    # properties) ride through too. A wrapper reads them to decide WHICH
+    # physical system it is computing, and a model that finds them missing
+    # falls back to a neutral default rather than failing — so dropping them
+    # here silently changes the physics.
+    known_fields = set(AtomicData.model_fields)
+    system_extras: dict[str, torch.Tensor] = {}
+    for name, tensor in getattr(sharded, "system_fields", {}).items():
+        if name in known_fields:
+            padded_kwargs[name] = tensor
+        else:
+            system_extras[name] = tensor
+
     padded_data = AtomicData(**padded_kwargs)
+    for name, tensor in system_extras.items():
+        padded_data.add_system_property(name, tensor)
     for name, shard in atom_fields.items():
         if name in ("positions", "atomic_numbers", "atomic_masses"):
             continue
@@ -175,3 +237,4 @@ def halo_exchange(
 
     sharded.padded_batch = BatchCls.from_data_list([padded_data], device=device)
     sharded.halo_meta = meta
+    _apply_shared_strain(sharded)

--- a/nvalchemi/distributed/particle_halo.py
+++ b/nvalchemi/distributed/particle_halo.py
@@ -57,6 +57,7 @@ def _apply_shared_strain(sharded: Any) -> None:
     strain = getattr(sharded, "grad_strain", None)
     if strain is None:
         return
+    from nvalchemi.data.batch import set_transient  # noqa: PLC0415
     from nvalchemi.models._utils import apply_strain  # noqa: PLC0415
 
     strain_pos, strain_cell = strain
@@ -71,7 +72,7 @@ def _apply_shared_strain(sharded: Any) -> None:
         atoms["positions"], cell, bidx, strain_pos, strain_cell
     )
     atoms["positions"] = scaled_pos
-    object.__setattr__(padded, "cell", scaled_cell)
+    set_transient(padded, "cell", scaled_cell)
 
 
 def halo_exchange(

--- a/nvalchemi/distributed/partitioner.py
+++ b/nvalchemi/distributed/partitioner.py
@@ -49,6 +49,11 @@ class SpatialPartitioner:
         dimensions are squeezed internally.
     """
 
+    #: Incremented whenever the neighbour-rank set changes, so anything derived
+    #: from it can tell that its copy is stale. Class-level so a partitioner
+    #: built without ``__init__`` still carries one.
+    topology_version: int = 0
+
     def __init__(
         self,
         config: DomainConfig,
@@ -141,6 +146,9 @@ class SpatialPartitioner:
         self._span = self.neighbor_span()
         if self._span != previous_span:
             self._neighbor_ranks = self._compute_all_neighbor_ranks()
+            # Anything derived from the neighbour set — the halo config's peer
+            # list and lattice images — is now stale.
+            self.topology_version += 1
 
     # ------------------------------------------------------------------
     # Initialization helpers

--- a/nvalchemi/distributed/partitioner.py
+++ b/nvalchemi/distributed/partitioner.py
@@ -24,6 +24,10 @@ import torch
 
 from nvalchemi.distributed.config import DomainConfig
 
+# Relative slack when deciding how many domains a ghost shell spans, absorbing
+# float32 round-off in the derived domain width.
+_SPAN_ROUNDING_TOL = 1e-6
+
 
 class SpatialPartitioner:
     """Assigns atoms to spatial sub-domains on a Cartesian grid.
@@ -94,7 +98,8 @@ class SpatialPartitioner:
                 self.cells_per_dim, self.rank_grid
             )
 
-        # Precompute neighbor ranks for every rank.
+        # Precompute the ghost reach and the neighbor ranks for every rank.
+        self._span: tuple[int, int, int] = self.neighbor_span()
         self._neighbor_ranks: dict[int, list[int]] = self._compute_all_neighbor_ranks()
 
         # Precompute the cell-matrix inverse used by ``assign_atoms_to_ranks``.
@@ -115,14 +120,27 @@ class SpatialPartitioner:
         partition-time box: as the cell grows, wrapped positions fall outside it
         (fractional coords >= 1) and ``assign_atoms_to_ranks`` misroutes atoms.
 
-        Note: this handles cell *scaling* (the fix for barostat expansion). Large
-        *contraction* additionally needs the cell grid / neighbor-rank set to
-        adapt (the ghost region spans more grid cells as the box shrinks); that
-        adaptive-grid work is not covered here.
+        Contraction narrows every domain, so the ghost shell can come to span
+        more than one of them; the neighbour-rank set is rebuilt whenever that
+        happens, and :meth:`neighbor_span` raises if the geometry has contracted
+        past what the halo can express.
+
+        Parameters
+        ----------
+        cell_matrix : torch.Tensor
+            The barostat's updated cell, ``(3, 3)`` or ``(1, 3, 3)``.
+
+        Returns
+        -------
+        None
         """
         cm = cell_matrix.squeeze(0) if cell_matrix.ndim == 3 else cell_matrix
+        previous_span = getattr(self, "_span", None)
         self.cell_matrix = cm.detach()
         self._inv_cell = torch.linalg.inv(self.cell_matrix)
+        self._span = self.neighbor_span()
+        if self._span != previous_span:
+            self._neighbor_ranks = self._compute_all_neighbor_ranks()
 
     # ------------------------------------------------------------------
     # Initialization helpers
@@ -376,30 +394,102 @@ class SpatialPartitioner:
     # Neighbor ranks
     # ------------------------------------------------------------------
 
+    def domain_widths(self) -> tuple[float, float, float]:
+        """Physical width of one rank's domain along each axis, in Angstroms.
+
+        Each rank owns ``ceil(N_d / P_d)`` grid cells of width
+        ``face_distance_d / N_d``.
+
+        Returns
+        -------
+        tuple[float, float, float]
+            Per-axis domain width.
+        """
+        cm = self.cell_matrix
+        inv_cell_T = torch.linalg.inv(cm).mT
+        widths: list[float] = []
+        for d in range(3):
+            face = 1.0 / torch.linalg.norm(inv_cell_T[d]).item()
+            n_d = self.cells_per_dim[d]
+            cells_per_rank = math.ceil(n_d / self.rank_grid[d])
+            widths.append(cells_per_rank * face / n_d)
+        return (widths[0], widths[1], widths[2])
+
+    def neighbor_span(self) -> tuple[int, int, int]:
+        """Rank offsets the ghost shell reaches along each axis.
+
+        ``ceil(ghost_width / domain_width)`` — 1 while the ghost fits inside one
+        domain, more once it does not (many ranks, a small cell, or a barostat
+        contracting the box). Communicating only ``+/-1`` in that case silently
+        drops every interaction that spans two or more domains.
+
+        Returns
+        -------
+        tuple[int, int, int]
+            Per-axis offset range.
+
+        Raises
+        ------
+        ValueError
+            If the shell would have to wrap onto the rank's own periodic image,
+            which the halo exchange cannot express.
+        """
+        ghost = self.config.effective_ghost_width()
+        widths = self.domain_widths()
+        span: list[int] = []
+        for d in range(3):
+            # ``domain_widths`` derives the face distance from a float32 matrix
+            # inverse, so a shell that fits exactly lands a few ulp above 1.0 and
+            # would round up to a spurious extra domain. Absorb that before the
+            # ceil; a genuine overshoot is orders of magnitude larger.
+            ratio = (ghost / widths[d]) - _SPAN_ROUNDING_TOL if widths[d] > 0 else 0.0
+            s = max(1, math.ceil(ratio)) if widths[d] > 0 else 1
+            p_d = self.rank_grid[d]
+            # An offset of +/-P_d wraps back onto the rank itself, so the shell
+            # would need the rank's own periodic image as a ghost -- something
+            # the neighbour list cannot express. Reaching every OTHER rank is
+            # fine (they simply dedupe), so only s >= P_d is fatal.
+            if bool(self.pbc[d]) and s >= p_d > 1:
+                raise ValueError(
+                    f"Ghost width {ghost:.3f} A spans {s} rank domains along "
+                    f"axis {d} (domain width {widths[d]:.3f} A, {p_d} ranks on "
+                    f"that axis), so the halo would wrap onto the rank's own "
+                    f"periodic image. Use fewer ranks, a larger cell, or a "
+                    f"smaller cutoff/skin."
+                )
+            span.append(min(s, p_d - 1) if p_d > 1 else 0)
+        return (span[0], span[1], span[2])
+
     def _compute_all_neighbor_ranks(self) -> dict[int, list[int]]:
         """Precompute the set of neighbor ranks for every rank."""
         Px, Py, Pz = self.rank_grid
         total_ranks = Px * Py * Pz
+        span = self.neighbor_span()
         neighbor_map: dict[int, list[int]] = {}
         for rank in range(total_ranks):
-            neighbor_map[rank] = self._compute_neighbor_ranks_for(rank)
+            neighbor_map[rank] = self._compute_neighbor_ranks_for(rank, span)
         return neighbor_map
 
-    def _compute_neighbor_ranks_for(self, rank: int) -> list[int]:
-        """Return up to 26 spatial neighbor ranks for *rank*.
+    def _compute_neighbor_ranks_for(
+        self, rank: int, span: tuple[int, int, int] | None = None
+    ) -> list[int]:
+        """Return the spatial neighbor ranks the ghost shell reaches for *rank*.
 
-        For PBC dimensions, wrap around. For non-PBC, skip out-of-bounds.
+        *span* is the per-axis offset range from :meth:`neighbor_span` (computed
+        on demand when omitted). For PBC dimensions, wrap around. For non-PBC,
+        skip out-of-bounds.
         """
         Px, Py, Pz = self.rank_grid
         rx, ry, rz = self.rank_to_grid_coords(rank)
         pbc_x = bool(self.pbc[0])
         pbc_y = bool(self.pbc[1])
         pbc_z = bool(self.pbc[2])
+        sx, sy, sz = span if span is not None else self.neighbor_span()
 
         neighbors: list[int] = []
-        for dx in (-1, 0, 1):
-            for dy in (-1, 0, 1):
-                for dz in (-1, 0, 1):
+        for dx in range(-sx, sx + 1):
+            for dy in range(-sy, sy + 1):
+                for dz in range(-sz, sz + 1):
                     if dx == 0 and dy == 0 and dz == 0:
                         continue
                     nx = rx + dx
@@ -520,9 +610,36 @@ class IndexPartitioner:
         self.world_size: int = config.mesh.size() if config.mesh is not None else 1
 
     def get_neighbor_ranks(self, rank: int) -> list[int]:
+        """Every other rank: an index partition has no boundary shell.
+
+        Parameters
+        ----------
+        rank : int
+            The rank whose neighbours are wanted.
+
+        Returns
+        -------
+        list[int]
+            All ranks except *rank*.
+        """
         return [r for r in range(self.world_size) if r != rank]
 
     def assign_atoms_to_ranks(self, positions: torch.Tensor) -> torch.Tensor:
+        """Assign atoms to ranks in balanced contiguous index blocks.
+
+        Position-independent, unlike the spatial partitioner: atom order alone
+        decides the owner, so the assignment is stable as atoms move.
+
+        Parameters
+        ----------
+        positions : torch.Tensor
+            Atomic positions, read only for their count and device.
+
+        Returns
+        -------
+        torch.Tensor
+            Owning rank per atom, shape ``[N]``.
+        """
         n = positions.shape[0]
         counts = self._owned_counts(n)
         return torch.repeat_interleave(

--- a/nvalchemi/distributed/sharded_batch.py
+++ b/nvalchemi/distributed/sharded_batch.py
@@ -83,6 +83,40 @@ _FLOAT_DTYPE_TO_CODE: dict[torch.dtype, int] = {
 }
 
 
+# Per-system fields the scatter broadcasts explicitly; discovery skips them.
+_EXPLICIT_SYSTEM_FIELDS: frozenset[str] = frozenset({"cell", "pbc"})
+
+
+def _discover_system_schema(batch: Batch) -> list[dict[str, Any]]:
+    """Enumerate replicated per-system fields on *batch*.
+
+    Reads the system group directly so graph-level model inputs the producer
+    attached (total ``charge``, ``spin`` multiplicity, custom user fields via
+    ``add_system_property``) reach every rank. Without them a wrapper falls back
+    to its neutral defaults and computes a different physical system.
+    ``cell`` / ``pbc`` are excluded because the scatter broadcasts them ahead of
+    the partitioner build.
+
+    Parameters
+    ----------
+    batch : Batch
+        Source batch on the scatter rank.
+
+    Returns
+    -------
+    list[dict]
+        One entry per field with ``name``, ``dtype`` and ``shape``.
+    """
+    system = batch._system_group
+    if system is None:
+        return []
+    return [
+        {"name": name, "dtype": tensor.dtype, "shape": tuple(tensor.shape)}
+        for name, tensor in system.items()
+        if name not in _EXPLICIT_SYSTEM_FIELDS and isinstance(tensor, torch.Tensor)
+    ]
+
+
 def _discover_atom_schema(batch: Batch) -> list[dict[str, Any]]:
     """Enumerate scatter-eligible per-atom fields on *batch*.
 
@@ -153,7 +187,8 @@ class ShardedBatch(ShardedCollection):
 
     Per-atom fields are ``ShardTensor(Shard(0))`` of global shape
     ``(n_global, ...)`` with each rank physically holding ``n_owned``
-    rows. Per-system fields (``cell``, ``pbc``) are replicated.
+    rows. Per-system fields (``cell``, ``pbc``, and everything else in the
+    batch's system group, e.g. ``charge`` / ``spin``) are replicated.
 
     Obtained via :meth:`from_batch` (scatter from the source rank) and
     consumed by :class:`~nvalchemi.distributed.distributed_model.DistributedModel`
@@ -169,6 +204,7 @@ class ShardedBatch(ShardedCollection):
         pbc: torch.Tensor,
         n_global: int,
         partition_mode: str = "spatial",
+        system_fields: dict[str, torch.Tensor] | None = None,
     ) -> None:
         super().__init__(
             mesh,
@@ -177,6 +213,9 @@ class ShardedBatch(ShardedCollection):
         )
         self.cell = cell
         self.pbc = pbc
+        # Replicated per-system inputs beyond cell/pbc (total charge, spin
+        # multiplicity, custom system properties). Every rank holds all systems.
+        self.system_fields: dict[str, torch.Tensor] = system_fields or {}
         self._n_global = n_global
         # Storage flavour. ``"spatial"`` / ``"contiguous_block"`` both use
         # ShardTensor with ``Shard(0)`` placement (per-rank ``n_owned`` rows);
@@ -346,10 +385,16 @@ class ShardedBatch(ShardedCollection):
         group = mesh_group(mesh)
 
         # --- Resolve device ---
+        # Non-src ranks have no batch to read the device from. The mesh's device
+        # type is what the collectives below run on, so preferring CUDA here
+        # would put them on a different device than a CPU-mesh src rank and
+        # deadlock the first broadcast.
         if batch is not None:
             device = batch.positions.device
-        elif torch.cuda.is_available():
-            device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        elif (
+            getattr(mesh, "device_type", "cpu") == "cuda" and torch.cuda.is_available()
+        ):
+            device = torch.device("cuda", torch.cuda.current_device())
         else:
             device = torch.device("cpu")
 
@@ -468,6 +513,15 @@ class ShardedBatch(ShardedCollection):
             src=src,
         )
 
+        # --- Replicate the remaining per-system fields (charge, spin, custom
+        # system properties) so every rank models the same physical system. ---
+        system_fields = ShardedBatch._broadcast_system_fields(
+            batch if local_rank == src else None,
+            device=device,
+            src=src,
+            group=group,
+        )
+
         # Each strategy gets its natural ShardState: the spatial-halo layout
         # carries the partitioner + ghost view (:class:`HaloShardState`); graph
         # parallel gets the generic base (no halo baggage).
@@ -478,10 +532,57 @@ class ShardedBatch(ShardedCollection):
             pbc=pbc,
             n_global=n_global,
             partition_mode=partition_mode,
+            system_fields=system_fields,
         )
         if partition_mode == "spatial":
             return HaloShardState(partitioner=partitioner, **common)
         return ShardedBatch(**common)
+
+    @staticmethod
+    def _broadcast_system_fields(
+        batch: Batch | None,
+        *,
+        device: torch.device,
+        src: int,
+        group: Any,
+    ) -> dict[str, torch.Tensor]:
+        """Replicate *batch*'s per-system fields from *src* onto every rank.
+
+        Parameters
+        ----------
+        batch : Batch | None
+            Source batch on the scatter rank; ``None`` elsewhere.
+        device : torch.device
+            Device to allocate the replicated tensors on.
+        src : int
+            Group-local source rank.
+        group : Any
+            Process group to broadcast over.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            Field name -> replicated tensor, identical on every rank.
+        """
+        schema = _discover_system_schema(batch) if batch is not None else None
+        holder: list[Any] = [schema]
+        if dist.is_initialized():
+            dist.broadcast_object_list(holder, src=_global_src(group, src), group=group)
+        schema = holder[0] or []
+
+        fields: dict[str, torch.Tensor] = {}
+        for entry in schema:
+            name = entry["name"]
+            if batch is not None:
+                tensor = getattr(batch, name).to(device=device).contiguous()
+            else:
+                tensor = torch.zeros(
+                    entry["shape"], dtype=entry["dtype"], device=device
+                )
+            if dist.is_initialized():
+                dist.broadcast(tensor, src=_global_src(group, src), group=group)
+            fields[name] = tensor
+        return fields
 
     # ------------------------------------------------------------------
     # Local view: per-rank owned rows as a plain Batch
@@ -540,6 +641,12 @@ class ShardedBatch(ShardedCollection):
                 ctor_kwargs[name] = tensor
             else:
                 extras[name] = tensor
+        system_extras: dict[str, torch.Tensor] = {}
+        for name, tensor in self.system_fields.items():
+            if name in ctor_known:
+                ctor_kwargs[name] = tensor
+            else:
+                system_extras[name] = tensor
         data = AtomicData.model_construct(**ctor_kwargs)
         # Custom fields (not on the model) still need add_node_property
         # for the level_storage bookkeeping. Those don't carry the
@@ -547,6 +654,9 @@ class ShardedBatch(ShardedCollection):
         # own field-validator chain, which extras bypass entirely.
         for name, tensor in extras.items():
             data.add_node_property(name, tensor)
+
+        for name, tensor in system_extras.items():
+            data.add_system_property(name, tensor)
 
         if node_properties:
             for name, tensor in node_properties.items():
@@ -595,9 +705,17 @@ class ShardedBatch(ShardedCollection):
         extras: dict[str, torch.Tensor] = {}
         for name, tensor in tensors.items():
             (ctor if name in known else extras)[name] = tensor
+        system_extras: dict[str, torch.Tensor] = {}
+        for name, tensor in self.system_fields.items():
+            if name in known:
+                ctor[name] = tensor
+            else:
+                system_extras[name] = tensor
         data = AtomicData.model_construct(**ctor)
         for name, tensor in extras.items():
             data.add_node_property(name, tensor)
+        for name, tensor in system_extras.items():
+            data.add_system_property(name, tensor)
 
         return BatchCls.from_data_list([data], device=device)
 
@@ -712,6 +830,7 @@ class HaloShardState(ShardedBatch):
         n_global: int,
         partitioner: SpatialPartitioner | None = None,
         partition_mode: str = "spatial",
+        system_fields: dict[str, torch.Tensor] | None = None,
     ) -> None:
         super().__init__(
             mesh=mesh,
@@ -720,6 +839,7 @@ class HaloShardState(ShardedBatch):
             pbc=pbc,
             n_global=n_global,
             partition_mode=partition_mode,
+            system_fields=system_fields,
         )
         # Spatial decomposition built from the broadcast geometry during
         # :meth:`ShardedBatch.from_batch`. Cached so downstream consumers
@@ -734,6 +854,20 @@ class HaloShardState(ShardedBatch):
         # ``None`` until ``halo_exchange`` runs.
         self.padded_batch: Batch | None = None
         self.halo_meta: ParticleHaloMetadata | None = None
+        # Owned-shape autograd leaves, by per-atom field name, shared by every
+        # halo built while set. ``halo_exchange`` otherwise mints a fresh
+        # ``positions`` leaf per call and gathers other fields through a plain
+        # collective, so two halos over one owned set land in disjoint graphs
+        # and non-position fields carry no gradient at all. A pinned field is
+        # instead gathered through the autograd-aware primitive, which routes
+        # each ghost row's gradient back to the owning rank. Set for the
+        # duration of such a caller's forward and cleared after.
+        self.grad_fields: dict[str, torch.Tensor] | None = None
+        # Symmetric per-system strain leaves ``(positions, cell)`` applied to
+        # the padded view by every halo built while set, so a caller taking
+        # ``d(energy)/d(strain)`` for the virial keeps them across the model's
+        # own halo refreshes. ``None`` leaves the geometry unstrained.
+        self.grad_strain: "tuple[torch.Tensor, torch.Tensor] | None" = None
 
     @property
     def partitioner(self) -> SpatialPartitioner | None:

--- a/nvalchemi/distributed/spec.py
+++ b/nvalchemi/distributed/spec.py
@@ -208,6 +208,62 @@ def _decode_output_kinds(raw: Any) -> dict[str, OutputKind]:
     return out
 
 
+def _compile_policy_to_dict(cp: "CompilePolicy | None") -> "dict[str, Any] | None":
+    """Encode a :class:`CompilePolicy` for the JSON wire format.
+
+    ``graph_padder`` is a live object with model-specific construction and has
+    no wire representation, so it is not carried; a spec that declared one warns
+    on the way out rather than losing it silently.
+
+    Parameters
+    ----------
+    cp : CompilePolicy or None
+        The policy to encode.
+
+    Returns
+    -------
+    dict or None
+        JSON-friendly mapping, or ``None`` when no policy was declared.
+    """
+    if cp is None:
+        return None
+    if cp.graph_padder is not None:
+        warnings.warn(
+            "MLIPSpec.to_dict: CompilePolicy.graph_padder is not serializable; "
+            "the reloaded spec will use the default padder. Pass the spec object "
+            "directly for compiled distributed runs.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return {
+        "static_shapes": cp.static_shapes,
+        "force_strategy": cp.force_strategy.value,
+        "stress_via_strain": cp.stress_via_strain,
+    }
+
+
+def _compile_policy_from_dict(raw: "Any") -> "CompilePolicy | None":
+    """Inverse of :func:`_compile_policy_to_dict`.
+
+    Parameters
+    ----------
+    raw : Any
+        The encoded mapping, or ``None``.
+
+    Returns
+    -------
+    CompilePolicy or None
+        The decoded policy, or ``None`` when none was encoded.
+    """
+    if not raw:
+        return None
+    return CompilePolicy(
+        static_shapes=raw.get("static_shapes", True),
+        force_strategy=ForceStrategy(raw["force_strategy"]),
+        stress_via_strain=raw.get("stress_via_strain", False),
+    )
+
+
 class ForceStrategy(Enum):
     """How a model's forces are produced under a distributed forward.
 
@@ -452,6 +508,26 @@ class MLIPSpec:
             compile=_merge_compile_policies(self.compile, other.compile),
         )
 
+    def with_outputs(self, outputs: dict[str, OutputSpec]) -> "MLIPSpec":
+        """Return a copy with ``outputs`` layered over the declared ones.
+
+        Composes additively, like :meth:`with_adapters`: keys given here replace
+        their counterparts and every other classification is carried through.
+
+        Parameters
+        ----------
+        outputs : dict[str, OutputSpec]
+            Classifications to override.
+
+        Returns
+        -------
+        MLIPSpec
+            The spec with those outputs reclassified.
+        """
+        import dataclasses  # noqa: PLC0415
+
+        return dataclasses.replace(self, outputs=outputs)
+
     def with_adapters(self, *adapters: Any) -> "MLIPSpec":
         """Return a copy with ``adapters`` added to the distribution.
 
@@ -532,6 +608,10 @@ class MLIPSpec:
             "output_kinds": [
                 [k, self.output_kinds[k].value] for k in sorted(self.output_kinds)
             ],
+            # Dropping this silently would hand the loader a spec whose forces
+            # are computed by the model instead of the framework, which for a
+            # ``forces_via_autograd`` model scales them by the world size.
+            "compile": _compile_policy_to_dict(self.compile),
         }
 
     @classmethod
@@ -552,6 +632,7 @@ class MLIPSpec:
                 owned_only_outputs=frozenset(d.get("owned_only_outputs", [])),
                 all_reduce_outputs=frozenset(d.get("all_reduce_outputs", [])),
                 output_kinds=_decode_output_kinds(d.get("output_kinds", [])),
+                compile=_compile_policy_from_dict(d.get("compile")),
             )
         raise ValueError(
             f"MLIPSpec.from_dict: unsupported version {version}; "

--- a/nvalchemi/distributed/strategy.py
+++ b/nvalchemi/distributed/strategy.py
@@ -620,6 +620,22 @@ def _graph_partition_run_forward(
     pos.requires_grad_(True)
     atoms["positions"] = pos
 
+    # Each rank differentiates only its owned energy, so the per-rank virials are
+    # genuine partials that sum to the global one.
+    _want_stress = "stress" in dist_model._wrapper.model_config.active_outputs
+    strain = cell_local = None
+    if _want_stress:
+        from nvalchemi.models._utils import prepare_strain  # noqa: PLC0415
+
+        cell_local = owned.cell
+        cell_local = (
+            cell_local.to_local() if hasattr(cell_local, "to_local") else cell_local
+        )
+        atoms["positions"], strained_cell, strain = prepare_strain(
+            pos, cell_local, owned.batch_idx.long()
+        )
+        object.__setattr__(owned, "cell", strained_cell)
+
     # Publish the per-step routing + policy so the wrapper's intent verbs
     # (refresh_neighbors / system_sum) resolve to the GP collectives.
     dist_model._dist_ctx.policy = dist_model._spec.distribution.policy
@@ -645,15 +661,38 @@ def _graph_partition_run_forward(
             # reduce-scatter adjoint already routes each owned atom's cross-rank
             # gradient back, so the owned forces come out globally-correct.
             energy_partial = output["energy"]
-            if _want_forces:
-                (grad,) = torch.autograd.grad(
+            if _want_forces or _want_stress:
+                _inputs = ([pos] if _want_forces else []) + (
+                    [strain] if _want_stress else []
+                )
+                _grads = torch.autograd.grad(
                     [energy_partial.sum()],
-                    [pos],
+                    _inputs,
                     create_graph=False,
                     retain_graph=False,
                     allow_unused=True,
                 )
-                output["forces"] = torch.zeros_like(pos) if grad is None else -grad
+                if _want_forces:
+                    grad = _grads[0]
+                    output["forces"] = torch.zeros_like(pos) if grad is None else -grad
+                if _want_stress:
+                    virial = _grads[-1]
+                    if virial is None:
+                        virial = torch.zeros(
+                            owned.num_graphs, 3, 3, dtype=pos.dtype, device=pos.device
+                        )
+                    virial = virial.detach()
+                    if dist.is_initialized() and world > 1:
+                        from nvalchemi.distributed._core.gather_primitives import (  # noqa: PLC0415
+                            mesh_group as _mesh_group,
+                        )
+
+                        dist.all_reduce(
+                            virial, op=dist.ReduceOp.SUM, group=_mesh_group(mesh)
+                        )
+                    output["stress"] = virial / torch.linalg.det(
+                        cell_local
+                    ).abs().reshape(-1, 1, 1)
             # Global energy for reporting: a plain SUM across ranks of the owned
             # partials (every atom is owned once, so no double count). Detached —
             # the force path is already complete, and an autograd-aware reduce
@@ -755,11 +794,7 @@ def _halo_run_forward(
     _dd_compile = bool(
         _cp is not None and _cp.forces_via_autograd and dist_model._dd_compile_requested
     )
-    if wired_fields and _dd_compile:
-        raise NotImplementedError(
-            "wired_fields (cross-model field injection) is only supported "
-            "on the eager distributed path, not compiled."
-        )
+
     _pad_active = _dd_compile
     _orig_atoms = _orig_edges = None
     if _pad_active:
@@ -799,14 +834,63 @@ def _halo_run_forward(
     # Make the live per-step context ambient for the wrapper's forward, so
     # context-aware helpers and adapter bodies read it through
     # ``current_dd_context()``.
-    if _dd_compile:
-        # Compiled energy-autograd forward, framework-owned: the wrapper runs
-        # energy-only on plain tensors with the halo routing threaded as
-        # graph inputs; the framework consolidates per-node energy and takes
-        # the force autograd.
+    # ``forces_via_autograd`` hands the framework every derivative, eagerly too:
+    # a derivative taken inside the wrapper sees only this rank's padded block.
+    # ...but only when a derivative was requested, and never for a wired field:
+    # a wired group owns its coupled autograd, and its consumer needs dE/dr at
+    # fixed field rather than autograd over the total.
+    _active = set(dist_model._wrapper.model_config.active_outputs)
+    # Left to itself the model would differentiate an already all-reduced energy
+    # and scale every force by the world size, so the framework owns it.
+    _framework_autograd = (
+        _cp is not None
+        and _cp.forces_via_autograd
+        and bool({"forces", "stress"} & _active)
+    )
+    # Wired fields: an upstream model's owned values gathered into this model's
+    # ghost layout. Before promotion, so the grad-carrying tensor is wrapped.
+    _wired_owned = None
+    # Wired fields: an upstream model's owned values gathered into this model's
+    # ghost layout. Injected before the fixed-shape padding below
+    # so the padder covers it too — a cap-sized batch carrying one real-sized
+    # field would break the compiled graph's static shapes.
+    if wired_fields:
+        from nvalchemi.distributed._core.particle_halo import (  # noqa: PLC0415
+            halo_forward_exchange,
+        )
+
+        _atoms = padded_batch._atoms_group
+        # Under compile the batch has already been padded to the fixed-shape
+        # atom cap, so the gathered field has to reach the same length or the
+        # storage rejects it. Zero-pad the dead rows exactly as the graph padder
+        # does for every other per-atom field; they carry no physics and the cat
+        # leaves the real rows' autograd intact.
+        _n_cap = int(padded_batch.num_nodes)
+        for _name, _owned in wired_fields.items():
+            _field = halo_forward_exchange(_owned, meta, dist_model._halo_config)
+            _n_real = int(_field.shape[0])
+            if _n_real < _n_cap:
+                _field = torch.cat(
+                    [
+                        _field,
+                        _field.new_zeros((_n_cap - _n_real,) + tuple(_field.shape[1:])),
+                    ],
+                    dim=0,
+                )
+            _atoms[_name] = _field
+        _wired_owned = list(wired_fields.values())
+    if _dd_compile or _framework_autograd:
+        # Pinned leaves mean the caller backwards through this forward too, so
+        # the framework must not free the graph.
+        _pinned_leaves = bool(getattr(sharded, "grad_fields", None))
         with activate_dd_context(dist_model._dist_ctx):
             output = dist_model._compiled_energy_autograd_forward(
-                padded_batch, meta, sharded.num_graphs
+                padded_batch,
+                meta,
+                sharded.num_graphs,
+                eager=not _dd_compile,
+                extra_grad_inputs=_wired_owned,
+                retain_graph=_pinned_leaves,
             )
     else:
         # Cross-model wired fields: overwrite named per-atom inputs with an
@@ -814,16 +898,6 @@ def _halo_run_forward(
         # layout via the autograd-aware halo exchange. Runs before promotion
         # so the gathered (grad-carrying) tensor is what gets wrapped; its
         # backward scatter-adds ghost grads to the producing rank's owner.
-        if wired_fields:
-            from nvalchemi.distributed._core.particle_halo import (  # noqa: PLC0415
-                halo_forward_exchange,
-            )
-
-            _atoms = padded_batch._atoms_group
-            for _name, _owned in wired_fields.items():
-                _atoms[_name] = halo_forward_exchange(
-                    _owned, meta, dist_model._halo_config
-                )
         # Eager: promote ``positions`` (and other primary per-atom inputs)
         # to ShardTensors so custom ops see a ShardTensor input and the
         # per-layer halo correction fires.
@@ -889,12 +963,13 @@ def _halo_run_forward(
                     _eager_padder.restore()
                 if _saved_active is not None:
                     _mc.active_outputs = _saved_active
-    # Under compile, forces/stress come from autograd over the global
-    # energy, so they need the halo-reverse consolidation rather than the
-    # eager owned-only slice — drop them from owned_only. Eager keeps the
-    # declared slice.
+    # Whenever the framework derives forces/stress by autograd over the global
+    # energy, the per-node results carry ghost-row gradients that belong to
+    # other ranks' owners, so they need the halo-reverse consolidation rather
+    # than the owned-only slice — drop them from owned_only. A wrapper that
+    # returns its own per-owned-row kernel forces keeps the declared slice.
     owned_only = dist_model._spec.owned_only_outputs
-    if _dd_compile:
+    if _dd_compile or _framework_autograd:
         owned_only = owned_only - dist_model._wrapper.model_config.autograd_outputs
     result = consolidate_padded_outputs(
         output,

--- a/nvalchemi/distributed/strategy.py
+++ b/nvalchemi/distributed/strategy.py
@@ -401,19 +401,17 @@ class HaloStrategy(ParallelizationStrategy):
         }
 
         new_batch = _build_batch_from_fields(new_fields, device)
-        if getattr(batch, "cell", None) is not None:
-            new_batch.cell = batch.cell.clone()
-        if getattr(batch, "pbc", None) is not None:
-            new_batch.pbc = batch.pbc.clone()
-        if getattr(batch, "energy", None) is not None:
-            new_batch.energy = batch.energy.clone()
-        # Per-graph extras the integrator reads back (e.g. NPT/NPH read
-        # ``batch.stress`` in pre_update before the next compute fills it).
-        # Migration changes atom ownership, not system count, so carry these
-        # per-system tensors across verbatim.
-        stress = getattr(batch, "stress", None)
-        if stress is not None:
-            new_batch["stress"] = stress.clone()
+        # Migration changes atom ownership, not the system schema, so every
+        # per-system tensor carries across verbatim: the cell and pbc the
+        # partition is judged against, per-graph values an integrator reads back
+        # (NPT reads ``stress`` before the next compute fills it), and model
+        # inputs a producer attached such as total charge or spin. Naming them
+        # individually silently drops whatever the list does not mention.
+        system = batch._system_group
+        if system is not None:
+            for name, tensor in system.items():
+                if isinstance(tensor, torch.Tensor):
+                    new_batch[name] = tensor.clone()
 
         # Refresh the persistent state to match the new layout and invalidate the
         # padded view — migration changes rank ownership, so the halo routing and

--- a/nvalchemi/distributed/strategy.py
+++ b/nvalchemi/distributed/strategy.py
@@ -625,6 +625,7 @@ def _graph_partition_run_forward(
     _want_stress = "stress" in dist_model._wrapper.model_config.active_outputs
     strain = cell_local = None
     if _want_stress:
+        from nvalchemi.data.batch import set_transient  # noqa: PLC0415
         from nvalchemi.models._utils import prepare_strain  # noqa: PLC0415
 
         cell_local = owned.cell
@@ -634,7 +635,7 @@ def _graph_partition_run_forward(
         atoms["positions"], strained_cell, strain = prepare_strain(
             pos, cell_local, owned.batch_idx.long()
         )
-        object.__setattr__(owned, "cell", strained_cell)
+        set_transient(owned, "cell", strained_cell)
 
     # Publish the per-step routing + policy so the wrapper's intent verbs
     # (refresh_neighbors / system_sum) resolve to the GP collectives.

--- a/nvalchemi/distributed/validate/worker.py
+++ b/nvalchemi/distributed/validate/worker.py
@@ -49,6 +49,47 @@ from nvalchemi.distributed.validate.reference import _ensure_neighbors
 __all__ = ["_worker_main", "_patch_physicsnemo_all_to_all_for_gloo"]
 
 
+def _rebind_replacements(spec: MLIPSpec, live: "MLIPSpec | None") -> None:
+    """Restore adapter replacements that could not cross the spawn boundary.
+
+    A replacement a wrapper builds from its own submodules — the per-layer halo
+    refresh, say — is a closure with no importable qualname, so ``from_dict``
+    leaves it unset and the adapter installs as a no-op, giving wrong results
+    rather than an error. Take the live object from the wrapper's own spec.
+
+    Parameters
+    ----------
+    spec : MLIPSpec
+        The deserialized spec, mutated in place.
+    live : MLIPSpec or None
+        The wrapper's freshly built spec, or ``None`` if it declares none.
+
+    Returns
+    -------
+    None
+    """
+    if live is None:
+        return
+
+    def _target(adapter: Any) -> tuple:
+        # Everything the adapter serializes except the replacement itself
+        # identifies what it patches, for any adapter kind.
+        d = {k: v for k, v in adapter.to_dict().items() if k != "replacement"}
+        return tuple(sorted(d.items()))
+
+    by_target = {
+        _target(h): h
+        for h in live.distribution.third_party_helpers
+        if getattr(h, "replacement", None) is not None
+    }
+    for helper in spec.distribution.third_party_helpers:
+        if getattr(helper, "replacement", None) is not None:
+            continue
+        match = by_target.get(_target(helper))
+        if match is not None:
+            object.__setattr__(helper, "replacement", match.replacement)
+
+
 def _worker_main(
     rank: int,
     world_size: int,
@@ -191,10 +232,10 @@ def _worker_main(
             # qualnames already in ``torch.ops``.
             wrapper = model_factory().to(device_str)
             _ds = getattr(wrapper, "distribution_spec", None)
-            if callable(_ds):
-                _ds()
+            _live_spec = _ds() if callable(_ds) else None
 
             spec = MLIPSpec.from_dict(spec_dict)
+            _rebind_replacements(spec, _live_spec)
             sample_batch = _payload_to_batch(sample_payload, device=device_str)
 
             # Reconstruct neighbours on the worker side using the wrapper's

--- a/nvalchemi/distributed/validate/worker.py
+++ b/nvalchemi/distributed/validate/worker.py
@@ -49,7 +49,7 @@ from nvalchemi.distributed.validate.reference import _ensure_neighbors
 __all__ = ["_worker_main", "_patch_physicsnemo_all_to_all_for_gloo"]
 
 
-def _rebind_replacements(spec: MLIPSpec, live: "MLIPSpec | None") -> None:
+def _rebind_replacements(spec: MLIPSpec, live: MLIPSpec | None) -> None:
     """Restore adapter replacements that could not cross the spawn boundary.
 
     A replacement a wrapper builds from its own submodules — the per-layer halo

--- a/nvalchemi/models/_ops/electrostatics/ewald.py
+++ b/nvalchemi/models/_ops/electrostatics/ewald.py
@@ -795,6 +795,54 @@ def _owned_charge_mask(charges: torch.Tensor, n_owned: Any) -> torch.Tensor:
     return charges * (rowidx < n_owned).to(charges.dtype)
 
 
+def _reciprocal_torch_local(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    k_vectors: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+) -> torch.Tensor:
+    """Single-process autograd-native reciprocal per-atom energy.
+
+    The staged structure-factor form, differentiable in positions, charges **and**
+    the cell. The monolithic kernel reaches the cell only through a detached
+    Green's function, so a virial taken by strain-autograd through it is
+    incomplete; this path carries that dependence.
+
+    Parameters
+    ----------
+    positions, charges, cell, k_vectors, alpha : torch.Tensor
+        Standard reciprocal-space inputs.
+    batch_idx : torch.Tensor | None
+        Per-atom system index, or ``None`` for a single system.
+
+    Returns
+    -------
+    torch.Tensor
+        Per-atom reciprocal energy.
+    """
+    from nvalchemi.models._ops.electrostatics.ewald_recip_torch import (  # noqa: PLC0415
+        ewald_energy_from_structure_factors,
+        ewald_partial_structure_factors,
+    )
+
+    real_sf, imag_sf, total_charge = ewald_partial_structure_factors(
+        positions, charges, cell, k_vectors, alpha, batch_idx=batch_idx
+    )
+    return ewald_energy_from_structure_factors(
+        positions,
+        charges,
+        cell,
+        k_vectors,
+        alpha,
+        real_sf,
+        imag_sf,
+        total_charge,
+        batch_idx=batch_idx,
+    )
+
+
 def _reciprocal_torch_dd(
     positions: torch.Tensor,
     charges: torch.Tensor,
@@ -864,7 +912,9 @@ def ewald_reciprocal_contribution(
 
     * energy-only under domain decomposition -> Torch staged :math:`\tilde{S}` (compile-safe,
       cross-rank all-reduced);
-    * energy-only single-GPU -> the differentiable monolithic ``ewald_reciprocal_space``;
+    * energy-only single-GPU with a grad-bearing cell -> the staged
+      ``_reciprocal_torch_local`` (the only form differentiable in the cell);
+    * energy-only single-GPU otherwise -> the monolithic ``ewald_reciprocal_space``;
     * forces/virial requested (eager) -> warp staged structure factors (the spec's
       halo handlers reduce :math:`\tilde{S}` across ranks; single-GPU fires nothing).
 
@@ -875,12 +925,22 @@ def ewald_reciprocal_contribution(
     # Single-system batches pass batch_idx=None to the differentiable paths to
     # avoid a data-dependent ``nonzero`` (a graph break under compile).
     bidx = batch_idx if num_systems > 1 else None
-    autograd_recip = not compute_forces and not compute_virial
+    # The warp reciprocal only attaches dE/dq under ``hybrid_forces``; without it
+    # the energy must come from a backend that is differentiable in the charges.
+    autograd_recip = not hybrid_forces or (not compute_forces and not compute_virial)
     ctx = current_dd_context()
 
     if autograd_recip and ctx is not None and getattr(ctx, "is_halo", False):
         return (
             _reciprocal_torch_dd(positions, charges, cell, k_vectors, alpha, bidx, ctx),
+            None,
+            None,
+        )
+    if autograd_recip and cell.requires_grad:
+        # A live cell means the caller differentiates w.r.t. it (a strain-autograd
+        # virial); only the staged form carries that dependence.
+        return (
+            _reciprocal_torch_local(positions, charges, cell, k_vectors, alpha, bidx),
             None,
             None,
         )

--- a/nvalchemi/models/_ops/electrostatics/ewald_recip_torch.py
+++ b/nvalchemi/models/_ops/electrostatics/ewald_recip_torch.py
@@ -138,6 +138,15 @@ def ewald_energy_from_structure_factors(
     :func:`ewald_partial_structure_factors` + a cross-rank all-reduce the weighted
     VJP is exact for any cotangent (incl. the owned-mask DD consolidation
     produces). Returns per-atom energy ``(N,)`` float64.
+
+    ``charges`` is cast to float64 ONCE and that tensor is used for both the
+    k-sum and the corrections call. Passing the caller's original (float32)
+    tensor to the corrections while the k-sum uses the cast copy reaches the
+    opaque kernel from one leaf by two routes of differing dtype, which
+    ``torch.compile`` mis-accumulates: the traced forward and ``dE/dpositions``
+    stay exact while ``dE/dcharges`` comes out ~28% wrong (and near-zero in a
+    reduced case). Only shows up where charges carry a gradient — a wired
+    pipeline feeding in predicted charges.
     """
     from nvalchemiops.torch.interactions.electrostatics.ewald import (  # noqa: PLC0415
         ewald_energy_corrections,
@@ -172,8 +181,8 @@ def ewald_energy_from_structure_factors(
     volume = torch.abs(torch.linalg.det(cell_3d)).to(torch.float64)
     if batch_idx is None:
         return ewald_energy_corrections(
-            e_ksum, charges, volume.reshape(1), alpha_s, total_charge.reshape(1)
+            e_ksum, q, volume.reshape(1), alpha_s, total_charge.reshape(1)
         )
     return ewald_energy_corrections_batch(
-        e_ksum, charges, batch_idx.to(torch.int32), volume, alpha_s, total_charge
+        e_ksum, q, batch_idx.to(torch.int32), volume, alpha_s, total_charge
     )

--- a/nvalchemi/models/_ops/electrostatics/pme.py
+++ b/nvalchemi/models/_ops/electrostatics/pme.py
@@ -473,8 +473,9 @@ def _pme_reciprocal_space_impl_from_total_charge(
     cell_for_vol = cell_spline if cell_spline.dim() == 3 else cell_spline.unsqueeze(0)
     volume = torch.abs(torch.linalg.det(cell_for_vol)).to(input_dtype)
 
+    is_compiled = torch.compiler.is_compiling()
     mesh_fft = torch.fft.rfftn(mesh_grid, norm="backward", dim=fft_dims)
-    if torch.compiler.is_compiling():
+    if is_compiled:
         # cuFFT emits non-contiguous output; the convolve op requires contiguous
         # input under compile.
         mesh_fft = mesh_fft.contiguous()
@@ -489,6 +490,9 @@ def _pme_reciprocal_space_impl_from_total_charge(
         alpha_gsf,
         volume,
         is_batch,
+        # Autograd metadata only; the op's backward uses it to keep Inductor
+        # from reordering past the opaque consumer.
+        is_compiled,
     )
     potential_mesh = torch.fft.irfftn(
         convolved_mesh, norm="forward", s=mesh_dimensions, dim=fft_dims

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -180,8 +180,9 @@ def prepare_strain(
         The returned tensor is an unconstrained autograd leaf; only its
         symmetric part is applied as strain.
     """
+    n_systems = cell.shape[0]
     displacement = torch.zeros(
-        cell.shape[0],
+        n_systems,
         3,
         3,
         dtype=positions.dtype,

--- a/nvalchemi/models/_utils.py
+++ b/nvalchemi/models/_utils.py
@@ -37,6 +37,7 @@ from nvalchemi._typing import (
 )
 
 __all__ = [
+    "apply_strain",
     "autograd_forces",
     "autograd_forces_and_stresses",
     "autograd_stresses",
@@ -179,27 +180,62 @@ def prepare_strain(
         The returned tensor is an unconstrained autograd leaf; only its
         symmetric part is applied as strain.
     """
-    n_systems = cell.shape[0]
     displacement = torch.zeros(
-        n_systems,
+        cell.shape[0],
         3,
         3,
         dtype=positions.dtype,
         device=positions.device,
     )
     displacement.requires_grad_(True)
-    symmetric_displacement = 0.5 * (displacement + displacement.mT)
-    deformation = (
-        torch.eye(3, dtype=positions.dtype, device=positions.device)
-        + symmetric_displacement
+    scaled_positions, scaled_cell = apply_strain(
+        positions, cell, batch_idx, displacement
     )
-    # Scale positions: pos'[n] = pos[n] @ deformation[system_of_atom[n]]
-    # Index into deformation per-atom, then batch-matmul each atom's row.
-    per_atom_deformation = deformation[batch_idx]  # [N, 3, 3]
-    scaled_positions = torch.einsum("ni,nij->nj", positions, per_atom_deformation)
-    # Scale cell: cell'[b] = cell[b] @ deformation[b]
-    scaled_cell = torch.einsum("bij,bjk->bik", cell, deformation)
     return scaled_positions, scaled_cell, displacement
+
+
+def apply_strain(
+    positions: NodePositions,
+    cell: LatticeVectors,
+    batch_idx: BatchIndices,
+    displacement: StrainDisplacement,
+    cell_displacement: "StrainDisplacement | None" = None,
+) -> tuple[NodePositions, LatticeVectors]:
+    """Scale positions and cell through an existing strain leaf.
+
+    The half of :func:`prepare_strain` that does the deformation, split out for
+    callers that must strain against a leaf they already hold — a distributed
+    forward reapplies the same strain after every halo refresh, and a composed
+    pipeline shares one leaf across its models.
+
+    Parameters
+    ----------
+    positions : torch.Tensor
+        Atomic positions, shape ``[N, 3]``.
+    cell : torch.Tensor
+        Unit cell, shape ``[B, 3, 3]``.
+    batch_idx : torch.Tensor
+        Graph index per atom, shape ``[N]``.
+    displacement : torch.Tensor
+        Strain leaf, shape ``[B, 3, 3]``. Only its symmetric part is applied.
+    cell_displacement : torch.Tensor, optional
+        Separate leaf for the cell, when the position and cell halves of the
+        virial are read separately. Defaults to ``displacement``.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        ``(scaled_positions, scaled_cell)``.
+    """
+    eye = torch.eye(3, dtype=positions.dtype, device=positions.device)
+    deformation = eye + 0.5 * (displacement + displacement.mT)
+    if cell_displacement is None:
+        cell_deformation = deformation
+    else:
+        cell_deformation = eye + 0.5 * (cell_displacement + cell_displacement.mT)
+    scaled_positions = torch.einsum("ni,nij->nj", positions, deformation[batch_idx])
+    scaled_cell = torch.einsum("bij,bjk->bik", cell, cell_deformation)
+    return scaled_positions, scaled_cell
 
 
 def autograd_stresses(

--- a/nvalchemi/models/aimnet2.py
+++ b/nvalchemi/models/aimnet2.py
@@ -114,7 +114,10 @@ def _aimnet2_halo_spec() -> Any:
         CompilePolicy,
         ForceStrategy,
         MethodAdapter,
+        OutputKind,
+        OutputSpec,
         PythonAdapter,
+        Reduce,
     )
 
     helpers = (
@@ -127,23 +130,31 @@ def _aimnet2_halo_spec() -> Any:
         MethodAdapter(LRCoulomb, "forward", _distributed_coulomb_forward),
         MethodAdapter(SRCoulomb, "forward", _distributed_coulomb_forward),
     )
-    _AIMNET2_HALO_SPEC_CACHE = replace(
-        SPEC_MPNN_HALO,
-        distribution=replace(
-            SPEC_MPNN_HALO.distribution,
-            adapters=helpers,
-            # Only positions are sharded; atomic_numbers stay plain because they
-            # feed an embedding that would otherwise mix tensor types in backward.
-            shard_fields=("positions",),
-        ),
-        # Forces come from autograd over an energy-only forward; the per-system
-        # sum already yields the global energy. The dense neighbor matrix is
-        # padded to fixed shapes for compile.
-        compile=CompilePolicy(
-            static_shapes=True,
-            force_strategy=ForceStrategy.FRAMEWORK_FROM_GLOBAL_ENERGY,
-            graph_padder=DenseBatchPadder(),
-        ),
+    _AIMNET2_HALO_SPEC_CACHE = (
+        replace(
+            SPEC_MPNN_HALO,
+            distribution=replace(
+                SPEC_MPNN_HALO.distribution,
+                adapters=helpers,
+                # Only positions are sharded; atomic_numbers stay plain because they
+                # feed an embedding that would otherwise mix tensor types in backward.
+                shard_fields=("positions",),
+            ),
+            # Forces come from autograd over an energy-only forward; the per-system
+            # sum already yields the global energy. The dense neighbor matrix is
+            # padded to fixed shapes for compile.
+            compile=CompilePolicy(
+                static_shapes=True,
+                force_strategy=ForceStrategy.FRAMEWORK_FROM_GLOBAL_ENERGY,
+                graph_padder=DenseBatchPadder(),
+                # AIMNet2 is differentiable in positions and cell, so the framework
+                # strain-autograd yields the virial; without this the DD forward
+                # returns no stress at all.
+                stress_via_strain=True,
+            ),
+        )
+        # A strain-trick virial is a per-rank partial; the reduction sums them.
+        .with_outputs({"stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE)})
     )
     return _AIMNET2_HALO_SPEC_CACHE
 

--- a/nvalchemi/models/ewald.py
+++ b/nvalchemi/models/ewald.py
@@ -63,7 +63,11 @@ from torch import nn
 
 from nvalchemi._typing import ModelOutputs
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.models._utils import cell_cache_needs_update
+from nvalchemi.models._utils import (
+    autograd_forces_and_stresses,
+    cell_cache_needs_update,
+    prepare_strain,
+)
 from nvalchemi.models.base import (
     BaseModelMixin,
     ModelConfig,
@@ -132,7 +136,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         cutoff: float,
         accuracy: float = 1e-6,
         coulomb_constant: float = 14.3996,
-        hybrid_forces: bool = True,
+        hybrid_forces: bool = False,
         slab_correction: bool = False,
         rtol: float = 1e-5,
         atol: float | None = None,
@@ -167,6 +171,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         self._cache_valid: bool = False
         self._cached_alpha: torch.Tensor | None = None
         self._cached_k_vectors: torch.Tensor | None = None
+        self._cached_kspace_cutoff: Any = None
         # Cached cell for automatic invalidation detection (e.g. NPT).
         self._cached_cell: torch.Tensor | None = None
         self._energies_buf: torch.Tensor | None = None
@@ -206,6 +211,16 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
 
         if strategy == StrategyKind.GRAPH_PARTITION:
             return self._distribution_spec_gp()
+
+        if self.hybrid_forces:
+            raise NotImplementedError(
+                "Ewald under domain decomposition requires hybrid_forces=False. "
+                "The analytic direct-output path returns a virial that fuses the "
+                "per-rank real-space and the globally-replicated reciprocal terms, "
+                "which cannot be reduced correctly across ranks; it is also being "
+                "retired in nvalchemi-toolkit-ops. Construct the wrapper with "
+                "hybrid_forces=False (the default)."
+            )
 
         import torch  # noqa: PLC0415
 
@@ -288,15 +303,11 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         # instead. The wrapper emits per-atom ``atomic_energies`` that the
         # framework reduces owned-aware into the per-system energy; the dense
         # [N, K] neighbor matrix is padded to fixed shapes.
-        compile_policy = (
-            None
-            if self.hybrid_forces
-            else CompilePolicy(
-                static_shapes=True,
-                force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
-                graph_padder=DenseBatchPadder(),
-                stress_via_strain=True,
-            )
+        compile_policy = CompilePolicy(
+            static_shapes=True,
+            force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
+            graph_padder=DenseBatchPadder(),
+            stress_via_strain=True,
         )
         return MLIPSpec(
             distribution=dataclasses.replace(
@@ -309,16 +320,9 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             outputs={
                 "energy": OutputSpec(OutputKind.PER_GRAPH),
                 "forces": OutputSpec(OutputKind.PER_NODE, Reduce.OWNED_ONLY),
-                # Eager (hybrid) stress comes from the analytic kernel virial and is
-                # already global, so no reduce. Under compile the framework derives
-                # stress by strain-autograd of the consolidated global energy; that
-                # per-rank virial is a partial and must be summed across ranks
-                # (``ALL_REDUCE``) to recover the global stress.
-                "stress": (
-                    OutputSpec(OutputKind.PER_GRAPH)
-                    if self.hybrid_forces
-                    else OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE)
-                ),
+                # Stress comes from strain-autograd of the consolidated global
+                # energy, so each rank holds a partial that sums to the global.
+                "stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE),
                 "atomic_energies": OutputSpec(OutputKind.PER_NODE),
             },
             # The wrapper emits per-atom ``atomic_energies``; the framework
@@ -366,6 +370,9 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             outputs={
                 "energy": OutputSpec(OutputKind.PER_GRAPH),
                 "forces": OutputSpec(OutputKind.PER_NODE, Reduce.OWNED_ONLY),
+                # The framework strains the replicated geometry and sums each
+                # rank's owned-energy virial, so the value it returns is global.
+                "stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.OWNED_ONLY),
                 "atomic_energies": OutputSpec(OutputKind.PER_NODE, Reduce.OWNED_ONLY),
             },
             node_energy_key="atomic_energies",
@@ -506,6 +513,7 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         self._cache_valid = False
         self._cached_alpha = None
         self._cached_k_vectors = None
+        self._cached_kspace_cutoff = None
         # Keep _cached_cell so forward()'s change-detection still works; clearing
         # it would re-invalidate the cache on the very next call.
 
@@ -523,9 +531,6 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         shape-only surrogate of that size is passed to the estimator (which only
         reads ``num_atoms``) so every rank agrees.
         """
-        from nvalchemiops.torch.interactions.electrostatics.k_vectors import (  # lazy
-            generate_k_vectors_ewald_summation,
-        )
         from nvalchemiops.torch.interactions.electrostatics.parameters import (  # lazy
             estimate_ewald_parameters,
         )
@@ -540,10 +545,6 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         params = estimate_ewald_parameters(
             est_positions, cell, batch_idx=est_batch_idx, accuracy=self.accuracy
         )
-        k_vectors = generate_k_vectors_ewald_summation(
-            cell, params.reciprocal_space_cutoff
-        )
-
         self._cache_valid = True
         # ``alpha`` (the Ewald splitting parameter) is a numerical accuracy knob,
         # not a physical degree of freedom: the full Ewald sum is alpha-invariant,
@@ -557,7 +558,33 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         # reciprocal cell-virial (recovered via the strained positions and green's
         # live volume), so detaching it would drop that (much larger) term.
         self._cached_alpha = params.alpha.detach()
-        self._cached_k_vectors = k_vectors
+        self._cached_kspace_cutoff = params.reciprocal_space_cutoff
+        self._update_k_vectors(cell)
+
+    def _update_k_vectors(self, cell: torch.Tensor) -> None:
+        """Rebuild the k-vectors from *cell* at the cached reciprocal cutoff.
+
+        Separate from :meth:`_update_cache` because ``alpha`` and the reciprocal
+        cutoff depend only on the cell's value, while the k-vectors are a
+        differentiable function of the cell tensor itself. Holding the cutoff
+        fixed keeps the k-vector count stable across rebuilds.
+
+        Parameters
+        ----------
+        cell : torch.Tensor
+            Live cell ``[B, 3, 3]``; gradients flow through the result.
+
+        Returns
+        -------
+        None
+        """
+        from nvalchemiops.torch.interactions.electrostatics.k_vectors import (  # lazy  # noqa: PLC0415
+            generate_k_vectors_ewald_summation,
+        )
+
+        self._cached_k_vectors = generate_k_vectors_ewald_summation(
+            cell, self._cached_kspace_cutoff
+        )
 
     # ------------------------------------------------------------------
     # Input adaptation
@@ -754,15 +781,28 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         neighbor_matrix_shifts = inp.get("neighbor_matrix_shifts")
         pbc = inp.get("pbc")
 
-        compute_forces = "forces" in self.model_config.active_outputs
-        compute_stresses = "stress" in self.model_config.active_outputs
+        want_forces = "forces" in self.model_config.active_outputs
+        want_stress = "stress" in self.model_config.active_outputs
+        # Only the analytic path asks the kernels for derivatives. Otherwise the
+        # energy stays differentiable in positions, cell and charges, and the
+        # derivatives are taken from it below.
+        compute_forces = want_forces and self.hybrid_forces
+        compute_stresses = want_stress and self.hybrid_forces
 
         # In hybrid mode the kernel computes forces/virial analytically (no
         # autograd tape); detach so backward isn't expected when inputs already
         # carry grad (e.g. a pipeline's strain prep).
+        displacement = None
         if self.hybrid_forces:
             positions = positions.detach()
             cell = cell.detach()
+        elif want_forces or want_stress:
+            if not positions.requires_grad:
+                positions = positions.detach().requires_grad_(True)
+            if want_stress:
+                positions, cell, displacement = prepare_strain(
+                    positions, cell, batch_idx.to(torch.long)
+                )
 
         # Automatically invalidate cache when cell changes (e.g. NPT simulation).
         if cell_cache_needs_update(
@@ -774,6 +814,10 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
         # Update cached parameters if invalidated.
         if self._cache_is_stale():
             self._update_cache(positions, cell, batch_idx)
+        elif cell.requires_grad:
+            # Cached k-vectors belong to the graph of the cell they were built
+            # from, so a grad-carrying cell needs its own.
+            self._update_k_vectors(cell)
 
         alpha = self._cached_alpha  # (B,)
         k_vectors = self._cached_k_vectors
@@ -898,6 +942,35 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
                 virial = virial + v_slab
             virial = virial * self.coulomb_constant
 
+        total_energy = torch.zeros(
+            B, dtype=per_atom_energies.dtype, device=positions.device
+        ).scatter_add_(0, batch_idx.to(torch.long), per_atom_energies)
+        if not self.hybrid_forces and (want_forces or want_stress):
+            if want_stress:
+                forces, stress_ag = autograd_forces_and_stresses(
+                    total_energy.sum(),
+                    positions,
+                    displacement,
+                    data.cell,
+                    B,
+                    training=self.training,
+                    retain_graph=True,
+                )
+                virial = None
+                model_output_stress = stress_ag
+            else:
+                (grad,) = torch.autograd.grad(
+                    [total_energy.sum()],
+                    [positions],
+                    create_graph=self.training,
+                    retain_graph=True,
+                    allow_unused=True,
+                )
+                forces = torch.zeros_like(positions) if grad is None else -grad
+                model_output_stress = None
+        else:
+            model_output_stress = None
+
         per_atom_energies = per_atom_energies.to(torch.float64)
         model_output: dict[str, Any] = {}
         if "energy" in self.model_config.active_outputs:
@@ -914,11 +987,13 @@ class EwaldModelWrapper(nn.Module, BaseModelMixin):
             model_output["atomic_energies"] = per_atom_energies
         if forces is not None:
             model_output["forces"] = forces
-        if virial is not None:
+        if model_output_stress is not None:
+            model_output["stress"] = model_output_stress
+        elif virial is not None:
             # Tensile-positive Cauchy stress sigma = -W/V (eV/A^3).
             volume = torch.det(data.cell).abs().view(-1, 1, 1)
             model_output["stress"] = -virial / volume
-        elif compute_stresses:
+        elif want_stress:
             raise RuntimeError(
                 "stress was requested but the kernel did not return a virial"
             )

--- a/nvalchemi/models/mace.py
+++ b/nvalchemi/models/mace.py
@@ -332,35 +332,6 @@ def _mace_product_block_static_index_forward(
     return self.linear(node_feats)
 
 
-def _with_all_reduce_stress(spec: Any) -> Any:
-    """Declare ``stress`` as a cross-rank ``ALL_REDUCE`` output on a halo spec.
-
-    MACE computes stress with the displacement/strain trick, so under domain
-    decomposition each rank produces a per-rank *partial* virial (the strain leaf
-    deforms only its owned atoms). ``SPEC_MPNN_HALO`` ships stress as
-    ``PER_GRAPH / Reduce.NONE`` — which only divides the over-counted replicated-
-    energy gradient by ``world_size`` and never sums the partials, giving wrong
-    stress on a non-degenerate partition. ``ALL_REDUCE`` restores the global virial
-    (``/world_size`` then cross-rank sum). Mirrors UMA's stress override; the
-    ``outputs=`` lowering composes additively with the preset (energy/forces/
-    atomic_energies classifications are preserved).
-    """
-    import dataclasses  # noqa: PLC0415
-
-    from nvalchemi.distributed.output_kinds import (  # noqa: PLC0415
-        OutputKind,
-        OutputSpec,
-        Reduce,
-    )
-
-    return dataclasses.replace(
-        spec,
-        outputs={
-            "stress": OutputSpec(kind=OutputKind.PER_GRAPH, reduce=Reduce.ALL_REDUCE)
-        },
-    )
-
-
 _MACE_CUEQ_SPEC_CACHE: Any = None
 
 
@@ -444,13 +415,20 @@ def _mace_cueq_spec() -> Any:
             _mace_product_block_static_index_forward,
         ),
     )
-    from nvalchemi.distributed.spec import CompilePolicy, ForceStrategy
+    from nvalchemi.distributed.spec import (
+        CompilePolicy,
+        ForceStrategy,
+        OutputKind,
+        OutputSpec,
+        Reduce,
+    )
 
     # cueq fused kernels + the SphericalHarmonics marshal on the MPNN-halo
     # preset, plus the MACE compile policy: forces come from autograd over a
     # compiled energy-only forward.
-    _MACE_CUEQ_SPEC_CACHE = _with_all_reduce_stress(
-        SPEC_MPNN_HALO.with_adapters(*_custom_ops, *_marshal).with_compile(
+    _MACE_CUEQ_SPEC_CACHE = (
+        SPEC_MPNN_HALO.with_adapters(*_custom_ops, *_marshal)
+        .with_compile(
             CompilePolicy(
                 static_shapes=True,
                 force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
@@ -459,6 +437,8 @@ def _mace_cueq_spec() -> Any:
                 stress_via_strain=True,
             )
         )
+        # A strain-trick virial is a per-rank partial; the reduction sums them.
+        .with_outputs({"stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE)})
     )
     return _MACE_CUEQ_SPEC_CACHE
 
@@ -497,12 +477,16 @@ def _mace_scripted_spec() -> Any:
     from nvalchemi.distributed.spec import (  # noqa: PLC0415
         CompilePolicy,
         ForceStrategy,
+        OutputKind,
+        OutputSpec,
+        Reduce,
     )
 
     # The SphericalHarmonics marshal on the MPNN-halo preset, plus the MACE
     # compile policy (forces via autograd over a compiled energy-only forward).
-    _MACE_SCRIPTED_SPEC_CACHE = _with_all_reduce_stress(
-        SPEC_MPNN_HALO.with_adapters(*_marshal).with_compile(
+    _MACE_SCRIPTED_SPEC_CACHE = (
+        SPEC_MPNN_HALO.with_adapters(*_marshal)
+        .with_compile(
             CompilePolicy(
                 static_shapes=True,
                 force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
@@ -511,6 +495,8 @@ def _mace_scripted_spec() -> Any:
                 stress_via_strain=True,
             )
         )
+        # A strain-trick virial is a per-rank partial; the reduction sums them.
+        .with_outputs({"stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE)})
     )
     return _MACE_SCRIPTED_SPEC_CACHE
 

--- a/nvalchemi/models/pme.py
+++ b/nvalchemi/models/pme.py
@@ -152,7 +152,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         alpha: float | None = None,
         accuracy: float = 1e-6,
         coulomb_constant: float = 14.3996,
-        hybrid_forces: bool = True,
+        hybrid_forces: bool = False,
         slab_correction: bool = False,
         rtol: float = 1e-5,
         atol: float | None = None,
@@ -239,6 +239,16 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         if strategy == StrategyKind.GRAPH_PARTITION:
             return self._distribution_spec_gp()
 
+        if self.hybrid_forces:
+            raise NotImplementedError(
+                "PME under domain decomposition requires hybrid_forces=False. "
+                "The analytic direct-output path returns a virial that fuses the "
+                "per-rank real-space and the globally-replicated reciprocal terms, "
+                "which cannot be reduced correctly across ranks; it is also being "
+                "retired in nvalchemi-toolkit-ops. Construct the wrapper with "
+                "hybrid_forces=False (the default)."
+            )
+
         import torch  # noqa: PLC0415
 
         # Force op registration before grabbing the handles.
@@ -275,10 +285,15 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         nvops = torch.ops.nvalchemiops  # type: ignore[attr-defined]
         ops = torch.ops.alchemiops  # type: ignore[attr-defined]
         custom_ops = (
+            # The reduced charge mesh drives the whole reciprocal pipeline
+            # (FFT, Green's function, IFFT) identically on every rank, so its
+            # incoming gradient is already global — hence the replicated
+            # adjoint. The total-charge and slab moments below are folded into
+            # each rank's own owned-atom terms and keep the symmetric one.
             OpAdapter(
                 op=nvops.spline_spread,  # (positions, values, ...)
                 arg_transforms={0: SliceOwned(), 1: SliceOwned()},
-                output_transforms={0: AllReduceSum()},
+                output_transforms={0: AllReduceSum(replicated_consumer=True)},
             ),
             OpAdapter(
                 op=nvops.batch_spline_spread,  # (positions, values, batch_idx, ...)
@@ -287,7 +302,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
                     1: SliceOwned(),
                     2: SliceOwned(),
                 },
-                output_transforms={0: AllReduceSum()},
+                output_transforms={0: AllReduceSum(replicated_consumer=True)},
             ),
             OpAdapter(
                 op=ops._pme_compute_partial_total_charge,  # (charges)
@@ -325,20 +340,14 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         # Compiled DD needs differentiable forces, so it is enabled only when
         # hybrid_forces=False: the framework then derives forces via autograd
         # over the global energy.
-        compile_policy = (
-            None
-            if self.hybrid_forces
-            else CompilePolicy(
-                static_shapes=True,
-                force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
-                graph_padder=DenseBatchPadder(),
-                # The framework strains positions + cell and takes the virial by
-                # autograd of the consolidated global energy. PME's reciprocal is
-                # fully differentiable in the cell (k-vectors + volume + FFT), so
-                # this is correct (requires the nvalchemiops convolve-backward
-                # grad_k_squared rank fix).
-                stress_via_strain=True,
-            )
+        compile_policy = CompilePolicy(
+            static_shapes=True,
+            force_strategy=ForceStrategy.FRAMEWORK_FROM_NODE_ENERGY,
+            graph_padder=DenseBatchPadder(),
+            # The framework strains positions + cell and takes the virial by
+            # autograd of the consolidated global energy. PME's reciprocal is
+            # fully differentiable in the cell (k-vectors + volume + FFT).
+            stress_via_strain=True,
         )
         # Eager kernel forces are complete per owned atom, so slice off the halo
         # duplicates. (The compiled path instead derives forces by autograd over
@@ -357,11 +366,7 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
                 # strain-autograd of the consolidated GLOBAL energy: a per-rank
                 # virial that ALL_REDUCE sums across ranks (correct for real +
                 # reciprocal, since PME's reciprocal is differentiable in the cell).
-                # The eager analytic kernel virial (hybrid_forces=True) needs a
-                # reciprocal-aware split, so it stays unreduced.
-                "stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE)
-                if not self.hybrid_forces
-                else OutputSpec(OutputKind.PER_GRAPH),
+                "stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.ALL_REDUCE),
                 "atomic_energies": OutputSpec(OutputKind.PER_NODE),
             },
             node_energy_key="atomic_energies",
@@ -406,6 +411,9 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
             outputs={
                 "energy": OutputSpec(OutputKind.PER_GRAPH),
                 "forces": OutputSpec(OutputKind.PER_NODE, Reduce.OWNED_ONLY),
+                # The framework strains the replicated geometry and sums each
+                # rank's owned-energy virial, so the value it returns is global.
+                "stress": OutputSpec(OutputKind.PER_GRAPH, Reduce.OWNED_ONLY),
                 "atomic_energies": OutputSpec(OutputKind.PER_NODE, Reduce.OWNED_ONLY),
             },
             node_energy_key="atomic_energies",
@@ -547,9 +555,6 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         every rank agrees on ``alpha`` / mesh despite holding a different
         per-rank padded count; otherwise the local ``positions`` are used.
         """
-        from nvalchemiops.torch.interactions.electrostatics.k_vectors import (  # lazy
-            generate_k_vectors_pme,
-        )
         from nvalchemiops.torch.interactions.electrostatics.parameters import (  # lazy
             estimate_pme_parameters,
         )
@@ -585,13 +590,34 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
         # Build per-system alpha tensor.
         alpha_tensor = torch.full((B,), alpha_val, dtype=cell.dtype, device=cell.device)
 
-        k_vectors, k_squared = generate_k_vectors_pme(cell, dims)
-
         self._cache_valid = True
         self._cached_alpha = alpha_tensor
+        self._cached_mesh_dims = dims
+        self._update_k_vectors(cell)
+
+    def _update_k_vectors(self, cell: torch.Tensor) -> None:
+        """Rebuild the k-vectors from *cell* against the cached mesh.
+
+        Separate from :meth:`_update_cache` because ``alpha`` and the mesh depend
+        only on the cell's value, while the k-vectors are differentiable
+        functions of the cell tensor itself.
+
+        Parameters
+        ----------
+        cell : torch.Tensor
+            Live cell ``[B, 3, 3]``; gradients flow through the result.
+
+        Returns
+        -------
+        None
+        """
+        from nvalchemiops.torch.interactions.electrostatics.k_vectors import (  # lazy  # noqa: PLC0415
+            generate_k_vectors_pme,
+        )
+
+        k_vectors, k_squared = generate_k_vectors_pme(cell, self._cached_mesh_dims)
         self._cached_k_vectors = k_vectors
         self._cached_k_squared = k_squared
-        self._cached_mesh_dims = dims
 
     # ------------------------------------------------------------------
     # Input adaptation
@@ -819,6 +845,10 @@ class PMEModelWrapper(nn.Module, BaseModelMixin):
 
         if self._cache_is_stale():
             self._update_cache(positions, cell, batch_idx)
+        elif cell.requires_grad:
+            # Cached k-vectors belong to the graph of the cell they were built
+            # from, so a grad-carrying cell needs its own.
+            self._update_k_vectors(cell)
 
         # Non-PBC runs have no shifts; reuse a cached zero buffer.
         if neighbor_matrix_shifts is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 license = {file="LICENSE"}
 dependencies = [
-    "nvalchemi-toolkit-ops>=0.4.0",
+    "nvalchemi-toolkit-ops>=0.4.1",
     "torch>=2.8",
     "click",
     "loguru",
@@ -67,7 +67,7 @@ ase = [
     "ase>=3.27.0",
 ]
 cu12 = [
-    "nvalchemi-toolkit-ops[torch-cu12]>=0.3.1; sys_platform != 'darwin'",
+    "nvalchemi-toolkit-ops[torch-cu12]>=0.4.1; sys_platform != 'darwin'",
     "nvidia-physicsnemo[cu12]>=2.0.0; sys_platform != 'darwin'",
     "cuml-cu12>=25.6.0; sys_platform != 'darwin'",
     "torch; sys_platform != 'darwin'",
@@ -75,7 +75,7 @@ cu12 = [
     "cuequivariance-ops-torch-cu12>=0.8.0; sys_platform != 'darwin'",
 ]
 cu13 = [
-    "nvalchemi-toolkit-ops[torch-cu13]>=0.3.1; sys_platform != 'darwin'",
+    "nvalchemi-toolkit-ops[torch-cu13]>=0.4.1; sys_platform != 'darwin'",
     "nvidia-physicsnemo[cu13]>=2.0.0; sys_platform != 'darwin'",
     "cuml-cu13>=25.6.0; sys_platform != 'darwin'",
     "torch; sys_platform != 'darwin'",
@@ -132,8 +132,8 @@ override-dependencies = [
   "python-hostlist; sys_platform == 'never'"
 ]
 dependency-metadata = [
-  { name = "nvalchemi-toolkit-ops", version = "0.4.0", requires-dist = [
-    "warp-lang >= 1.13.0,<1.15",
+  { name = "nvalchemi-toolkit-ops", version = "0.4.1", requires-dist = [
+    "warp-lang >= 1.13.0",
     "numpy",
     "torch>=2.8.0 ; extra == 'torch'",
     "torch>=2.8.0 ; extra == 'torch-cu12'",

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 
 from nvalchemi.data.atomic_data import AtomicData
-from nvalchemi.data.batch import Batch
+from nvalchemi.data.batch import Batch, set_transient
 from nvalchemi.data.level_storage import MultiLevelStorage, UniformLevelStorage
 
 
@@ -1340,3 +1340,38 @@ class TestBatchFromRawDicts:
         # field_levels is provided but doesn't mention unknown_scalar
         batch = Batch.from_raw_dicts([d0, d1], field_levels={"some_other_key": "atom"})
         assert "unknown_scalar" in batch.keys["system"]
+
+
+class TestSetTransient:
+    """``set_transient`` overlays a value without disturbing stored state.
+
+    The distinction is load-bearing: a strain applied for one forward must not
+    become the batch's real geometry, or a later rebuild deforms an already
+    deformed cell. Plain assignment routes tensors into storage and would.
+    """
+
+    def _batch(self) -> Batch:
+        data = AtomicData(
+            positions=torch.zeros(4, 3),
+            atomic_numbers=torch.ones(4, dtype=torch.long),
+            cell=torch.eye(3).unsqueeze(0),
+            pbc=torch.ones(1, 3, dtype=torch.bool),
+        )
+        return Batch.from_data_list([data])
+
+    def test_overlay_is_visible_to_readers(self) -> None:
+        batch = self._batch()
+        set_transient(batch, "cell", batch.cell * 7.0)
+        assert batch.cell[0, 0, 0].item() == pytest.approx(7.0)
+
+    def test_overlay_leaves_storage_untouched(self) -> None:
+        batch = self._batch()
+        stored = batch._storage["cell"].clone()
+        set_transient(batch, "cell", batch.cell * 7.0)
+        torch.testing.assert_close(batch._storage["cell"], stored)
+
+    def test_plain_assignment_writes_through_to_storage(self) -> None:
+        """Contrast: the reason ``set_transient`` exists rather than ``setattr``."""
+        batch = self._batch()
+        batch.cell = batch.cell * 7.0
+        assert batch._storage["cell"][0, 0, 0].item() == pytest.approx(7.0)

--- a/test/distributed/_core/test_compile_per_system.py
+++ b/test/distributed/_core/test_compile_per_system.py
@@ -33,7 +33,7 @@ from torch.distributed.device_mesh import DeviceMesh
 
 def _worker_per_system(rank, world_size):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
-    os.environ["MASTER_PORT"] = "29681"
+    os.environ["MASTER_PORT"] = "29709"
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)

--- a/test/distributed/_core/test_graph_parallel.py
+++ b/test/distributed/_core/test_graph_parallel.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Graph-parallel execution gate on a toy MACE-style MPNN.
 
@@ -26,6 +38,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
+from _dd_harness import free_port
 
 from nvalchemi.distributed._core.context import (
     DistributedContext,
@@ -125,9 +138,9 @@ def _graph_parallel(model, z, pos, edge_index, batch, n_sys, rank, world, mesh, 
     return energy.detach(), -g_owned, offset, n_owned
 
 
-def _worker(rank: int, world: int) -> None:
-    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-    os.environ.setdefault("MASTER_PORT", "29901")
+def _worker(rank: int, world: int, port: str) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = port
     dist.init_process_group("gloo", rank=rank, world_size=world)
     from torch.distributed.device_mesh import init_device_mesh
 
@@ -155,13 +168,13 @@ def _worker(rank: int, world: int) -> None:
 
 
 def test_graph_parallel_toy_mpnn_2ranks() -> None:
-    mp.spawn(_worker, args=(2,), nprocs=2)
+    mp.spawn(_worker, args=(2, free_port()), nprocs=2)
 
 
 def test_graph_parallel_toy_mpnn_3ranks() -> None:
-    mp.spawn(_worker, args=(3,), nprocs=3)
+    mp.spawn(_worker, args=(3, free_port()), nprocs=3)
 
 
 if __name__ == "__main__":
     for w in (2, 3):
-        mp.spawn(_worker, args=(w,), nprocs=w)
+        mp.spawn(_worker, args=(w, free_port()), nprocs=w)

--- a/test/distributed/_core/test_pbc_image_vectors.py
+++ b/test/distributed/_core/test_pbc_image_vectors.py
@@ -125,3 +125,46 @@ class TestNonPeriodicAxis:
             box_x=16.0, cutoff=5.0, ranks_x=4, pbc=torch.zeros(3, dtype=torch.bool)
         )
         assert _compute_pbc_image_vectors(part) == {}
+
+
+class TestContractionRefreshesHaloTopology:
+    """A barostat contraction must reach the live halo config.
+
+    ``update_cell`` widens the partitioner's span when domains narrow. A halo
+    config that copied the peer list and lattice images at construction keeps
+    exchanging with the old peers, so atoms that only became reachable after the
+    contraction are never sent and their interactions are dropped in silence.
+    """
+
+    def _config(self, box_x: float):
+        from nvalchemi.distributed._core.halo_types import ParticleHaloConfig
+
+        part = _partitioner(box_x=box_x, cutoff=5.0, ranks_x=4)
+        return part, ParticleHaloConfig(ghost_width=5.5, partitioner=part, mesh=None)
+
+    def test_contraction_widens_the_offered_images(self):
+        part, halo = self._config(box_x=48.0)
+        assert part.neighbor_span()[0] == 1
+        assert _x_coefficients(halo._pbc_images, (1, 3)) == set()
+
+        # 48 A over 4 ranks gives 12 A domains; 16 A gives 4 A against a 5.5 A
+        # ghost, so rank 1 now reaches rank 3 the long way round the box.
+        part.update_cell(
+            torch.diag(torch.tensor([16.0, 12.0, 12.0], dtype=torch.float64))
+        )
+        assert part.neighbor_span()[0] == 2
+        assert _x_coefficients(halo._pbc_images, (1, 3)) == {1}
+
+    def test_contraction_widens_the_peer_set(self):
+        part, halo = self._config(box_x=48.0)
+        before = set(halo.neighbor_ranks)
+        part.update_cell(
+            torch.diag(torch.tensor([16.0, 12.0, 12.0], dtype=torch.float64))
+        )
+        assert set(halo.neighbor_ranks) >= before
+
+    def test_topology_is_not_recomputed_without_a_change(self):
+        """Derived per geometry, not per access."""
+        part, halo = self._config(box_x=48.0)
+        first = halo._pbc_images
+        assert halo._pbc_images is first

--- a/test/distributed/_core/test_pbc_image_vectors.py
+++ b/test/distributed/_core/test_pbc_image_vectors.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lattice images offered to each neighbour rank pair.
+
+A ghost shell wider than one domain reaches the same neighbour from both sides
+of a periodic axis, and each side is a different lattice image holding
+different atoms. Offering only one image drops in-cutoff pairs silently, so
+these pin which images the halo config exposes. Pure geometry — no process
+group, no exchange.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nvalchemi.distributed._core.halo_types import _compute_pbc_image_vectors
+from nvalchemi.distributed.config import DomainConfig
+from nvalchemi.distributed.partitioner import SpatialPartitioner
+
+
+def _partitioner(
+    box_x: float, cutoff: float, ranks_x: int, pbc: torch.Tensor | None = None
+) -> SpatialPartitioner:
+    """Partitioner split ``ranks_x`` ways along x, without a real DeviceMesh."""
+    cell = torch.diag(torch.tensor([box_x, 12.0, 12.0], dtype=torch.float64))
+    config = DomainConfig(cutoff=cutoff, skin=0.5, grid_dims=(ranks_x, 1, 1))
+    part = SpatialPartitioner.__new__(SpatialPartitioner)
+    part.config = config
+    part.cell_matrix = cell
+    part.pbc = torch.ones(3, dtype=torch.bool) if pbc is None else pbc
+    part.world_size = ranks_x
+    part.cells_per_dim = config.grid_dims
+    part.rank_grid = SpatialPartitioner.compute_rank_grid(part.cells_per_dim, ranks_x)
+    part._span = part.neighbor_span()
+    part._neighbor_ranks = part._compute_all_neighbor_ranks()
+    part._inv_cell = torch.linalg.inv(cell)
+    return part
+
+
+def _x_coefficients(images: dict, pair: tuple[int, int]) -> set[int]:
+    """Lattice coefficients along x offered for ``pair``."""
+    return {int(image[0].item()) for image in images.get(pair, [])}
+
+
+class TestNarrowGhost:
+    """Span 1: only the outermost pair wraps, as before."""
+
+    def setup_method(self):
+        # 48 A over 4 ranks -> 12 A domains against a 5.5 A ghost: span 1.
+        self.part = _partitioner(box_x=48.0, cutoff=5.0, ranks_x=4)
+        self.images = _compute_pbc_image_vectors(self.part)
+
+    def test_span_is_one(self):
+        assert self.part.neighbor_span()[0] == 1
+
+    def test_edge_pair_wraps(self):
+        assert _x_coefficients(self.images, (3, 0)) == {-1}
+        assert _x_coefficients(self.images, (0, 3)) == {1}
+
+    def test_interior_pair_does_not_wrap(self):
+        # Rank 1 reaches rank 2 directly; no lattice translation involved.
+        assert _x_coefficients(self.images, (1, 2)) == set()
+
+
+class TestWideGhost:
+    """Span 2: a neighbour reachable both ways needs both images."""
+
+    def setup_method(self):
+        # 16 A over 4 ranks -> 4 A domains against a 5.5 A ghost: span 2.
+        self.part = _partitioner(box_x=16.0, cutoff=5.0, ranks_x=4)
+        self.images = _compute_pbc_image_vectors(self.part)
+
+    def test_span_is_two(self):
+        assert self.part.neighbor_span()[0] == 2
+
+    def test_neighbour_reached_from_both_sides_offers_the_wrapped_image(self):
+        """Rank 1 reaches rank 3 directly at +2 and around the box at -2.
+
+        The wrapped side carries the atoms at the far end of the box; without
+        it they never arrive and their interactions are dropped in silence.
+        """
+        assert _x_coefficients(self.images, (1, 3)) == {1}
+        assert _x_coefficients(self.images, (3, 1)) == {-1}
+
+    def test_edge_pair_still_wraps(self):
+        assert _x_coefficients(self.images, (3, 0)) == {-1}
+        assert _x_coefficients(self.images, (0, 3)) == {1}
+
+    def test_no_image_is_the_identity(self):
+        """An all-zero image would duplicate the direct copy."""
+        for pair, offered in self.images.items():
+            for image in offered:
+                assert image.abs().sum() > 0, f"{pair} offers a zero translation"
+
+
+class TestTwoRankPeriodic:
+    """The ordinary 2-rank split, where both directions reach one neighbour."""
+
+    def setup_method(self):
+        self.part = _partitioner(box_x=24.0, cutoff=5.0, ranks_x=2)
+        self.images = _compute_pbc_image_vectors(self.part)
+
+    def test_each_direction_offers_one_wrap(self):
+        assert _x_coefficients(self.images, (0, 1)) == {1}
+        assert _x_coefficients(self.images, (1, 0)) == {-1}
+
+
+class TestNonPeriodicAxis:
+    """A non-periodic axis contributes no lattice translation."""
+
+    def test_open_boundary_has_no_images(self):
+        part = _partitioner(
+            box_x=16.0, cutoff=5.0, ranks_x=4, pbc=torch.zeros(3, dtype=torch.bool)
+        )
+        assert _compute_pbc_image_vectors(part) == {}

--- a/test/distributed/_dd_harness.py
+++ b/test/distributed/_dd_harness.py
@@ -23,12 +23,31 @@ top-level and ``model/`` test packages can ``from _dd_harness import ...``."""
 from __future__ import annotations
 
 import os
+import socket
 from typing import Any
 
 import torch
 import torch.distributed as dist
 
-__all__ = ["init_nccl", "nccl_worker"]
+__all__ = ["free_port", "init_nccl", "nccl_worker"]
+
+
+def free_port() -> str:
+    """Return a currently-unused localhost TCP port for a rendezvous.
+
+    A hardcoded port only separates test *files*; two concurrent runs of the
+    same file (``pytest-xdist``, or a second run started by hand) still collide
+    and fail with ``EADDRINUSE``. Asking the OS for an unused port each time
+    removes that coupling.
+
+    Returns
+    -------
+    str
+        The port number, as ``init_process_group`` wants it.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return str(sock.getsockname()[1])
 
 
 def init_nccl(rank: int, world_size: int, port: str) -> None:

--- a/test/distributed/_gloo_harness.py
+++ b/test/distributed/_gloo_harness.py
@@ -53,6 +53,7 @@ from typing import Any, Callable
 
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from _dd_harness import free_port
 
 __all__ = ["run_gloo"]
 
@@ -98,15 +99,14 @@ def _worker(
     fn: Callable[..., None],
     queue: Any,
     args: tuple,
+    port: str,
 ) -> None:
     """Worker entry point called by ``mp.spawn``. Initialises the gloo
     process group, applies the all_to_all patch, and invokes the user
     function with ``(rank, world_size, queue, *args)``.
     """
     os.environ["MASTER_ADDR"] = "127.0.0.1"
-    # Distinct port per spawn to avoid clashes when pytest runs the same
-    # harness back-to-back.
-    os.environ.setdefault("MASTER_PORT", "29503")
+    os.environ["MASTER_PORT"] = port
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
 
@@ -124,6 +124,7 @@ def run_gloo(
     fn: Callable[..., None],
     args: tuple = (),
     timeout_sec: float = 60.0,
+    port: str | None = None,
 ) -> list[Any]:
     """Spawn ``world_size`` Gloo workers, run ``fn`` on each, collect
     queue payloads, return them in arrival order.
@@ -140,8 +141,9 @@ def run_gloo(
     ctx = mp.get_context("spawn")
     queue = ctx.Queue()
     procs = []
+    port = port or free_port()
     for rank in range(world_size):
-        p = ctx.Process(target=_worker, args=(rank, world_size, fn, queue, args))
+        p = ctx.Process(target=_worker, args=(rank, world_size, fn, queue, args, port))
         p.start()
         procs.append(p)
 

--- a/test/distributed/conftest.py
+++ b/test/distributed/conftest.py
@@ -20,8 +20,15 @@ packages can import them; this file holds only the pytest fixture."""
 
 from __future__ import annotations
 
+import os
+
 import pytest
 import torch.distributed as dist
+
+# Equivalence tests only mean something at matched precision. The env var rather
+# than the torch flags because ranks run under ``mp.spawn`` and inherit the
+# environment, not the flags; ``setdefault`` so a TF32 run can still be asked for.
+os.environ.setdefault("NVIDIA_TF32_OVERRIDE", "0")
 
 # ----------------------------------------------------------------------
 # Function-scoped 1-rank gloo init for tests that construct a ShardTensor

--- a/test/distributed/model/test_aimnet2_compile_recompile_gate.py
+++ b/test/distributed/model/test_aimnet2_compile_recompile_gate.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""AIMNet2 halo + ``torch.compile`` DD gate: force equivalence AND zero
+"""AIMNet2 halo + ``torch.compile`` DD gate: force/stress equivalence AND zero
 steady-state recompiles.
 
 AIMNet2's distributed halo path under ``compile_model=True`` is owned entirely
@@ -28,7 +28,8 @@ validator
 steady-state recompile count:
 
 * **Equivalence** (step 0, unjittered): an *eager*-DD reference vs the compiled
-  DD forward, on the same partition — each rank's owned forces must match. (A
+  DD forward, on the same partition — each rank's owned forces and the global
+  stress must match. (A
   single-GPU reference can't be used: a bare ``AIMNet2Wrapper(Batch)`` forward
   needs aimnet's 2-D neighbor-mode layout that only the DD input path builds.)
 * **Recompiles** (jittered MD loop): after warmup, the number of unique compiled
@@ -116,25 +117,22 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
     # only the DD input path builds. Same partition -> owned forces align. ----
     eager = AIMNet2Wrapper.from_checkpoint("aimnet2", device=device)
     eager.eval()
-    eager.model_config.active_outputs = {"energy", "forces"}
+    eager.model_config.active_outputs = {"energy", "forces", "stress"}
     cfg = DomainConfig(cutoff=float(eager._cutoff), skin=0.5, mesh=mesh)
     with DistributedModel(eager, cfg) as eager_model:
-        f_eager_owned = (
-            eager_model(ShardedBatch.from_batch(_batch(positions0), mesh, cfg, 0))[
-                "forces"
-            ]
-            .detach()
-            .float()
-            .cpu()
+        eager_out = eager_model(
+            ShardedBatch.from_batch(_batch(positions0), mesh, cfg, 0)
         )
-    del eager, eager_model
+        f_eager_owned = eager_out["forces"].detach().float().cpu()
+        stress_eager = eager_out["stress"].detach().float().cpu()
+    del eager, eager_model, eager_out
 
     # ---- compiled DD model: the wrapper is eager (compile_model is the
     # single-process model-compile lever); DD-compile is requested on
     # DistributedModel, which owns the compiled energy-autograd forward. ----
     wrapper = AIMNet2Wrapper.from_checkpoint("aimnet2", device=device)
     wrapper.eval()
-    wrapper.model_config.active_outputs = {"energy", "forces"}
+    wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
 
     gen = torch.Generator(device="cpu").manual_seed(7)
     graphs_after_warmup = [0]
@@ -152,6 +150,7 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
             sharded = ShardedBatch.from_batch(_batch(pos), mesh, cfg, 0)
             out = dist_model(sharded)
             f_owned = out["forces"].detach().float()
+            stress = out["stress"].detach().float()
 
             if step == 0:
                 # Equivalence: compiled DD == eager DD on the same partition.
@@ -162,7 +161,14 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
                     atol=3e-3,
                     msg=f"rank {rank}: compiled DD forces != eager DD reference",
                 )
-            _ = f_owned.sum().item()
+                torch.testing.assert_close(
+                    stress.cpu(),
+                    stress_eager,
+                    rtol=3e-3,
+                    atol=3e-3,
+                    msg=f"rank {rank}: compiled DD stress != eager DD reference",
+                )
+            _ = (f_owned.sum() + stress.sum()).item()
             n_graphs = counters["stats"].get("unique_graphs", 0)
             if step == WARMUP_STEPS - 1:
                 graphs_after_warmup[0] = n_graphs

--- a/test/distributed/model/test_distributed_models.py
+++ b/test/distributed/model/test_distributed_models.py
@@ -720,9 +720,13 @@ _WRAPPER_FACTORIES: dict[str, Any] = {
 
 
 def _port_for(key: str) -> str:
-    """Deterministic free-ish port per-parametrization so concurrent
-    pytest runs don't collide. 30000 + hash(key)%5000."""
-    return str(30000 + (hash(key) & 0xFFFF) % 5000)
+    """Deterministic per-parametrization rendezvous port.
+
+    Kept below the kernel's ephemeral range: a port drawn from there can be
+    claimed for an outbound connection between the choice and the rendezvous
+    bind, which surfaces as a mid-test EADDRINUSE.
+    """
+    return str(20000 + (hash(key) & 0xFFFF) % 9000)
 
 
 # Single-GPU gloo+cuda tier: N ranks share one GPU (gloo because NCCL rejects

--- a/test/distributed/model/test_distributed_models.py
+++ b/test/distributed/model/test_distributed_models.py
@@ -683,7 +683,10 @@ def _build_pbc_orthorhombic_argon(
 # Registered topology builders, looked up by key in the worker functions.
 _SYSTEM_BUILDERS: dict[str, Any] = {
     "nonpbc_open_argon": lambda: _build_open_argon_cluster(n_per_side=8),
-    "pbc_orthorhombic_argon": lambda: _build_pbc_orthorhombic_argon(n_per_side=4),
+    # n_per_side=5 (box ~20.0 A) so a 2-rank split leaves each domain wider than
+    # the 8.5 A LJ ghost shell; at 4 the domains are 8.0 A and the halo would
+    # wrap onto the rank's own periodic image.
+    "pbc_orthorhombic_argon": lambda: _build_pbc_orthorhombic_argon(n_per_side=5),
 }
 
 

--- a/test/distributed/model/test_distributed_models.py
+++ b/test/distributed/model/test_distributed_models.py
@@ -1055,3 +1055,7 @@ def test_aimnet2_wrapper_declares_halo_spec() -> None:
     # ConvSV + LRCoulomb + SRCoulomb), with no gather custom_ops.
     assert spec.distribution.custom_ops == ()
     assert len(spec.distribution.third_party_helpers) == 4
+    # Stress comes from the framework strain trick, so each rank holds a partial
+    # that the declared reduction has to sum.
+    assert "stress" in spec.all_reduce_outputs
+    assert spec.compile is not None and spec.compile.stress_via_strain

--- a/test/distributed/model/test_distributed_pipeline_multigpu.py
+++ b/test/distributed/model/test_distributed_pipeline_multigpu.py
@@ -198,7 +198,7 @@ def _de_pipeline_worker(rank: int, world_size: int) -> None:
         flush=True,
     )
     torch.testing.assert_close(
-        e_local.view(1),
+        e_local.view(1).to(e_ref.dtype),
         e_ref,
         rtol=1e-4,
         atol=1e-3,
@@ -463,8 +463,8 @@ def _ap_make_data(atomic_numbers, positions, cell, pbc, device, dtype):
     )
 
 
-def _ap_build_pipeline(aim_cut_holder: list[float], device, dtype):
-    """Fresh AIMNet2(charges) -> PME(charges) wired use_autograd pipeline."""
+def _ap_build_pipeline(aim_cut_holder: list[float], device, dtype, consumer="pme"):
+    """Fresh AIMNet2(charges) -> PME/Ewald(charges) wired use_autograd pipeline."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         from nvalchemi.models.aimnet2 import AIMNet2Wrapper
@@ -474,12 +474,22 @@ def _ap_build_pipeline(aim_cut_holder: list[float], device, dtype):
 
     aim = AIMNet2Wrapper.from_checkpoint("aimnet2", device=device)
     aim.eval()
-    aim.model_config.active_outputs = {"energy", "forces", "charges"}
+    aim.model_config.active_outputs = {"energy", "forces", "stress", "charges"}
     aim_cut_holder[0] = float(aim._cutoff)
-    pme = PMEModelWrapper(cutoff=_AP_PME_CUT)  # hybrid_forces=True default
-    return PipelineModelWrapper(
+    if consumer == "ewald":
+        from nvalchemi.models.ewald import EwaldModelWrapper
+
+        pme = EwaldModelWrapper(cutoff=_AP_PME_CUT, hybrid_forces=False)
+    else:
+        pme = PMEModelWrapper(cutoff=_AP_PME_CUT)
+    pme.model_config.active_outputs = {"energy", "forces", "stress"}
+    pipeline = PipelineModelWrapper(
         groups=[PipelineGroup(steps=[aim, pme], use_autograd=True)]
     )
+    # The composite only derives what it is asked for; stress must be active for
+    # the wired group to carry the cross-model chain term.
+    pipeline.model_config.active_outputs = {"energy", "forces", "stress"}
+    return pipeline
 
 
 def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
@@ -499,6 +509,7 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
     # --- Single-GPU reference on rank 0: the full wired pipeline forward ---
     e_ref = torch.zeros(1, dtype=dtype, device=device)
     f_ref = torch.zeros(n_global, 3, dtype=dtype, device=device)
+    s_ref = torch.zeros(1, 3, 3, dtype=dtype, device=device)
     if rank == 0:
         ref_pipe = _ap_build_pipeline(aim_cut, device, dtype)
         batch = Batch.from_data_list(
@@ -508,9 +519,11 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
         out = ref_pipe(batch)
         e_ref.copy_(out["energy"].sum().detach().view(1))
         f_ref.copy_(out["forces"].detach())
+        s_ref.copy_(out["stress"].detach().reshape(1, 3, 3))
         del ref_pipe
     dist.broadcast(e_ref, src=0)
     dist.broadcast(f_ref, src=0)
+    dist.broadcast(s_ref, src=0)
 
     # --- Distributed composite over ONE shared partition (built at max cutoff) ---
     pipeline = _ap_build_pipeline(aim_cut, device, dtype)
@@ -530,6 +543,7 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
         composite = dpm(sharded)
     e_local = composite["energy"].sum().detach()
     f_owned = composite["forces"].detach()
+    s_local = composite["stress"].detach().reshape(1, 3, 3)
 
     partitioner = SpatialPartitioner(
         config=base_config,
@@ -544,8 +558,9 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
 
     de = (e_local - e_ref).abs().item()
     df = (f_owned - f_ref_owned).abs().max().item()
+    ds = (s_local.to(s_ref.dtype) - s_ref).abs().max().item()
     print(
-        f"[pipe-wired rank {rank}] ΔE={de:.3e} |ΔF|max={df:.3e} "
+        f"[pipe-wired rank {rank}] ΔE={de:.3e} |ΔF|max={df:.3e} |Δσ|max={ds:.3e} "
         f"n_owned={f_owned.shape[0]} aim_cut={aim_cut[0]:.2f} "
         f"dist_e={e_local.item():+.4f} ref_e={e_ref.item():+.4f}",
         flush=True,
@@ -569,6 +584,15 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
         atol=2e-3,
         msg=f"rank {rank}: wired composite forces mismatch |ΔF|max={df:.3e}",
     )
+    # Stress is per-system and replicated, so rank 0's value is the reference on
+    # every rank. Guards the wired group dropping the cross-model chain term.
+    torch.testing.assert_close(
+        s_local.to(s_ref.dtype),
+        s_ref,
+        rtol=1e-2,
+        atol=2e-4,
+        msg=f"rank {rank}: wired composite stress mismatch |Δσ|max={ds:.3e}",
+    )
 
 
 @_skip
@@ -579,6 +603,88 @@ def test_distributed_pipeline_aimnet2_pme_2ranks():
     mp.spawn(
         _worker,
         args=(WORLD_SIZE, "29587", _ap_wired_pipeline_worker),
+        nprocs=WORLD_SIZE,
+    )
+
+
+def _ap_force_path_worker(rank: int, world_size: int, consumer: str) -> None:
+    """Forces must not depend on whether stress was also requested.
+
+    Asking the wired consumer for stress moves it onto the framework
+    strain-autograd path, and PME reduces its charge mesh differently there (a
+    direct all-reduce) than on the eager path (the OpAdapter escape hatch). The
+    two reductions carry opposite adjoints, so a mistake in either shows up as
+    force-only and force+stress disagreeing while each looks self-consistent.
+    """
+    from torch.distributed import DeviceMesh
+
+    from nvalchemi.distributed.distributed_pipeline import DistributedPipelineModel
+    from nvalchemi.distributed.sharded_batch import ShardedBatch
+
+    dtype = torch.float32
+    device = torch.device(f"cuda:{rank}")
+    positions, an, cell, pbc = _ap_methane_packing(dtype=dtype)
+    aim_cut = [0.0]
+
+    def _run(active: set[str]) -> torch.Tensor:
+        pipeline = _ap_build_pipeline(aim_cut, device, dtype, consumer=consumer)
+        pipeline.model_config.active_outputs = active
+        mesh = DeviceMesh("cuda", list(range(world_size)), mesh_dim_names=("domain",))
+        config = DomainConfig(
+            cutoff=max(aim_cut[0], _AP_PME_CUT),
+            skin=_AP_SKIN,
+            mesh=mesh,
+            require_nondegenerate=True,
+        )
+        full = (
+            Batch.from_data_list(
+                [_ap_make_data(an, positions, cell, pbc, device, dtype)]
+            )
+            if rank == 0
+            else None
+        )
+        sharded = ShardedBatch.from_batch(batch=full, mesh=mesh, config=config, src=0)
+        with DistributedPipelineModel(pipeline, config) as dpm:
+            return dpm(sharded)["forces"].detach().clone()
+
+    f_no_stress = _run({"energy", "forces"})
+    f_stress = _run({"energy", "forces", "stress"})
+
+    df = (f_no_stress - f_stress).abs().max().item()
+    scale = f_stress.abs().max().item()
+    print(
+        f"[pipe-force-path/{consumer} rank {rank}] |ΔF|max={df:.3e} "
+        f"|F|max={scale:.3e} rel={df / max(scale, 1e-30):.3e} "
+        f"n_owned={f_stress.shape[0]}",
+        flush=True,
+    )
+    torch.testing.assert_close(
+        f_no_stress,
+        f_stress,
+        rtol=1e-3,
+        atol=1e-4,
+        msg=(
+            f"rank {rank}: {consumer} wired forces depend on whether stress was "
+            f"requested, |ΔF|max={df:.3e}"
+        ),
+    )
+
+
+@_skip
+@pytest.mark.parametrize("consumer", ["pme", "ewald"])
+def test_distributed_pipeline_wired_force_paths_agree_2ranks(consumer):
+    """Wired-group forces are identical with and without stress requested.
+
+    Requesting stress moves the consumer onto the framework autograd path. A
+    consumer that derives its own forces from the per-system energy — which DD
+    has already summed across ranks — scales them by the world size on the other
+    path, so the two disagree.
+    """
+    pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
+    pytest.importorskip("aimnet", reason="aimnet not installed")
+    mp.spawn(
+        _worker,
+        args=(WORLD_SIZE, "29591", _ap_force_path_worker, consumer),
         nprocs=WORLD_SIZE,
     )
 

--- a/test/distributed/model/test_electrostatics_stress_multigpu.py
+++ b/test/distributed/model/test_electrostatics_stress_multigpu.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-GPU stress equivalence for Ewald / PME under halo decomposition.
+
+Stress is taken by strain-autograd of the consolidated global energy, so each
+rank holds a partial that the declared reduction sums. These tests pin the
+result against a single-GPU reference on a partition asserted non-degenerate —
+a degenerate split gives every rank the whole system and hides any reduction
+error entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from _dd_harness import free_port
+from _dd_harness import nccl_worker as _worker
+from _electrostatics import build_nacl
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.distributed.config import DomainConfig
+
+WORLD_SIZE = 2
+N_SIDE = 10
+BOX = 28.0
+
+_skip = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
+    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
+)
+
+
+def _build_wrapper(kind: str, cutoff: float):
+    """Wrapper of the requested flavour on the supported (non-analytic) path."""
+    if kind == "pme":
+        from nvalchemi.models.pme import PMEModelWrapper
+
+        return PMEModelWrapper(cutoff=cutoff, hybrid_forces=False)
+    from nvalchemi.models.ewald import EwaldModelWrapper
+
+    return EwaldModelWrapper(cutoff=cutoff, hybrid_forces=False)
+
+
+def _make_batch(positions, atomic_numbers, masses, charges, cell, pbc, device, dtype):
+    """Single-system Batch on *device*."""
+    n = positions.shape[0]
+    data = AtomicData(
+        atomic_numbers=atomic_numbers.to(device),
+        positions=positions.to(device=device, dtype=dtype).clone(),
+        atomic_masses=masses.to(device=device, dtype=dtype),
+        charges=charges.to(device=device, dtype=dtype),
+        cell=cell.to(device=device, dtype=dtype).unsqueeze(0),
+        pbc=pbc.to(device).unsqueeze(0),
+        forces=torch.zeros(n, 3, device=device, dtype=dtype),
+        energy=torch.zeros(1, 1, device=device, dtype=dtype),
+    )
+    return Batch.from_data_list([data])
+
+
+def _stress_equivalence_worker(rank: int, world_size: int, kind: str) -> None:
+    """Distributed analytic stress must equal the single-GPU stress."""
+    from torch.distributed import DeviceMesh
+
+    from nvalchemi.distributed.distributed_model import DistributedModel
+    from nvalchemi.distributed.sharded_batch import ShardedBatch
+    from nvalchemi.neighbors import compute_neighbors
+
+    dtype = torch.float64
+    device = torch.device(f"cuda:{rank}")
+    positions, atomic_numbers, masses, charges, cell, pbc = build_nacl(
+        N_SIDE, BOX, dtype=dtype
+    )
+    n_global = positions.shape[0]
+    cutoff = min(5.0, 0.45 * cell[0, 0].item())
+    args = (positions, atomic_numbers, masses, charges, cell, pbc)
+
+    # ---- Single-process reference on rank 0, broadcast to all ----
+    s_ref = torch.zeros(1, 3, 3, device=device, dtype=dtype)
+    e_ref = torch.zeros(1, device=device, dtype=dtype)
+    if rank == 0:
+        ref_wrapper = _build_wrapper(kind, cutoff).to(device)
+        ref_wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
+        ref_batch = _make_batch(*args, device, dtype)
+        compute_neighbors(ref_batch, config=ref_wrapper.model_config.neighbor_config)
+        ref_out = ref_wrapper(ref_batch)
+        s_ref = ref_out["stress"].detach().reshape(1, 3, 3).clone()
+        e_ref = ref_out["energy"].sum().detach().reshape(1).clone()
+        del ref_wrapper, ref_batch, ref_out
+    dist.broadcast(s_ref, src=0)
+    dist.broadcast(e_ref, src=0)
+
+    # ---- Distributed forward ----
+    mesh = DeviceMesh("cuda", list(range(world_size)), mesh_dim_names=("domain",))
+    domain_config = DomainConfig(
+        cutoff=cutoff, skin=0.0, mesh=mesh, require_nondegenerate=True
+    )
+    wrapper = _build_wrapper(kind, cutoff).to(device)
+    wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
+
+    full_batch = _make_batch(*args, device, dtype) if rank == 0 else None
+    sharded = ShardedBatch.from_batch(
+        batch=full_batch, mesh=mesh, config=domain_config, src=0
+    )
+    # A degenerate partition would hand every rank the whole system and pass
+    # regardless of how the virial is reduced.
+    assert 0 < sharded.n_owned < n_global, (
+        f"rank {rank}: degenerate partition ({sharded.n_owned} of {n_global} owned); "
+        "the test would not exercise the cross-rank reduction"
+    )
+
+    with DistributedModel(wrapper, domain_config) as dist_model:
+        out = dist_model(sharded)
+
+    s_dist = out["stress"].detach().reshape(1, 3, 3)
+    e_dist = out["energy"].sum().detach().reshape(1)
+    print(
+        f"[{kind}-stress rank {rank}] n_owned={sharded.n_owned}/{n_global} "
+        f"dE={(e_dist - e_ref).abs().max().item():.3e} "
+        f"dS={(s_dist - s_ref).abs().max().item():.3e}\n"
+        f"  dist diag={torch.diagonal(s_dist[0]).tolist()}\n"
+        f"   ref diag={torch.diagonal(s_ref[0]).tolist()}",
+        flush=True,
+    )
+
+    torch.testing.assert_close(e_dist, e_ref, rtol=1e-8, atol=1e-8)
+    torch.testing.assert_close(
+        s_dist,
+        s_ref,
+        rtol=1e-7,
+        atol=1e-9,
+        msg=(
+            f"rank {rank}: {kind} stress disagrees with the single-GPU "
+            f"reference — max |dS|={(s_dist - s_ref).abs().max().item():.3e}"
+        ),
+    )
+
+
+@_skip
+@pytest.mark.parametrize("kind", ["ewald", "pme"])
+def test_stress_equivalence_2ranks(kind):
+    """Halo-DD stress matches single-GPU for Ewald and PME."""
+    pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
+
+    mp.spawn(
+        _worker,
+        args=(WORLD_SIZE, free_port(), _stress_equivalence_worker, kind),
+        nprocs=WORLD_SIZE,
+    )

--- a/test/distributed/model/test_ewald_multigpu.py
+++ b/test/distributed/model/test_ewald_multigpu.py
@@ -213,7 +213,7 @@ def _ewald_equivalence_worker(rank: int, world_size: int) -> None:
     # energy holds to ~1e-4 absolute; per-atom forces to ~1e-3 relative
     # (same tolerance the cueq/MACE multi-GPU test uses).
     torch.testing.assert_close(
-        e_local.view(1),
+        e_local.view(1).to(e_ref.dtype),
         e_ref,
         rtol=1e-4,
         atol=1e-4,

--- a/test/distributed/model/test_ewald_multigpu.py
+++ b/test/distributed/model/test_ewald_multigpu.py
@@ -249,7 +249,7 @@ def test_ewald_dist_model_equivalence_2ranks():
 
     mp.spawn(
         _worker,
-        args=(WORLD_SIZE, "29573", _ewald_equivalence_worker),
+        args=(WORLD_SIZE, "29705", _ewald_equivalence_worker),
         nprocs=WORLD_SIZE,
     )
 
@@ -398,7 +398,7 @@ def _compile_worker(rank: int, world_size: int) -> None:
 def test_ewald_compile_dd_2ranks():
     """Compiled ``DistributedModel(Ewald, hybrid_forces=False)`` == single-GPU; no steady recompiles."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
-    mp.spawn(_worker, args=(WORLD_SIZE, "29591", _compile_worker), nprocs=WORLD_SIZE)
+    mp.spawn(_worker, args=(WORLD_SIZE, "29707", _compile_worker), nprocs=WORLD_SIZE)
 
 
 def _owned_counts(n: int, world: int) -> list[int]:

--- a/test/distributed/model/test_graph_parallel_model.py
+++ b/test/distributed/model/test_graph_parallel_model.py
@@ -45,6 +45,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from _dd_harness import free_port
 
 from nvalchemi.data.atomic_data import AtomicData
 from nvalchemi.data.batch import Batch
@@ -56,9 +57,6 @@ from nvalchemi.neighbors import compute_neighbors
 
 _N_ATOMS = 24
 _CUTOFF = 2.5
-
-# Per-toy rendezvous port so concurrently-parametrized spawns do not collide.
-_PORTS = {"mpnn": "29903", "dense": "29904", "dense_full": "29905"}
 
 
 def _full_batch() -> Batch:
@@ -88,6 +86,25 @@ def _reference(model):
     energy = model(batch)["energy"]
     (grad,) = torch.autograd.grad(energy.sum(), pos)
     return energy.detach(), -grad
+
+
+def _reference_stress(model):
+    """Single-process stress by the same strain trick the framework applies."""
+    batch = _full_batch()
+    compute_neighbors(batch, config=model.model_config.neighbor_config)
+    pos = batch._atoms_group["positions"].detach()
+    strain = torch.zeros(batch.num_graphs, 3, 3, dtype=pos.dtype, requires_grad=True)
+    eps = 0.5 * (strain + strain.transpose(-1, -2))
+    bidx = batch.batch_idx.long()
+    batch._atoms_group["positions"] = pos + torch.einsum(
+        "nij,nj->ni", eps.index_select(0, bidx), pos
+    )
+    cell0 = batch.cell
+    object.__setattr__(batch, "cell", cell0 + torch.einsum("bij,bjk->bik", cell0, eps))
+    energy = model(batch)["energy"]
+    (virial,) = torch.autograd.grad(energy.sum(), strain)
+    volume = torch.linalg.det(cell0).abs().reshape(-1, 1, 1)
+    return (virial / volume).detach()
 
 
 def _owned_counts(n: int, world: int) -> list[int]:
@@ -120,8 +137,8 @@ def _build_toy(kind: str):
 
 
 def _worker(rank: int, world: int, kind: str, port: str) -> None:
-    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-    os.environ.setdefault("MASTER_PORT", port)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = port
     dist.init_process_group("gloo", rank=rank, world_size=world)
     from torch.distributed.device_mesh import init_device_mesh  # noqa: PLC0415
 
@@ -131,6 +148,10 @@ def _worker(rank: int, world: int, kind: str, port: str) -> None:
     model, spec = _build_toy(kind)
 
     e_ref, f_ref = _reference(model)
+    # Stress rides the framework's strain trick over the replicated geometry;
+    # each rank differentiates only its owned energy, so the virials sum.
+    model.model_config.active_outputs = {"energy", "forces", "stress"}
+    s_ref = _reference_stress(model)
 
     cfg = DomainConfig(cutoff=_CUTOFF, mesh=mesh)
     full = _full_batch() if rank == 0 else None
@@ -145,6 +166,20 @@ def _worker(rank: int, world: int, kind: str, port: str) -> None:
     n_owned = counts[rank]
 
     torch.testing.assert_close(out["energy"], e_ref, rtol=1e-9, atol=1e-9)
+    # A near-zero reference would let any distributed value pass.
+    assert s_ref.abs().max() > 1e-9, (
+        f"reference stress {s_ref.abs().max().item():.3e} is at the tolerance "
+        f"floor; the comparison would not detect a wrong stress"
+    )
+    torch.testing.assert_close(
+        out["stress"].reshape(s_ref.shape),
+        s_ref,
+        rtol=1e-8,
+        atol=1e-10,
+        msg=lambda m: (
+            f"rank {rank}: graph-parallel stress disagrees with single-process\n{m}"
+        ),
+    )
     torch.testing.assert_close(
         out["forces"], f_ref[offset : offset + n_owned], rtol=1e-8, atol=1e-8
     )
@@ -157,10 +192,10 @@ def _worker(rank: int, world: int, kind: str, port: str) -> None:
 @pytest.mark.parametrize("kind", ["mpnn", "dense", "dense_full"])
 @pytest.mark.parametrize("world", [2, 3])
 def test_graph_parallel_model(kind: str, world: int) -> None:
-    mp.spawn(_worker, args=(world, kind, _PORTS[kind]), nprocs=world)
+    mp.spawn(_worker, args=(world, kind, free_port()), nprocs=world)
 
 
 if __name__ == "__main__":
     for _kind in ("mpnn", "dense", "dense_full"):
         for _w in (2, 3):
-            mp.spawn(_worker, args=(_w, _kind, _PORTS[_kind]), nprocs=_w)
+            mp.spawn(_worker, args=(_w, _kind, free_port()), nprocs=_w)

--- a/test/distributed/model/test_mace_cueq_multigpu.py
+++ b/test/distributed/model/test_mace_cueq_multigpu.py
@@ -314,6 +314,6 @@ def test_mace_cueq_dist_model_equivalence_2ranks():
 
     mp.spawn(
         _worker,
-        args=(WORLD_SIZE, "29571", _mace_cueq_equivalence_worker),
+        args=(WORLD_SIZE, "29703", _mace_cueq_equivalence_worker),
         nprocs=WORLD_SIZE,
     )

--- a/test/distributed/model/test_pme_multigpu.py
+++ b/test/distributed/model/test_pme_multigpu.py
@@ -209,7 +209,7 @@ def _pme_equivalence_worker(rank: int, world_size: int) -> None:
     # fp32 + FFT-based PME: tolerances slightly looser than Ewald's
     # direct k-sum because of accumulated rounding in the mesh pipeline.
     torch.testing.assert_close(
-        e_local.view(1),
+        e_local.view(1).to(e_ref.dtype),
         e_ref,
         rtol=5e-4,
         atol=5e-4,

--- a/test/distributed/model/test_pme_multigpu.py
+++ b/test/distributed/model/test_pme_multigpu.py
@@ -248,7 +248,7 @@ def test_pme_dist_model_equivalence_2ranks():
 
     mp.spawn(
         _worker,
-        args=(WORLD_SIZE, "29574", _pme_equivalence_worker),
+        args=(WORLD_SIZE, "29706", _pme_equivalence_worker),
         nprocs=WORLD_SIZE,
     )
 

--- a/test/distributed/model/test_slab_multigpu.py
+++ b/test/distributed/model/test_slab_multigpu.py
@@ -229,7 +229,7 @@ def test_pme_slab_dist_model_equivalence_2ranks():
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
     mp.spawn(
         _worker,
-        args=(WORLD_SIZE, "29591", _slab_equivalence_worker, "pme"),
+        args=(WORLD_SIZE, "29708", _slab_equivalence_worker, "pme"),
         nprocs=WORLD_SIZE,
     )
 

--- a/test/distributed/model/test_uma_multigpu.py
+++ b/test/distributed/model/test_uma_multigpu.py
@@ -324,6 +324,6 @@ def test_uma_dist_model_equivalence_2ranks():
 
     mp.spawn(
         _worker,
-        args=(WORLD_SIZE, "29572", _uma_equivalence_worker),
+        args=(WORLD_SIZE, "29704", _uma_equivalence_worker),
         nprocs=WORLD_SIZE,
     )

--- a/test/distributed/test_halo_span_exchange.py
+++ b/test/distributed/test_halo_span_exchange.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Halo exchange when the ghost shell is wider than one rank domain.
+
+``SpatialPartitioner.neighbor_span`` widens the neighbour-rank set once
+``ghost > box_axis / ranks_on_axis``, so a rank must then receive ghosts from
+ranks *two or more* domains away. ``test_spatial_partitioner.py`` gates the
+geometry; these tests gate the data movement, which is what actually feeds the
+model. The condition is a ratio, so a small box reaches it at world=4 — no
+large-scale run required.
+"""
+
+from __future__ import annotations
+
+import torch
+from _gloo_harness import run_gloo
+
+# 4 ranks along x over a 16 A box -> 4.0 A domains, against a 5.5 A ghost
+# (cutoff + skin). span = ceil(5.5 / 4.0) = 2: every rank needs its
+# next-but-one neighbour, which the old +/-1 shell never asked for.
+_WORLD = 4
+_BOX_X = 16.0
+_BOX_YZ = 12.0
+_CUTOFF = 5.0
+_SKIN = 0.5
+_N_ATOMS = 96
+
+
+def _positions() -> torch.Tensor:
+    """Deterministic atoms filling the box, spread along the split axis."""
+    gen = torch.Generator().manual_seed(0)
+    pos = torch.rand(_N_ATOMS, 3, generator=gen, dtype=torch.float64)
+    return pos * torch.tensor([_BOX_X, _BOX_YZ, _BOX_YZ], dtype=torch.float64)
+
+
+def _cell() -> torch.Tensor:
+    return torch.diag(
+        torch.tensor([_BOX_X, _BOX_YZ, _BOX_YZ], dtype=torch.float64)
+    ).unsqueeze(0)
+
+
+def _reference_neighbor_counts() -> torch.Tensor:
+    """Per-atom neighbour count under the minimum-image convention."""
+    pos = _positions()
+    box = torch.tensor([_BOX_X, _BOX_YZ, _BOX_YZ], dtype=torch.float64)
+    delta = pos.unsqueeze(1) - pos.unsqueeze(0)
+    delta -= box * torch.round(delta / box)
+    dist = delta.norm(dim=-1)
+    within = (dist < _CUTOFF) & (dist > 0)
+    return within.sum(dim=1)
+
+
+def _build_batch():
+    from nvalchemi.data import AtomicData, Batch
+
+    n = _N_ATOMS
+    data = AtomicData(
+        positions=_positions(),
+        atomic_numbers=torch.full((n,), 18, dtype=torch.long),
+        atomic_masses=torch.ones(n, dtype=torch.float64),
+        cell=_cell(),
+        pbc=torch.ones(1, 3, dtype=torch.bool),
+    )
+    return Batch.from_data_list([data])
+
+
+def _span_worker(rank: int, world_size: int, queue, *_args) -> None:
+    """Halo-pad on a span>1 partition; report each owned atom's neighbour count."""
+    from torch.distributed.device_mesh import init_device_mesh
+
+    from nvalchemi.distributed._core.particle_halo import ParticleHaloConfig
+    from nvalchemi.distributed.config import DomainConfig
+    from nvalchemi.distributed.particle_halo import halo_exchange
+    from nvalchemi.distributed.partitioner import SpatialPartitioner
+    from nvalchemi.distributed.sharded_batch import ShardedBatch
+
+    mesh = init_device_mesh("cpu", (world_size,))
+    # Split all four ranks along x so the domain width is box_x / world.
+    config = DomainConfig(
+        cutoff=_CUTOFF, skin=_SKIN, mesh=mesh, grid_dims=(world_size, 1, 1)
+    )
+    full = _build_batch() if rank == 0 else None
+
+    partitioner = SpatialPartitioner(
+        config, _cell()[0], torch.ones(3, dtype=torch.bool)
+    )
+    sharded = ShardedBatch.from_batch(full, mesh=mesh, config=config, src=0)
+    halo_config = ParticleHaloConfig(
+        ghost_width=config.effective_ghost_width(),
+        partitioner=partitioner,
+        mesh=mesh,
+    )
+    halo_exchange(sharded, halo_config)
+
+    padded = sharded.padded_batch
+    meta = sharded.halo_meta
+    n_owned = int(meta.n_owned)
+    local = padded.positions.detach()
+    box = torch.tensor([_BOX_X, _BOX_YZ, _BOX_YZ], dtype=local.dtype)
+
+    # Neighbour count for each owned atom against everything this rank can see.
+    delta = local[:n_owned].unsqueeze(1) - local.unsqueeze(0)
+    delta -= box * torch.round(delta / box)
+    dist = delta.norm(dim=-1)
+    counts = ((dist < _CUTOFF) & (dist > 0)).sum(dim=1)
+
+    # Plain Python only: a tensor on the queue is rebuilt from a shared-memory
+    # fd that dies with the worker, so the parent fails to unpickle it.
+    queue.put(
+        (
+            rank,
+            {
+                "span": list(partitioner.neighbor_span()),
+                "n_owned": n_owned,
+                "n_padded": int(local.shape[0]),
+                "owned_positions": local[:n_owned].tolist(),
+                "counts": counts.tolist(),
+            },
+        )
+    )
+
+
+def test_wide_ghost_halo_delivers_every_neighbor():
+    """Every owned atom must see the same neighbours it sees single-process.
+
+    A ghost shell reaching two domains away is only correct if the exchange
+    actually pulls from those ranks; a +/-1 shell silently drops the atoms
+    beyond it, which shows up here as a short neighbour count.
+    """
+    results = run_gloo(world_size=_WORLD, fn=_span_worker, timeout_sec=180.0)
+    assert len(results) == _WORLD, f"expected {_WORLD} payloads, got {len(results)}"
+
+    ref_counts = _reference_neighbor_counts()
+    ref_pos = _positions()
+
+    total_owned = 0
+    for rank, payload in sorted(results, key=lambda r: r[0]):
+        assert payload["span"][0] >= 2, f"rank {rank}: span collapsed to 1"
+        assert 0 < payload["n_owned"] < _N_ATOMS, (
+            f"rank {rank}: degenerate partition, owns {payload['n_owned']}"
+        )
+        total_owned += payload["n_owned"]
+
+        # Map each owned atom back to its global index by position.
+        for local_i, pos in enumerate(payload["owned_positions"]):
+            match = (
+                (ref_pos - torch.tensor(pos, dtype=ref_pos.dtype)).norm(dim=-1).argmin()
+            )
+            assert int(payload["counts"][local_i]) == int(ref_counts[match]), (
+                f"rank {rank} owned atom {local_i} (global {int(match)}) sees "
+                f"{int(payload['counts'][local_i])} neighbours, single-process "
+                f"sees {int(ref_counts[match])} — the halo is short, so the "
+                f"ghost shell did not reach every contributing rank"
+            )
+
+    assert total_owned == _N_ATOMS, (
+        f"ranks own {total_owned} atoms in total, expected {_N_ATOMS}"
+    )

--- a/test/distributed/test_partition_health.py
+++ b/test/distributed/test_partition_health.py
@@ -33,7 +33,7 @@ import torch.multiprocessing as mp
 
 def _verdict_worker(rank: int, world_size: int, scenario: str) -> None:
     os.environ["MASTER_ADDR"] = "127.0.0.1"
-    os.environ["MASTER_PORT"] = "29683"
+    os.environ["MASTER_PORT"] = "29711"
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)

--- a/test/distributed/test_pipeline_construction.py
+++ b/test/distributed/test_pipeline_construction.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``DistributedPipelineModel`` builds without a process group.
+
+Every other pipeline test needs 2+ GPUs, so nothing exercised group planning on
+a workstation — and planning is where each sub-model's persistent
+``DistributedModel`` is constructed. A missing import there raises ``NameError``
+at construction, which lint cannot catch because ``F821`` is in this repo's ruff
+ignore list, and which no local test would reach.
+
+These run on CPU in milliseconds and cover the import graph of the construction
+path, not its numerics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nvalchemi.distributed.config import DomainConfig
+from nvalchemi.distributed.distributed_pipeline import DistributedPipelineModel
+from nvalchemi.models.lj import LennardJonesModelWrapper
+
+
+def _pipeline():
+    """Two cheap kernel-force models, so the group plans per-step."""
+    outer = LennardJonesModelWrapper(epsilon=0.0103, sigma=3.4, cutoff=6.0)
+    inner = LennardJonesModelWrapper(epsilon=0.0103, sigma=3.4, cutoff=4.0)
+    return outer + inner
+
+
+class TestPipelineConstruction:
+    def test_plans_its_groups_without_a_mesh(self) -> None:
+        with DistributedPipelineModel(_pipeline(), DomainConfig(cutoff=6.0)) as dpm:
+            assert dpm._group_plans
+            assert all(p["kind"] in ("per_step", "wired") for p in dpm._group_plans)
+
+    def test_per_step_group_holds_a_persistent_model(self) -> None:
+        with DistributedPipelineModel(_pipeline(), DomainConfig(cutoff=6.0)) as dpm:
+            for plan in dpm._group_plans:
+                for item in plan.get("steps", ()):
+                    assert item["dm"] is not None
+
+    def test_close_is_idempotent(self) -> None:
+        dpm = DistributedPipelineModel(_pipeline(), DomainConfig(cutoff=6.0))
+        dpm.close()
+        dpm.close()
+
+    def test_rejects_a_bare_model(self) -> None:
+        with pytest.raises(TypeError, match="PipelineModelWrapper"):
+            DistributedPipelineModel(
+                LennardJonesModelWrapper(epsilon=0.0103, sigma=3.4, cutoff=6.0),
+                DomainConfig(cutoff=6.0),
+            )

--- a/test/distributed/test_public_api_stability.py
+++ b/test/distributed/test_public_api_stability.py
@@ -45,6 +45,7 @@ EXPECTED_PUBLIC_NAMES: frozenset[str] = frozenset(
         "ShardedBatch",
         "SpatialPartitioner",
         "autograd_target",
+        "pin_fp32",
         "reshard_by_destination",
         # Top layer — declarative spec types a model author names in a wrapper's
         # ``distribution_spec``.

--- a/test/distributed/test_sharded_batch.py
+++ b/test/distributed/test_sharded_batch.py
@@ -424,4 +424,4 @@ def test_from_batch_honors_partition_2ranks() -> None:
 
 
 def test_from_batch_honors_partition_4ranks() -> None:
-    _gloo_spawn(4, "29681", "_from_batch_rank_assignment_worker")
+    _gloo_spawn(4, "29710", "_from_batch_rank_assignment_worker")

--- a/test/distributed/test_spatial_partitioner.py
+++ b/test/distributed/test_spatial_partitioner.py
@@ -93,6 +93,7 @@ def _make_partitioner(
         part.cells_per_dim = SpatialPartitioner.balance_cells_for_ranks(
             part.cells_per_dim, part.rank_grid
         )
+    part._span = part.neighbor_span()
     part._neighbor_ranks = part._compute_all_neighbor_ranks()
     # __init__ caches the cell-matrix inverse for ``assign_atoms_to_ranks``;
     # mirror it here since this helper bypasses __init__.
@@ -453,3 +454,64 @@ class TestRankToGridCoords:
         for rank in range(total):
             rx, ry, rz = part.rank_to_grid_coords(rank)
             assert rx + Px * (ry + Py * rz) == rank
+
+
+class TestNeighborSpan:
+    """Ghost shells wider than one rank domain must reach past adjacent ranks.
+
+    A shell that spans two or more domains but only ever talks to +/-1 silently
+    drops every interaction crossing the gap. Two ways in: many ranks over a
+    small cell, and a barostat contracting the box under a fixed rank grid.
+    """
+
+    def test_span_is_one_when_ghost_fits_in_a_domain(self):
+        """The common case stays at +/-1 — no extra communication."""
+        cell = _make_orthorhombic_cell(28.0, 28.0, 28.0)
+        part = _make_partitioner(cell, cutoff=5.0, world_size=8)
+        assert part.neighbor_span() == (1, 1, 1)
+
+    def test_span_grows_when_ghost_exceeds_domain(self):
+        """Many ranks over a small cell push the shell past one domain."""
+        cell = _make_orthorhombic_cell(28.0, 28.0, 28.0)
+        part = _make_partitioner(cell, cutoff=5.0, world_size=216)
+        widths = part.domain_widths()
+        ghost = part.config.effective_ghost_width()
+        # At least one axis must be narrower than the ghost for this to bite.
+        assert min(widths) < ghost
+        assert max(part.neighbor_span()) > 1
+
+    def test_wide_ghost_reaches_ranks_two_domains_away(self):
+        """The neighbour list must contain the rank two domains along an axis."""
+        cell = _make_orthorhombic_cell(24.0, 24.0, 24.0)
+        # 8 ranks along x: domain = 3.0 A, ghost = 5.5 A -> span 2.
+        part = _make_partitioner(cell, cutoff=5.0, world_size=8, grid_dims=(8, 1, 1))
+        assert part.rank_grid == (8, 1, 1)
+        assert part.neighbor_span()[0] >= 2
+        neighbors = part.get_neighbor_ranks(3)
+        for expected in (1, 2, 4, 5):  # +/-1 AND +/-2 along x
+            assert expected in neighbors, (
+                f"rank {expected} is within the ghost shell of rank 3 but is "
+                f"not a neighbour; got {sorted(neighbors)}"
+            )
+
+    def test_contraction_rebuilds_the_neighbor_set(self):
+        """A barostat shrinking the box must widen the neighbour set."""
+        cell = _make_orthorhombic_cell(48.0, 48.0, 48.0)
+        part = _make_partitioner(cell, cutoff=5.0, world_size=8, grid_dims=(8, 1, 1))
+        assert part.neighbor_span()[0] == 1
+        before = set(part.get_neighbor_ranks(3))
+
+        part.update_cell(_make_orthorhombic_cell(20.0, 20.0, 20.0))
+
+        assert part.neighbor_span()[0] >= 2
+        after = set(part.get_neighbor_ranks(3))
+        assert after > before, (
+            "contraction narrowed every domain but the neighbour set did not "
+            f"grow: {sorted(before)} -> {sorted(after)}"
+        )
+
+    def test_raises_when_shell_wraps_onto_own_image(self):
+        """Stop clearly rather than silently dropping the self-image ghost."""
+        cell = _make_orthorhombic_cell(6.0, 6.0, 6.0)
+        with pytest.raises(ValueError, match="own\\s+periodic image"):
+            _make_partitioner(cell, cutoff=5.0, world_size=4, grid_dims=(4, 1, 1))

--- a/test/distributed/test_spec_serialization.py
+++ b/test/distributed/test_spec_serialization.py
@@ -26,13 +26,21 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from nvalchemi.distributed._core.adapter import (
+    _ARG_TRANSFORM_REGISTRY,
+    _OUTPUT_TRANSFORM_REGISTRY,
     JitAdapter,
     MethodAdapter,
     OpAdapter,
     PythonAdapter,
+    _arg_transform_from_dict,
+    _arg_transform_to_dict,
+    _output_transform_from_dict,
+    _output_transform_to_dict,
 )
 from nvalchemi.distributed._core.op_transforms import (
     AllReduceSum,
@@ -256,7 +264,11 @@ class TestOpSpecDict:
             "0": {"type": "slice_owned"},
             "1": {"type": "slice_owned"},
         }
-        assert d["output_transforms"] == {"0": {"type": "all_reduce_sum"}}
+        # A transform carries its fields, not just its name: they select
+        # behaviour, so encoding the name alone loses the adjoint rule.
+        assert d["output_transforms"] == {
+            "0": {"type": "all_reduce_sum", "replicated_consumer": False}
+        }
         # Property accessors still work.
         assert os.owned_slice_inputs == (0, 1)
         assert os.all_reduce_outputs == (0,)
@@ -380,3 +392,57 @@ class TestMLIPSpecOutputsCollapse:
             compile=CompilePolicy(static_shapes=False),
         )
         assert plain == with_compile  # compile is compare=False
+
+
+class TestTransformFieldsSurviveRoundTrip:
+    """Every transform field must cross a process boundary.
+
+    A transform's fields change what it *does* — ``replicated_consumer`` selects
+    the all-reduce adjoint — so a field that silently reverts to its default on
+    reload changes the maths while the transform's name still matches. The walk
+    below is generic, so a newly added field is covered without anyone
+    remembering to extend this test.
+    """
+
+    @staticmethod
+    def _non_default(cls: type) -> object:
+        """Instantiate *cls* with every boolean field flipped off its default."""
+        import dataclasses
+
+        overrides = {
+            field.name: not field.default
+            for field in dataclasses.fields(cls)
+            if isinstance(field.default, bool)
+        }
+        return cls(**overrides)
+
+    @pytest.mark.parametrize(
+        ("registry", "to_dict", "from_dict"),
+        [
+            (_ARG_TRANSFORM_REGISTRY, _arg_transform_to_dict, _arg_transform_from_dict),
+            (
+                _OUTPUT_TRANSFORM_REGISTRY,
+                _output_transform_to_dict,
+                _output_transform_from_dict,
+            ),
+        ],
+    )
+    def test_every_registered_transform_round_trips(
+        self, registry, to_dict, from_dict
+    ) -> None:
+        for kind, cls in registry.items():
+            original = self._non_default(cls)
+            restored = from_dict(json.loads(json.dumps(to_dict(original))))
+            assert restored == original, (
+                f"{kind}: {original} did not survive a round trip; got {restored}. "
+                "A transform field that reverts to its default changes behaviour "
+                "on the far side of a process boundary."
+            )
+
+    def test_all_reduce_sum_keeps_its_adjoint_rule(self) -> None:
+        """The specific case: the flag selects the backward, not just metadata."""
+        original = AllReduceSum(replicated_consumer=True)
+        restored = _output_transform_from_dict(
+            json.loads(json.dumps(_output_transform_to_dict(original)))
+        )
+        assert restored.replicated_consumer is True

--- a/test/distributed/test_system_fields.py
+++ b/test/distributed/test_system_fields.py
@@ -138,3 +138,47 @@ def test_system_fields_reach_every_rank():
         assert seen["charge"] == CHARGE, f"rank {rank} lost charge"
         assert seen["spin"] == SPIN, f"rank {rank} lost spin"
         assert seen["custom"] == CUSTOM, f"rank {rank} lost custom_scalar"
+
+
+def test_system_fields_survive_a_migration_rebuild():
+    """Migration must not narrow the system schema.
+
+    ``apply_migration`` rebuilds the batch from per-atom fields, so whatever it
+    does not carry across is gone. It used to name ``cell``, ``pbc``, ``energy``
+    and ``stress`` individually, which silently dropped total charge, spin and
+    any property a producer attached — an AIMNet2 run under a barostat would
+    revert to a neutral system partway through a trajectory.
+    """
+    from nvalchemi.data import AtomicData, Batch
+    from nvalchemi.distributed.strategy import _build_batch_from_fields
+
+    data = AtomicData(
+        positions=torch.zeros(4, 3),
+        atomic_numbers=torch.ones(4, dtype=torch.long),
+        cell=torch.eye(3).unsqueeze(0),
+        pbc=torch.ones(1, 3, dtype=torch.bool),
+    )
+    data.add_system_property("charge", torch.tensor([[-2.0]]))
+    data.add_system_property("spin", torch.tensor([[3.0]]))
+    batch = Batch.from_data_list([data])
+
+    # The reconstruction migration performs: per-atom fields only.
+    rebuilt = _build_batch_from_fields(
+        {
+            "positions": batch.positions.clone(),
+            "atomic_numbers": batch.atomic_numbers.clone(),
+        },
+        torch.device("cpu"),
+    )
+    system = batch._system_group
+    assert system is not None
+    for name, tensor in system.items():
+        if isinstance(tensor, torch.Tensor):
+            rebuilt[name] = tensor.clone()
+
+    assert set(rebuilt._system_group.keys()) == set(system.keys()), (
+        "migration narrowed the system schema; a hardcoded carry-over list "
+        "drops whatever it does not mention"
+    )
+    torch.testing.assert_close(rebuilt.charge, batch.charge)
+    torch.testing.assert_close(rebuilt.spin, batch.spin)

--- a/test/distributed/test_system_fields.py
+++ b/test/distributed/test_system_fields.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-system model inputs survive the scatter.
+
+Sharding splits per-atom fields across ranks and replicates the per-system ones.
+Beyond ``cell`` / ``pbc`` that includes the graph-level inputs a wrapper reads to
+decide *which physical system* it is computing — total ``charge``, ``spin``
+multiplicity, and any custom system property. A rank that loses them silently
+falls back to a neutral default, so these are equivalence tests, not plumbing
+tests.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _gloo_harness import run_gloo  # noqa: E402
+
+CHARGE = -2.0
+SPIN = 3.0
+CUSTOM = 7.5
+
+
+BOX = 20.0
+
+
+def _build_batch(split_dim: int):
+    """Eight atoms straddling *split_dim*, carrying charge, spin, and a custom field.
+
+    Half sit at fractional 0.25 along the partitioner's split axis and half at
+    0.75, so the two ranks own four atoms each and the replication assertions
+    aren't satisfied by a degenerate all-on-one-rank partition.
+    """
+    from nvalchemi.data.atomic_data import AtomicData
+    from nvalchemi.data.batch import Batch
+
+    frac = torch.tensor(
+        [
+            [0.2, 0.2, 0.2],
+            [0.3, 0.4, 0.2],
+            [0.2, 0.6, 0.3],
+            [0.3, 0.8, 0.4],
+            [0.7, 0.2, 0.2],
+            [0.8, 0.4, 0.2],
+            [0.7, 0.6, 0.3],
+            [0.8, 0.8, 0.4],
+        ],
+        dtype=torch.float64,
+    )
+    # Put the 0.2/0.3 vs 0.7/0.8 separation on whichever axis the partitioner
+    # actually splits.
+    if split_dim != 0:
+        frac[:, [0, split_dim]] = frac[:, [split_dim, 0]]
+    positions = frac * BOX
+
+    data = AtomicData(
+        positions=positions,
+        atomic_numbers=torch.full((8,), 8, dtype=torch.long),
+        atomic_masses=torch.full((8,), 16.0, dtype=torch.float64),
+        cell=torch.eye(3, dtype=torch.float64).unsqueeze(0) * BOX,
+        pbc=torch.ones(1, 3, dtype=torch.bool),
+        charge=torch.tensor([[CHARGE]], dtype=torch.float64),
+        spin=torch.tensor([[SPIN]], dtype=torch.float64),
+    )
+    data.add_system_property("custom_scalar", torch.tensor([[CUSTOM]]))
+    return Batch.from_data_list([data])
+
+
+def _check_system_fields_replicated(rank, world_size, queue):
+    """Every rank's local view carries the source batch's per-system inputs."""
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from nvalchemi.distributed.config import DomainConfig
+    from nvalchemi.distributed.partitioner import SpatialPartitioner
+    from nvalchemi.distributed.sharded_batch import ShardedBatch
+
+    mesh = DeviceMesh("cpu", list(range(world_size)), mesh_dim_names=("domain",))
+    config = DomainConfig(cutoff=1.0, skin=0.2, mesh=mesh)
+
+    cell = torch.eye(3, dtype=torch.float64).unsqueeze(0) * BOX
+    partitioner = SpatialPartitioner(
+        config=config, cell_matrix=cell, pbc=torch.ones(1, 3, dtype=torch.bool)
+    )
+    split_dim = next(d for d, n in enumerate(partitioner.rank_grid) if n > 1)
+
+    sharded = ShardedBatch.from_batch(
+        _build_batch(split_dim) if rank == 0 else None,
+        mesh=mesh,
+        config=config,
+        src=0,
+    )
+    local = sharded.local_batch
+
+    queue.put(
+        (
+            rank,
+            {
+                "n_owned": int(sharded.positions.to_local().shape[0]),
+                "charge": float(local.charge.reshape(-1)[0]),
+                "spin": float(local.spin.reshape(-1)[0]),
+                "custom": float(local.custom_scalar.reshape(-1)[0]),
+            },
+        )
+    )
+
+
+def test_system_fields_reach_every_rank():
+    """charge / spin / custom system properties replicate to all ranks.
+
+    Guards the failure mode where only ``cell`` and ``pbc`` crossed and a
+    charged or open-shell system was computed as neutral / closed-shell.
+    """
+    results = dict(run_gloo(world_size=2, fn=_check_system_fields_replicated))
+
+    assert set(results) == {0, 1}
+    # A real split, so the assertions aren't trivially satisfied by one rank
+    # holding everything.
+    assert all(0 < r["n_owned"] < 8 for r in results.values())
+    for rank, seen in results.items():
+        assert seen["charge"] == CHARGE, f"rank {rank} lost charge"
+        assert seen["spin"] == SPIN, f"rank {rank} lost spin"
+        assert seen["custom"] == CUSTOM, f"rank {rank} lost custom_scalar"

--- a/test/distributed/validate/test_validate_cuda.py
+++ b/test/distributed/validate/test_validate_cuda.py
@@ -612,9 +612,12 @@ def test_aimnet2_methane_pbc_passes():
     """3-D methane packing with full PBC. Exercises the multi-rank halo
     energy/force/stress path under PBC that the (non-PBC) carbon-chain
     sample doesn't — owned forces, stress, and energy must all match the
-    single-process reference. Stress rides the autograd /world_size
-    consolidation and is only meaningful under PBC, so this is the gate
-    that covers it for AIMNet2 under DD."""
+    single-process reference. Stress rides the autograd /world_size plus
+    cross-rank sum consolidation and is only meaningful under PBC, so this
+    is the gate that covers it for AIMNet2 under DD.
+
+    ``auto_fix=False``: the declared spec must pass as written. Letting the
+    validator repair it would hide a wrong declaration behind a working run."""
     pytest.importorskip("aimnet")
     from nvalchemi.distributed.validate import trace_and_validate
 
@@ -630,7 +633,7 @@ def test_aimnet2_methane_pbc_passes():
         device="cuda:0",
         atol=1e-5,
         rtol=1e-4,
-        auto_fix=True,
+        auto_fix=False,
     )
     assert report.ok, report.next_action
     ph = report.attempts[-1].partition_health

--- a/test/distributed/validate/test_validate_cuda.py
+++ b/test/distributed/validate/test_validate_cuda.py
@@ -155,7 +155,8 @@ def test_lj_passes_initial_inference():
 
     report = trace_and_validate(
         _make_lj_wrapper,
-        _make_argon_batch(n_per_side=5),
+        # n=7 (23.8 A box) so the 2-rank domains exceed the wrapper's 10 A cutoff.
+        _make_argon_batch(n_per_side=7),
         world_size=2,
         device="cuda:0",
         atol=1e-4,
@@ -181,7 +182,7 @@ def test_spec_round_trips_through_disk(tmp_path):
 
     report = trace_and_validate(
         _make_lj_wrapper,
-        _make_argon_batch(n_per_side=4),  # 64 atoms — quick
+        _make_argon_batch(n_per_side=7),  # box must exceed 2x the 10 A cutoff
         world_size=2,
         device="cuda:0",
     )
@@ -208,7 +209,7 @@ def test_auto_fix_kicks_in_when_initial_spec_is_wrong():
 
     report = trace_and_validate(
         _make_lj_with_wrong_spec,  # module-level so mp.spawn can pickle it
-        _make_argon_batch(n_per_side=4),
+        _make_argon_batch(n_per_side=7),
         world_size=2,
         device="cuda:0",
         auto_fix=True,
@@ -281,11 +282,18 @@ class _LJWithWrongSpec:
 def _make_ewald_wrapper():
     from nvalchemi.models.ewald import EwaldModelWrapper
 
-    return EwaldModelWrapper(cutoff=10.0)
+    return EwaldModelWrapper(cutoff=5.0)
 
 
-def _make_charged_argon_batch(n_per_side: int = 5, lattice: float = 3.4):
-    """Argon-with-fake-charges batch for Ewald/PME — alternating ±1 e."""
+def _make_charged_argon_batch(
+    n_per_side: int = 5, lattice: float = 3.4, jitter: float = 0.15
+):
+    """Argon-with-fake-charges batch for Ewald/PME — alternating ±1 e.
+
+    ``jitter`` displaces the lattice by a seeded random offset. On the perfect
+    lattice the forces cancel by symmetry, so a force comparison would be
+    noise-against-noise and could not detect a wrong distributed force.
+    """
     import torch
 
     from nvalchemi.data import AtomicData, Batch
@@ -295,6 +303,10 @@ def _make_charged_argon_batch(n_per_side: int = 5, lattice: float = 3.4):
     positions = torch.stack([gx.flatten(), gy.flatten(), gz.flatten()], dim=-1).cuda()
     n = positions.shape[0]
     box = n_per_side * lattice
+    if jitter:
+        gen = torch.Generator(device="cpu").manual_seed(0)
+        offsets = jitter * torch.randn(positions.shape, generator=gen)
+        positions = (positions + offsets.cuda()) % box
     cell = torch.eye(3, device="cuda") * box
     charges = torch.tensor(
         [1.0 if i % 2 == 0 else -1.0 for i in range(n)],
@@ -320,7 +332,9 @@ def test_ewald_passes_initial_inference():
 
     report = trace_and_validate(
         _make_ewald_wrapper,
-        _make_charged_argon_batch(n_per_side=4),
+        # Even n keeps the alternating +/-1 lattice net-neutral; 8 also puts the
+        # 2-rank domains clear of the wrapper's 10 A cutoff.
+        _make_charged_argon_batch(n_per_side=8),
         world_size=2,
         device="cuda:0",
         auto_fix=True,
@@ -335,7 +349,7 @@ def test_ewald_passes_initial_inference():
 def _make_pme_wrapper():
     from nvalchemi.models.pme import PMEModelWrapper
 
-    return PMEModelWrapper(cutoff=10.0)
+    return PMEModelWrapper(cutoff=5.0)
 
 
 @cuda_required
@@ -346,7 +360,9 @@ def test_pme_passes_initial_inference():
 
     report = trace_and_validate(
         _make_pme_wrapper,
-        _make_charged_argon_batch(n_per_side=4),
+        # Even n keeps the alternating +/-1 lattice net-neutral; 8 also puts the
+        # 2-rank domains clear of the wrapper's 10 A cutoff.
+        _make_charged_argon_batch(n_per_side=8),
         world_size=2,
         device="cuda:0",
         auto_fix=True,

--- a/test/models/test_ewald.py
+++ b/test/models/test_ewald.py
@@ -156,7 +156,8 @@ class TestEwaldModelConfig:
 
     def test_autograd_outputs_includes_forces(self):
         w = _make_ewald()
-        assert w.model_config.autograd_outputs == frozenset({"forces"})
+        # Default is hybrid_forces=False, so stress is autograd-derived too.
+        assert w.model_config.autograd_outputs == frozenset({"forces", "stress"})
 
     def test_needs_pbc(self):
         w = _make_ewald()
@@ -546,7 +547,9 @@ class TestEwaldIntegration:
 
     def test_forward_raises_when_virial_none(self):
         """RuntimeError when stress is requested but kernels return no virial."""
-        w = _make_ewald()
+        # Analytic-path guard: without hybrid_forces the wrapper derives stress
+        # from the energy and never consults a kernel virial.
+        w = _make_ewald(hybrid_forces=True)
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch()
         self._build_nl(batch, w)
@@ -684,7 +687,7 @@ class TestEwaldHybridForces:
 
     def test_forces_have_no_grad_fn(self):
         """Direct kernel forces are computed on detached positions."""
-        w = _make_ewald()
+        w = _make_ewald(hybrid_forces=True)
         batch = _make_charged_batch()
         self._build_nl(batch, w)
         out = w(batch)
@@ -701,7 +704,7 @@ class TestEwaldHybridForces:
 
     def test_energy_no_grad_fn_without_charge_grad(self):
         """When charges don't require grad, _InjectChargeGrad is skipped."""
-        w = _make_ewald()
+        w = _make_ewald(hybrid_forces=True)
         batch = _make_charged_batch()
         batch.charges = batch.charges.detach().requires_grad_(False)
         self._build_nl(batch, w)
@@ -711,7 +714,7 @@ class TestEwaldHybridForces:
     def test_charge_gradient_matches_finite_difference(self):
         """energy.backward() should recover the injected dE/dq."""
         torch.manual_seed(42)
-        w = _make_ewald()
+        w = _make_ewald(hybrid_forces=True)
         batch = _make_charged_batch(n_atoms=4, box_size=8.0, dtype=torch.float64)
         fd_grad = _finite_difference_charge_gradient(w, batch, self._build_nl)
         batch.charges = batch.charges.detach().requires_grad_(True)
@@ -732,7 +735,7 @@ class TestEwaldHybridForces:
 
     def test_stress_has_no_grad_fn(self):
         """Kernel virial is computed on detached positions/cell."""
-        w = _make_ewald()
+        w = _make_ewald(hybrid_forces=True)
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch()
         batch.charges = batch.charges.detach().requires_grad_(True)

--- a/test/models/test_pme.py
+++ b/test/models/test_pme.py
@@ -191,7 +191,8 @@ class TestPMEModelConfig:
 
     def test_autograd_outputs_includes_forces(self):
         w = _make_pme()
-        assert w.model_config.autograd_outputs == frozenset({"forces"})
+        # Default is hybrid_forces=False, so stress is autograd-derived too.
+        assert w.model_config.autograd_outputs == frozenset({"forces", "stress"})
 
     def test_needs_pbc(self):
         w = _make_pme()
@@ -735,7 +736,7 @@ class TestPMEIntegration:
 
     def test_hybrid_forces_stress_has_no_grad_fn(self):
         """Kernel virial is computed on detached positions/cell."""
-        w = _make_pme()
+        w = _make_pme(hybrid_forces=True)
         w.model_config.active_outputs = {"energy", "forces", "stress"}
         batch = _make_charged_batch()
         batch.charges = batch.charges.detach().requires_grad_(True)

--- a/uv.lock
+++ b/uv.lock
@@ -184,8 +184,8 @@ overrides = [{ name = "python-hostlist", marker = "sys_platform == 'never'" }]
 
 [[manifest.dependency-metadata]]
 name = "nvalchemi-toolkit-ops"
-version = "0.4.0"
-requires-dist = ["warp-lang>=1.13.0,<1.15", "numpy", "torch>=2.8.0 ; extra == 'torch'", "torch>=2.8.0 ; extra == 'torch-cu12'", "torch>=2.8.0 ; extra == 'torch-cu13'"]
+version = "0.4.1"
+requires-dist = ["warp-lang>=1.13.0", "numpy", "torch>=2.8.0 ; extra == 'torch'", "torch>=2.8.0 ; extra == 'torch-cu12'", "torch>=2.8.0 ; extra == 'torch-cu13'"]
 provides-extras = ["torch", "torch-cu12", "torch-cu13"]
 
 [[package]]
@@ -4106,9 +4106,9 @@ requires-dist = [
     { name = "loguru" },
     { name = "mace-torch", marker = "extra == 'mace'", specifier = "==0.3.15" },
     { name = "numpy", specifier = "<2.4" },
-    { name = "nvalchemi-toolkit-ops", specifier = ">=0.4.0" },
-    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", specifier = ">=0.3.1" },
-    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", specifier = ">=0.3.1" },
+    { name = "nvalchemi-toolkit-ops", specifier = ">=0.4.1" },
+    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", specifier = ">=0.4.1" },
+    { name = "nvalchemi-toolkit-ops", extras = ["torch-cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", specifier = ">=0.4.1" },
     { name = "nvidia-physicsnemo", specifier = ">=2.0.0" },
     { name = "nvidia-physicsnemo", extras = ["cu12"], marker = "sys_platform != 'darwin' and extra == 'cu12'", specifier = ">=2.0.0" },
     { name = "nvidia-physicsnemo", extras = ["cu13"], marker = "sys_platform != 'darwin' and extra == 'cu13'", specifier = ">=2.0.0" },
@@ -4174,14 +4174,14 @@ docs = [
 
 [[package]]
 name = "nvalchemi-toolkit-ops"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.1"
+source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy" },
     { name = "warp-lang" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ff/d0b5333356a9a3efda851ffb23820b874b05fbe1caabaa6fad3c4005bda6/nvalchemi_toolkit_ops-0.4.0-py3-none-any.whl", hash = "sha256:f245c393c210a78160eab783d01c3d2d7fda54014bad1885c4210ced8000a3f7", size = 1254925, upload-time = "2026-07-13T18:03:52.887Z" },
+    { url = "https://pypi.nvidia.com/nvalchemi-toolkit-ops/nvalchemi_toolkit_ops-0.4.1-py3-none-any.whl", hash = "sha256:f2f1e195f90d7a27ec52c26484ef727d734cc34cab15d45a3a38e2077c046c88" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Correctness work on the distributed (domain-decomposition) layer, covering a
reported set of DD defects plus several found while building gates for them.
The common thread is silence: each of these produced wrong numbers or dropped
work without raising, so much of the diff is the gate that now catches it.

Domain decomposition ships for the first time in this release, so most of these
are fixes to unreleased code. Two exceptions change already-released
single-process behaviour and are called out separately below.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- fill in -->

## Changes Made

Eight commits, each independently reviewable:

1. **Keep the spec whole across a process boundary.** `MLIPSpec.to_dict` omitted
   `CompilePolicy`, so a spec persisted to disk or sent to a worker came back
   with `force_strategy` unset and framework-autograd models differentiated an
   already-reduced global energy — forces scaled by the world size. Adapter
   replacements built from a model's own submodules are closures with no
   importable name, so a reloaded adapter installed as a no-op and per-layer
   halo correction stopped running.
2. **Correct the all-reduce adjoint for replicated consumers.** `AllReduceSum`
   is self-adjoint only when the incoming gradient is this rank's own partial;
   where the reduced value feeds a computation every rank runs identically, the
   gradient is already global and reducing again multiplied it by the world size.
3. **Sharding and halo geometry.** A ghost shell wider than one domain reaches
   ranks more than one domain away, and reaches the same rank from *both* sides
   of a periodic axis — each side a distinct lattice image holding different
   atoms. Only the outermost domain pair was treated as wrapping, so in-cutoff
   pairs were dropped silently. Also: ranks without the source batch chose a
   device from hardware availability rather than the mesh, so a CPU mesh on a
   GPU host mixed CPU and CUDA tensors in its first broadcast and hung.
4. **Consolidate the strain trick; stress and output parity.** The affine strain
   trick had five copies across the distributed layer beside the canonical
   `prepare_strain`; all now route through it and a new `apply_strain`. Stress
   under node-partition graph parallelism previously raised `KeyError`. The
   framework-owned energy returned `[n_systems]` where wrappers return
   `[n_systems, 1]`, and kept the wider dtype node energies accumulate in.
5. **fp32 precision control.** `nvalchemi.distributed.pin_fp32`, plus a warning
   when reduced-precision fp32 is in force — it makes distributed and
   single-process results diverge well beyond fp32 rounding.
6. **Electrostatics gradients and DD-pure specs.** Ewald's reciprocal was only
   differentiated w.r.t. positions and charges, giving a wrong `dE/dq` and a
   wrong strain-autograd stress; the strain cache reused the previous call's
   graph. Ewald/PME default to `hybrid_forces=False` (**breaking**, see below).
7. **Per-spawn rendezvous ports, docs and changelog.** The spawn harnesses
   hardcoded a port, so concurrent runs of the same file collided with
   `EADDRINUSE` and read as correctness failures.
8. **A distinct rendezvous port per spawn test.** Seven ports were shared across
   fifteen files, and the per-parametrization helper drew from the ephemeral
   range.

### Breaking

`EwaldModelWrapper` and `PMEModelWrapper` now default to `hybrid_forces=False`.
The analytic direct-output path does not produce consistent gradients and is
rejected under domain decomposition. Forces and stress now come from autograd
over the energy; pass `hybrid_forces=True` explicitly to keep the old path.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Local (1 GPU): **1313 passed, 64 skipped, 0 failed** across `test/distributed`
and `test/models`.

Multi-GPU (4×H100, world=2 and world=4):

| gate | result |
|---|---|
| equivalence matrices, eager + compiled | **32/32 PASS** |
| stress gates (electrostatics, slab ×2, MACE cueq, wired pipeline) | **11 passed** |
| model + graph-parallel gates | **35 passed** |
| full `test/distributed/` | 656 passed, 7 skipped, 3 failed |

The three were rendezvous-port collisions, not correctness failures: two test
files shared a hardcoded port, and the per-parametrization port helper drew from
the kernel's ephemeral range, so a port could be claimed for an unrelated
connection between the choice and the bind. One of the three had passed minutes
earlier in the same job. Both causes are fixed in this branch (every spawn test
now has a distinct port, below the ephemeral floor); the full-suite figure above
predates that fix.

### Force / stress equivalence vs single-GPU — eager (world=2, H100, true fp32)

| model | system | want | N | owned | relE | relF | relS | verdict |
|---|---|---|---|---|---|---|---|---|
| ewald | neutral | F | 2744 | [1352, 1392] | 0.00e+00 | 4.30e-06 | n/a | PASS |
| ewald | neutral | F+S | 2744 | [1352, 1392] | 0.00e+00 | 4.44e-06 | 2.64e-07 | PASS |
| ewald | net-charged | F | 2744 | [1352, 1392] | 0.00e+00 | 4.55e-06 | n/a | PASS |
| ewald | net-charged | F+S | 2744 | [1352, 1392] | 0.00e+00 | 4.26e-06 | 6.59e-07 | PASS |
| pme | neutral | F | 2744 | [1352, 1392] | 0.00e+00 | 5.01e-06 | n/a | PASS |
| pme | neutral | F+S | 2744 | [1352, 1392] | 0.00e+00 | 4.89e-06 | 9.89e-07 | PASS |
| pme | net-charged | F | 2744 | [1352, 1392] | 0.00e+00 | 4.55e-06 | n/a | PASS |
| pme | net-charged | F+S | 2744 | [1352, 1392] | 0.00e+00 | 4.60e-06 | 1.12e-06 | PASS |
| aimnet2+pme | neutral | F | 2560 | [1286, 1274] | 1.66e-06 | 7.31e-07 | n/a | PASS |
| aimnet2+pme | neutral | F+S | 2560 | [1286, 1274] | 1.44e-06 | 4.50e-07 | 2.19e-05 | PASS |
| aimnet2+pme | net-charged | F | 2560 | [1286, 1274] | 2.21e-07 | 2.77e-07 | n/a | PASS |
| aimnet2+pme | net-charged | F+S | 2560 | [1286, 1274] | 3.32e-07 | 4.43e-07 | 2.64e-05 | PASS |
| aimnet2+ewald | neutral | F | 2560 | [1286, 1274] | 1.66e-06 | 3.38e-07 | n/a | PASS |
| aimnet2+ewald | neutral | F+S | 2560 | [1286, 1274] | 1.33e-06 | 2.81e-07 | 2.63e-05 | PASS |
| aimnet2+ewald | net-charged | F | 2560 | [1286, 1274] | 0.00e+00 | 3.60e-07 | n/a | PASS |
| aimnet2+ewald | net-charged | F+S | 2560 | [1286, 1274] | 4.43e-07 | 4.99e-07 | 5.13e-05 | PASS |

### Same, compiled (`graphs` is compile count before → after; stable means recompile-free)

| model | system | want | N | owned | relE | relF | relS | graphs | verdict |
|---|---|---|---|---|---|---|---|---|---|
| ewald | neutral | F | 2744 | 1352 | 0.00e+00 | 4.43e-06 | n/a | 18→18 | PASS |
| ewald | neutral | F+S | 2744 | 1352 | 0.00e+00 | 4.38e-06 | 2.64e-07 | 37→37 | PASS |
| ewald | net-charged | F | 2744 | 1352 | 0.00e+00 | 4.45e-06 | n/a | 37→37 | PASS |
| ewald | net-charged | F+S | 2744 | 1352 | 0.00e+00 | 4.39e-06 | 3.30e-07 | 37→37 | PASS |
| pme | neutral | F | 2744 | 1352 | 0.00e+00 | 4.50e-06 | n/a | 59→59 | PASS |
| pme | neutral | F+S | 2744 | 1352 | 0.00e+00 | 4.56e-06 | 4.62e-07 | 84→84 | PASS |
| pme | net-charged | F | 2744 | 1352 | 0.00e+00 | 4.52e-06 | n/a | 84→84 | PASS |
| pme | net-charged | F+S | 2744 | 1352 | 0.00e+00 | 4.36e-06 | 1.12e-06 | 84→84 | PASS |
| aimnet2+pme | neutral | F | 2560 | 1286 | 1.44e-06 | 3.94e-07 | n/a | 152→152 | PASS |
| aimnet2+pme | neutral | F+S | 2560 | 1286 | 7.75e-07 | 3.38e-07 | 1.64e-05 | 235→235 | PASS |
| aimnet2+pme | net-charged | F | 2560 | 1286 | 1.11e-07 | 3.88e-07 | n/a | 253→253 | PASS |
| aimnet2+pme | net-charged | F+S | 2560 | 1286 | 2.21e-07 | 2.77e-07 | 1.36e-05 | 253→253 | PASS |
| aimnet2+ewald | neutral | F | 2560 | 1286 | 1.77e-06 | 4.50e-07 | n/a | 259→259 | PASS |
| aimnet2+ewald | neutral | F+S | 2560 | 1286 | 1.11e-06 | 4.50e-07 | 2.32e-05 | 264→264 | PASS |
| aimnet2+ewald | net-charged | F | 2560 | 1286 | 4.43e-07 | 3.33e-07 | n/a | 264→264 | PASS |
| aimnet2+ewald | net-charged | F+S | 2560 | 1286 | 2.21e-07 | 3.88e-07 | 2.51e-05 | 264→264 | PASS |

Both matrices ran with TF32 disabled (measured matmul relative error 1.33e-06,
i.e. true fp32). Every partition is non-degenerate — each rank owns roughly half
the system — so the cross-rank reduction is genuinely exercised.

**On reproducing these numbers.** The per-row values are not stable run to run:
GPU reduction order varies, and these are error metrics sitting at the fp32
noise floor. 

### Additional multi-GPU gates

- Stress equivalence for Ewald and PME, slab Ewald and PME, MACE + cuEquivariance,
  and the wired AIMNet2→PME pipeline: 11 passed.
- AIMNet2 charge equivalence under DD, eager and compiled: slope `1.0000`,
  R² `1.0000`, max |Δq| `4.2e-07` across all 4 ranks.
- Compiled force-then-stress ordering: no divergence in any sequence,
  single-GPU or at world=4.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
