### PR TITLE
docs: cut 0.2.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,80 +1,80 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-08-07
 
-### Added
+Second public-beta release. The headline additions are a training and
+fine-tuning framework, domain-decomposed multi-GPU inference and dynamics, a
+UMA model wrapper, and a reporting layer for live progress and TensorBoard
+output.
 
-- Domain decomposition for distributed inference and dynamics: a spatial halo
-  strategy and a graph-parallel strategy, both driven by a declarative
-  `MLIPSpec` a model wrapper publishes as `distribution_spec`. Ewald, PME,
-  MACE, AIMNet2 and UMA ship specs; composed pipelines decompose per stage.
-  Energy, forces and stress agree with a single-GPU reference to fp32 rounding
-  under both strategies, eager and compiled. `nvalchemi.distributed.pin_fp32`
-  pins full-precision fp32 for runs that must match a reference, since TF32
-  makes distributed and single-process results diverge well beyond fp32 noise.
+### Training And Fine-Tuning
 
-- MACE training example for end-to-end model training workflows.
-- `EMAHook._build_averaged_model` override seam, so a caller that owns
-  model sharding can supply a pre-built `AveragedModel` instead of the
-  default deepcopy — enabling EMA on `fully_shard` (FSDP2) / DTensor
-  models. Default behaviour unchanged.
-- Checkpointable training hooks. Hooks such as EMA can now save restart
-  state with strategy checkpoints, so resumed training keeps averaged
-  weights instead of starting them over.
-- Training strategy checkpoint restart support, including a periodic
-  checkpoint hook for step- or epoch-based saves and restart loading with
-  models, optimizers, schedulers, runtime counters, and restart-safe device
-  placement.
-- PhysicsNeMo-compatible atomic datapipes with `MultiDataset` composition,
-  multidataset-aware sampling policies, and fused batch loading that preserves
-  the Zarr reader's coalesced I/O path.
-- First-class validation on `TrainingStrategy`. Set a `ValidationConfig`
-  on `strategy.validation_config` and validation runs automatically at the
-  configured step or epoch cadence, plus one final pass at end-of-training;
-  the latest summary is stored on `strategy.last_validation`. Mechanics live
-  in a public, context-managed `ValidationLoop` that can also be run
-  standalone outside training. An `inference_model` slot lets EMA (or SWA /
-  a distillation teacher) publish averaged weights for validation to read.
-  A new `AFTER_VALIDATION` hook stage fires immediately after each pass so
-  loggers can read the live summary. For per-batch logging, pass a
-  `batch_callback` (any object matching the `BatchValidationCallback`
-  protocol) on the config; it is invoked once per validation batch with the
-  batch, predictions, and per-batch loss.
-- Metric-driven learning-rate schedulers. `ReduceLROnPlateau` is now
-  supported via `OptimizerConfig.scheduler_metric_adapter` (a summary-dict
-  key string or a callable). Time-based schedulers step every optimizer
-  step as before; metric-driven schedulers step only at validation
-  checkpoints, where the validation summary supplies the metric.
+- **`nvalchemi.training`** — a Pydantic-driven supervised training framework.
+  `TrainingStrategy` owns a run: the models to train, the dataloader, losses,
+  optimizers, schedulers, hooks, and the step or epoch budget.
+  `FineTuningStrategy` extends it with pretrained-checkpoint initialization,
+  module patches, trainable-parameter filters, and opt-in reuse of the source
+  checkpoint's loss and optimizer configuration.
+- **Loss library** (`nvalchemi.training.losses`) — energy (`EnergyMSELoss`,
+  `EnergyMAELoss`, `EnergyHuberLoss`), force (`ForceMSELoss`, `ForceHuberLoss`,
+  `ForceL2NormLoss`), and stress (`StressMSELoss`, `StressHuberLoss`) terms
+  built on a common `BaseLossFunction` template with per-atom normalization,
+  masking, and graph-balanced reductions. `ComposedLossFunction` combines terms
+  under static weights or a `LossWeightSchedule` (`ConstantWeight`,
+  `LinearWeight`, `CosineWeight`, `PiecewiseWeight`).
+- **Training hooks** (`nvalchemi.training.hooks`) — `CheckpointHook` for step-
+  or epoch-based saves, `EMAHook` for exponential moving averages, `DDPHook`
+  for data-parallel wrapping, `MixedPrecisionHook`, and `ModulePatchHook` /
+  `TrainableParameterHook` for fine-tuning control.
+- **Restartable checkpoints** — strategy checkpoints save and restore models,
+  optimizers, schedulers, runtime counters, and hook state, with restart-safe
+  device placement. Hooks implementing `CheckpointableHook`, such as EMA, carry
+  their own restart state, so a resumed run keeps its averaged weights.
+- **First-class validation on `TrainingStrategy`** — set a `ValidationConfig`
+  on `strategy.validation_config` and validation runs at the configured step or
+  epoch cadence, plus one final pass at end-of-training; the latest summary is
+  stored on `strategy.last_validation`. Mechanics live in a public,
+  context-managed `ValidationLoop` that also runs standalone outside training.
+  An `inference_model` slot lets EMA (or SWA, or a distillation teacher)
+  publish averaged weights for validation to read. The `AFTER_VALIDATION` hook
+  stage fires immediately after each pass so loggers can read the live summary.
+  For per-batch logging, pass a `batch_callback` (any object matching the
+  `BatchValidationCallback` protocol) on the config; it is invoked once per
+  validation batch with the batch, predictions, and per-batch loss.
+- **Metric-driven learning-rate schedulers** — `ReduceLROnPlateau` is supported
+  via `OptimizerConfig.scheduler_metric_adapter` (a summary-dict key string or
+  a callable). Time-based schedulers step every optimizer step as before;
+  metric-driven schedulers step at validation checkpoints, where the validation
+  summary supplies the metric.
+- **`EMAHook._build_averaged_model` override point** — a caller that owns model
+  sharding can supply a pre-built `AveragedModel` in place of the default
+  deepcopy, which enables EMA on `fully_shard` (FSDP2) / DTensor models.
+  Default behavior is unchanged.
+- **`nvalchemi-training` CLI** — scaffolds, validates, reports on, and runs
+  training specifications. `train init` scaffolds a from-scratch spec and
+  `finetune init mace|aimnet2|checkpoint|custom` scaffolds a fine-tuning spec
+  per source; `schema dump` / `schema template` emit JSON schema and templates
+  for offline authoring; `spec report` validates and renders a spec, and
+  `spec run` / `spec resume` build the runtime components and execute it.
+- MACE training example (`examples/advanced/10_mace_training.py`) covering an
+  end-to-end training workflow.
+
+### Distributed Inference And Dynamics
+
+- **Domain decomposition** — a spatial halo strategy and a graph-parallel
+  strategy, both driven by a declarative `MLIPSpec` a model wrapper publishes
+  as `distribution_spec`. Ewald, PME, MACE, AIMNet2 and UMA ship specs;
+  composed pipelines decompose per stage. Energy, forces and stress agree with
+  a single-GPU reference to fp32 rounding under both strategies, eager and
+  compiled. `nvalchemi.distributed.pin_fp32` pins full-precision fp32 for runs
+  that must match a reference, since TF32 makes distributed and single-process
+  results diverge well beyond fp32 noise.
+- `nvalchemi/distributed.py` is now a package. `DistributedManager`,
+  `resolve_world_size`, `resolve_global_rank`, and `collective_device` moved to
+  `nvalchemi/distributed/_runtime.py` and stay importable from
+  `nvalchemi.distributed`.
 
 ### Model Wrappers
-
-- **Pipeline neighbor-list adaptation policy** — `PipelineModelWrapper`
-  now accepts `neighbor_adaptation` (`"auto"`, `"always"`, `"never"`) and
-  `max_cutoff_ratio` (default `1.5`). The default `"auto"` mode only filters
-  a source neighbor list for a smaller cutoff when the source cutoff is at most
-  `max_cutoff_ratio` times the target cutoff; larger gaps get separate source
-  lists. `"always"` builds one max-cutoff source list, while `"never"` builds
-  exact cutoff source groups and skips cutoff filtering.
-
-### Core Data Layer
-
-- **In-memory datapipes** - new `InMemoryDataset` stores a fully materialized
-  `Batch` in memory and serves graph-indexed `Batch` selections through the
-  same `load_batches` / fused-prefetch interface used by `DataLoader`. It can
-  be constructed from an existing `Batch` or materialized from a reader in
-  chunks, with optional field-level metadata and batch transforms.
-- **User-specified transforms** - `Dataset` accepts a `transforms=` kwarg
-  (per-sample `(AtomicData, metadata) -> (AtomicData, metadata)`) and
-  `DataLoader` accepts a `batch_transforms=` kwarg (per-batch `Batch -> Batch`).
-  Both default to `None` (backward compatible). New `nvalchemi.data.transforms`
-  subpackage exposes a polymorphic `Compose` utility plus `SampleTransform`
-  and `BatchTransform` type aliases, re-exported from `nvalchemi.data`.
-  Per-sample transforms run after device transfer on both sync and prefetch
-  paths; per-batch transforms run on the consumer thread after `Batch.from_data_list`.
-  Transform failures are wrapped in `RuntimeError` with `transform[<i>]`
-  breadcrumb and `__cause__` preserved.
-
-### Models
 
 - **UMA (fairchem-core) wrapper** — new `UMAWrapper` exposes UMA
   (Universal Models for Atoms) foundation models (`uma-s-1p1`,
@@ -90,6 +90,67 @@
   environment. `from_checkpoint` forwards fairchem's `inference_settings`
   (including `"turbo"` for `torch.compile`). See the
   `examples/advanced/09_uma_nve.py` NVE/NVT/NPT walkthrough.
+- **Slab correction for electrostatics** — `EwaldModelWrapper` and
+  `PMEModelWrapper` accept `slab_correction` (default `False`) to apply the
+  two-dimensional slab correction. Per-system `pbc` flags with one `False`
+  entry mark slab systems, for example `[True, True, False]`, and mixed slab
+  and three-dimensional periodic batches are supported.
+- **Trainable model wrappers** — `MACEWrapper` forwards its own `self.training`
+  flag to the MACE model, and `PipelineModelWrapper` retains the autograd graph
+  when it is in training mode with gradients enabled, so both can sit inside a
+  `TrainingStrategy`.
+- **Pipeline neighbor-list adaptation policy** — `PipelineModelWrapper`
+  now accepts `neighbor_adaptation` (`"auto"`, `"always"`, `"never"`) and
+  `max_cutoff_ratio` (default `1.5`). The default `"auto"` mode only filters
+  a source neighbor list for a smaller cutoff when the source cutoff is at most
+  `max_cutoff_ratio` times the target cutoff; larger gaps get separate source
+  lists. `"always"` builds one max-cutoff source list, while `"never"` builds
+  exact cutoff source groups and skips cutoff filtering.
+
+### Core Data Layer
+
+- **Explicit batch loading** — `Dataset.load_batches(...)` is the canonical
+  explicit batch API. It issues fused `read_many` requests through the reader,
+  preserving the Zarr backend's coalesced I/O path, and returns one `Batch` per
+  requested batch-index list. `Dataset.read_many(...)` and
+  `Dataset.get_batch(...)` cover single-request sample and batch reads.
+- **Dataset composition and sampling** — `MultiDataset` wraps several `Dataset`
+  instances behind one global index space and routes `load_batches` requests to
+  the owning child datasets, restoring the requested global sample order.
+  `MultiDatasetSampler` and `MultiDatasetBatchSampler` add multidataset-aware
+  sampling policies over that index space.
+- **In-memory datapipes** — new `InMemoryDataset` stores a fully materialized
+  `Batch` in memory and serves graph-indexed `Batch` selections through the
+  same `load_batches` / fused-prefetch interface used by `DataLoader`. It can
+  be constructed from an existing `Batch` or materialized from a reader in
+  chunks, with optional field-level metadata and batch transforms.
+- **User-specified transforms** — `Dataset` accepts a `transforms=` kwarg
+  (per-sample `(AtomicData, metadata) -> (AtomicData, metadata)`) and
+  `DataLoader` accepts a `batch_transforms=` kwarg (per-batch `Batch -> Batch`).
+  Both default to `None` (backward compatible). New `nvalchemi.data.transforms`
+  subpackage exposes a polymorphic `Compose` utility plus `SampleTransform`
+  and `BatchTransform` type aliases, re-exported from `nvalchemi.data`.
+  Per-sample transforms run after device transfer on both sync and prefetch
+  paths; per-batch transforms run on the consumer thread after `Batch.from_data_list`.
+  Transform failures are wrapped in `RuntimeError` with `transform[<i>]`
+  breadcrumb and `__cause__` preserved.
+
+### Reporting And Hooks
+
+- **Reporting subsystem** (`nvalchemi.hooks.reporting`) —
+  `ReportingOrchestrator` fans workflow events out to registered reporters.
+  `RichReporter` renders a live terminal dashboard through `DynamicsRichLayout`
+  or `TrainingRichLayout`, and `TensorBoardReporter` writes scalar summaries
+  through the `tensorboard` extra. Scalar extraction helpers
+  (`collect_scalars`, `extract_dynamics_scalars`, `extract_loss_scalars`,
+  `extract_optimizer_lr_scalars`) pull values out of dynamics and training
+  state, and reporting is rank-safe under distributed runs.
+- **`StageTimingHook`** — per-stage wall-clock timing for any hook-enabled
+  workflow, for both dynamics and training.
+- **`TorchProfilerHook`** — captures PyTorch profiler traces through
+  PhysicsNeMo's profiler wrapper.
+- **`CheckpointableHook`** protocol — hooks that own restart state declare it
+  and participate in strategy checkpoint save and load.
 
 ### Fixed
 
@@ -100,7 +161,25 @@
   routes to the staged reciprocal.
 - **Ewald / PME strain cache** — cached k-vectors were rebuilt from the strained
   cell, so a second stress evaluation reused the first call's autograd graph.
-
+- **Merged force and stress autograd** (#88) — `PipelineModelWrapper` and
+  `AIMNet2Wrapper` now take forces and stress from a single merged autograd
+  call when both are requested, and detach autograd tensors at the pipeline
+  boundary so graph-attached batch tensors are released on both normal returns
+  and exceptions.
+- **Asymmetric strain displacement** (#111) — `prepare_strain` applies only the
+  symmetric part of the displacement tensor when deforming positions and cells,
+  so an asymmetric energy yields a symmetric stress.
+- **Double particle thermostat coupling in NPT** (#96) — high-level NPT
+  velocity half-steps route through the no-drag NPH primitive, since particle
+  Nosé-Hoover scaling is applied separately in the toolkit's operator split.
+- **Inflight refill system IDs** (#113) — systems retained across an inflight
+  refill keep their IDs and status bookkeeping; only replaced slots take new
+  sampler IDs.
+- **Inactive cells during masked updates** (#116) — a masked post-update
+  restores the cells of systems outside the mask instead of overwriting them.
+- **MACE cuEquivariance device context** (#114) — checkpoint target devices are
+  normalized before load and final placement, and cuEq conversion runs under
+  the requested CUDA device context. Non-CUDA targets warn and skip conversion.
 - **Distributed dynamics lifecycle** — keep per-system integrator state aligned
   when pipeline receives and graduates systems, clear reusable communication
   buffers before every send without shrinking their segmented capacity, and run
@@ -136,7 +215,8 @@
 
 ### Deprecated
 
-- `cells_inv` argument on `_cell_kinetic_energy`. Cell kinetic energy
+- `cells_inv` argument on `_cell_kinetic_energy` in
+  `nvalchemi/dynamics/integrators/npt.py`. Cell kinetic energy
   is computed directly from the strain rate `ε̇` and no longer needs
   the cell inverse. The argument is retained for backwards
   compatibility (a `DeprecationWarning` is emitted when passed) and
@@ -149,12 +229,6 @@
   consistent gradients and is not supported under domain decomposition, where
   `distribution_spec` rejects it. Forces and stress now come from autograd over
   the energy; pass `hybrid_forces=True` explicitly to keep the old path.
-
-- Dataset-level explicit batch reads now use `load_batches(...)`. The raw
-  `read_many(...)` API remains on readers, where storage backends can optimize
-  ordered I/O, but `Dataset.read_many(...)` and `Dataset.get_batch(...)` have
-  been removed to keep the public Dataset API focused on sample access,
-  batch materialization, and prefetching.
 - Split hook context state into `HookContext`, `DynamicsContext`, and
   `TrainContext` so each workflow exposes only the fields it owns.
   Dynamics-specific state such as `step_count`, `converged_mask`, and
@@ -185,6 +259,20 @@
    `EvaluationZarrSink` output classes were removed; replace summary logging
    with an `AFTER_VALIDATION` hook and per-batch logging with a
    `ValidationConfig(batch_callback=...)`.
+
+### Requirements
+
+- Python 3.11–3.13
+- PyTorch >= 2.8
+- `nvalchemi-toolkit-ops` >= 0.4.1; the CUDA build now comes from the `cu12` /
+  `cu13` extras
+- `nvidia-physicsnemo` >= 2.0.0, `click`, and `plotext` join the required
+  dependencies; `numpy` is pinned to `<2.4`
+- Optional extras: `aimnet`, `ase`, `cu12`, `cu13`, `mace`, `pymatgen`,
+  `tensorboard`, `uma`. `cu12` and `cu13` select the matching CUDA build of
+  `nvalchemi-toolkit-ops`, `nvidia-physicsnemo`, `cuml`, and
+  `cuequivariance-ops-torch`, so pick exactly one. `uma` conflicts with `mace`
+  and with both CUDA extras and resolves into its own environment.
 
 ## 0.1.0 — 2026-04-16
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Cuts the `Unreleased` section as `0.2.0 — 2026-08-07` (release date from the v0.2.0 tag) and audits every entry in it against the code between `v0.1.0` and the release.

The audit found the section covered roughly half of what shipped: several subsystems that landed in 0.2.0 had no entry, and two entries described behavior the code contradicts. Diff is `CHANGELOG.md` only.

## Type of Change

- [x] Documentation update

## Related Issues

Relates to the 0.2.0 release (#161).

## Changes Made

- Renamed `## Unreleased` to `## 0.2.0 — 2026-08-07` with a short intro paragraph, matching the 0.1.0 heading format.
- **Corrected two claims the code contradicts:**
  - Breaking Changes listed `Dataset.read_many(...)` and `Dataset.get_batch(...)` as removed. Neither existed on `Dataset` in v0.1.0 and both are present today (`nvalchemi/data/datapipes/dataset.py:806`, `:825`). The entry moved to Core Data Layer and now describes `load_batches(...)` as the canonical explicit batch API.
  - The datapipes entry claimed "PhysicsNeMo-compatible atomic datapipes". PhysicsNeMo appears only under `nvalchemi/distributed/`; the data layer builds on torch `Sampler` protocols. Rewritten to describe `MultiDataset` and its samplers.
- **Added subsystems that shipped in 0.2.0 with no entry** (all confirmed absent from `v0.1.0` via `git grep`):
  - `nvalchemi.training` — `TrainingStrategy`, `FineTuningStrategy`, the loss library, training hooks, restartable checkpoints, and the `nvalchemi-training` CLI.
  - `nvalchemi.hooks.reporting` — `ReportingOrchestrator`, `RichReporter`, `TensorBoardReporter`, layouts, scalar extraction.
  - `StageTimingHook`, `TorchProfilerHook`, the `CheckpointableHook` protocol.
  - Slab correction on `EwaldModelWrapper` / `PMEModelWrapper`; trainable `MACEWrapper` and `PipelineModelWrapper`.
  - `MultiDataset`, `MultiDatasetSampler`, `MultiDatasetBatchSampler`, `Dataset.load_batches(...)`.
  - `nvalchemi/distributed.py` becoming a package.
- **Added fixes** #88, #96, #111, #113, #114, #116.
- **Added a Requirements block** matching `pyproject.toml`: torch >= 2.8, `nvalchemi-toolkit-ops` >= 0.4.1, `nvidia-physicsnemo` >= 2.0.0, and the full extras list including `cu12` / `cu13` / `tensorboard` / `uma`.
- Grouped entries into topical sections matching the 0.1.0 layout.

## Testing

- [x] Linting passes — `markdownlint-cli` v0.35.0 with `--disable=MD024` (the pre-commit config) exits 0 on `CHANGELOG.md`; no trailing whitespace, file ends with a newline.
- [x] Every public name cited in the new section was import-checked against the 0.2.0 tree, not just grepped. All resolve.
- [x] Every CLI invocation in the `nvalchemi-training` bullet was run (`--help` on the root group and each subgroup) and the bullet matches what the CLI prints. This caught `finetune init`, which is a group requiring a further `mace` / `aimnet2` / `checkpoint` / `custom` subcommand rather than a leaf command.
- [x] Defaults and literals verified in source: `max_cutoff_ratio=1.5`, `neighbor_adaptation` values, `hybrid_forces=False`, `slab_correction=False`, `transforms=`/`batch_transforms=` default `None`, UMA model ids, `examples/advanced/09_uma_nve.py`.
- [x] Removals confirmed gone: `EvaluateHook`, `EvaluationSink`, `EvaluationZarrSink` have no hits under `nvalchemi/`.
- [x] The `cells_inv` deprecation confirmed still functional: the argument is accepted and emits `DeprecationWarning` (`nvalchemi/dynamics/integrators/npt.py:101`).
- No unit tests apply; no source changes.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes — n/a, docs only
- [x] I have updated the documentation (if applicable)

## Additional Notes

Two conventions worth flagging for review:

- `## Unreleased` is removed rather than left as an empty section, matching what happened after the 0.1.0 release. The next feature PR reintroduces it.
- New bullets follow the file's existing `**Bold** — text` format so the section reads uniformly.

One correction was caught mid-audit and is worth mentioning because it argues for grepping symbols rather than trusting file lists: `git log --diff-filter=A` reports `nvalchemi/dynamics/hooks/cell_align.py` as newly added, but `AlignCellHook` exists at that exact path in `v0.1.0`. Every symbol named in the new sections was subsequently checked with `git grep <symbol> v0.1.0` rather than inferred from the file list.

The 0.1.0 section is untouched. Its Requirements block lists `PyTorch >= 2.8` while `v0.1.0`'s `pyproject.toml` pinned `torch>=2.5.1` — a pre-existing discrepancy in shipped release notes, left alone as out of scope here.
