### PR TITLE
ci: run multi-GPU tests on the 2-GPU H100 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@
 # 1. changed-files: Detects which files have changed compared to main branch
 # 2. lint: Runs static code checks and linting via pre-commit
 # 3. get-pr-labels: Retrieves PR labels for conditional job execution
-# 4. test: Runs pytest unit tests with coverage (on GPU runner). UMA, whose
+# 4. test: Runs pytest unit tests with coverage (on 1-GPU runner). UMA, whose
 #    deps conflict with the cu13/mace stack, is tested from a separate
 #    .venv-uma environment (gated on UMA changes or full runs).
-# 5. verify-status: Verifies all jobs completed successfully
+# 5. test-multigpu: Runs the `@pytest.mark.multigpu` tests on a 2-GPU runner.
+#    They auto-skip in job 4, so this is the only tier that executes them.
+#    Gated on DD-relevant changes, full runs, or the `ciflow:multigpu` label.
+# 6. verify-status: Verifies all jobs completed successfully
 
 name: "CI"
 
@@ -67,6 +70,7 @@ jobs:
     outputs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
       uma_changed: ${{ steps.uma-changed.outputs.any_changed }}
+      dd_changed: ${{ steps.dd-changed.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,10 +108,27 @@ jobs:
             test/models/test_uma.py
             examples/advanced/09_uma_nve.py
 
+      # The 2-GPU runner is scarcer and its tests slower, so gate that job on
+      # the paths those tests cover rather than on any change.
+      - uses: step-security/changed-files@95b56dadb92a30ca9036f16423fd3c088a71ee94 # v46
+        id: dd-changed
+        with:
+          base_sha: ${{ steps.merge-base.outputs.merge-base }}
+          files: |
+            nvalchemi/distributed/**
+            nvalchemi/models/**
+            nvalchemi/dynamics/**
+            test/distributed/**
+            test/dynamics/test_distributed_correctness.py
+            test/conftest.py
+            test/test_multigpu_marker.py
+            .github/workflows/ci.yml
+
       - name: Show output
         run: |
           echo '${{ toJSON(steps.changed-files.outputs) }}'
           echo 'uma_changed=${{ steps.uma-changed.outputs.any_changed }}'
+          echo 'dd_changed=${{ steps.dd-changed.outputs.any_changed }}'
 
   # ============================================================================
   # LINTING STAGE
@@ -433,6 +454,113 @@ jobs:
           retention-days: 7
 
   # ============================================================================
+  # MULTI-GPU TEST STAGE (2-GPU Runner)
+  # ============================================================================
+  # No testmon: selection is the marker, and a second writer would corrupt the
+  # cached db the 1-GPU job maintains. No coverage: appending from a separate
+  # job would desync the baseline/PR combine above.
+  test-multigpu:
+    needs:
+      - lint
+      - get-pr-labels
+      - changed-files
+    runs-on: nv-gpu-amd64-h100-2gpu
+    # DD equivalence + compile recompile gates dominate; UMA adds a second
+    # torch install and a possible checkpoint download.
+    timeout-minutes: 90
+    container:
+      image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
+      # NCCL and mp.spawn need more than the 64 MB default /dev/shm.
+      options: --gpus all --shm-size=8g
+    env:
+      IS_FULL_RUN: ${{ github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'merge_group' }}
+      NCCL_DEBUG: WARN
+    if: |
+      (github.event_name == 'schedule') ||
+      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') ||
+      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:multigpu') ||
+      (
+        !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
+        (needs.changed-files.outputs.dd_changed == 'true')
+      ) ||
+      (
+        (github.event_name == 'merge_group') &&
+        (needs.changed-files.outputs.any_changed == 'true')
+      ) ||
+      (github.ref == 'refs/heads/main')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install apt requirements
+        env:
+          DEBIAN_FRONTEND: "noninteractive"
+          TZ: "Etc/UTC"
+        run: |
+          apt-get update && \
+          apt-get install -y curl \
+            git \
+            build-essential
+
+      - name: Setup UV
+        env:
+          UV_VERSION: "0.9.25"
+          UV_CHECKSUM: "10fb1f54d56f3eb60622006797339d4ea0bfda9b358d07db635f73cf89f7094c"
+        run: |
+          UV_INSTALLER=$(mktemp)
+          curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
+          echo "${UV_CHECKSUM}  ${UV_INSTALLER}" | sha256sum -c -
+          sh "$UV_INSTALLER"
+          rm "$UV_INSTALLER"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv sync ${CI_UV_EXTRAS}
+
+      # Without this, a runner short a device would skip every test and
+      # report green.
+      - name: Verify 2 GPUs are visible
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          nvidia-smi
+          uv run ${CI_UV_EXTRAS} python -c "
+          import sys, torch
+          n = torch.cuda.device_count()
+          print(f'visible CUDA devices: {n}')
+          if n < 2:
+              sys.exit(f'expected >=2 GPUs on this runner, found {n}')
+          "
+
+      - name: Run multi-GPU tests
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv run ${CI_UV_EXTRAS} pytest -m multigpu test/
+
+      # ========================================================================
+      # UMA MULTI-GPU TESTS (isolated environment)
+      # ========================================================================
+      # Same split as the 1-GPU job; without HF access these skip cleanly.
+
+      - name: Install UMA environment (.venv-uma)
+        if: needs.changed-files.outputs.uma_changed == 'true' || env.IS_FULL_RUN == 'true'
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          UV_PROJECT_ENVIRONMENT=.venv-uma uv sync --extra uma --extra ase
+
+      - name: Run UMA multi-GPU tests (.venv-uma)
+        if: needs.changed-files.outputs.uma_changed == 'true' || env.IS_FULL_RUN == 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          UV_PROJECT_ENVIRONMENT=.venv-uma uv run --extra uma --extra ase \
+            pytest -m multigpu \
+            test/distributed/model/test_uma_multigpu.py \
+            test/distributed/model/test_uma_gp_partition_multigpu.py
+
+  # ============================================================================
   # VERIFY STATUS
   # ============================================================================
   verify-status:
@@ -440,6 +568,7 @@ jobs:
       - lint
       - get-pr-labels
       - test
+      - test-multigpu
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@
 #    .venv-uma environment (gated on UMA changes or full runs).
 # 5. test-multigpu: Runs the `@pytest.mark.multigpu` tests on a 2-GPU runner.
 #    They auto-skip in job 4, so this is the only tier that executes them.
-#    Gated on DD-relevant changes, full runs, or the `ciflow:multigpu` label.
+#    Gated on DD-relevant changes, the nightly run, or the `ci:multigpu` label.
 # 6. verify-status: Verifies all jobs completed successfully
 
 name: "CI"
@@ -478,16 +478,15 @@ jobs:
     if: |
       (github.event_name == 'schedule') ||
       contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') ||
-      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:multigpu') ||
+      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ci:multigpu') ||
       (
         !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
         (needs.changed-files.outputs.dd_changed == 'true')
       ) ||
       (
         (github.event_name == 'merge_group') &&
-        (needs.changed-files.outputs.any_changed == 'true')
-      ) ||
-      (github.ref == 'refs/heads/main')
+        (needs.changed-files.outputs.dd_changed == 'true')
+      )
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,10 @@ jobs:
       - lint
       - get-pr-labels
       - changed-files
-    runs-on: nv-gpu-amd64-h100-2gpu
+    # Overridable via a repo variable so a runner-fleet rename is a settings
+    # edit, not a code change; an unknown label queues silently until GitHub
+    # times it out ~24h later, with no runner ever assigned.
+    runs-on: ${{ vars.MULTIGPU_RUNNER || 'linux-amd64-gpu-h100-latest-2' }}
     # DD equivalence + compile recompile gates dominate; UMA adds a second
     # torch install and a possible checkpoint download.
     timeout-minutes: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,12 @@ be skippable with the `NVALCHEMI_SPHINX_BUILD` flag (see `docs/conf.py`)
 - CUDA-dependent tests guard with `torch.cuda.is_available()` (see
   `test/conftest.py`) and skip cleanly on CPU-only machines; the rest of the
   suite runs on CPU.
+- Tests needing 2 GPUs (NCCL, rank `r` on `cuda:r`, usually via
+  `test/distributed/_dd_harness.py`) use `@pytest.mark.multigpu`, not a
+  `device_count()` `skipif` — the 2-GPU CI job selects on the marker, and
+  `test/test_multigpu_marker.py` fails the build if one is missing. Gloo/CPU
+  multi-rank tests are not `multigpu`; a scenario needing more than 2 ranks
+  belongs there. `NVALCHEMI_FORCE_MULTIGPU=1` bypasses the skip.
 - Add or update regression tests for behavior changes, especially model adapters,
   dynamics hooks, data serialization, training specs, and optional-dependency
   paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,12 +168,8 @@ be skippable with the `NVALCHEMI_SPHINX_BUILD` flag (see `docs/conf.py`)
 - CUDA-dependent tests guard with `torch.cuda.is_available()` (see
   `test/conftest.py`) and skip cleanly on CPU-only machines; the rest of the
   suite runs on CPU.
-- Tests needing 2 GPUs (NCCL, rank `r` on `cuda:r`, usually via
-  `test/distributed/_dd_harness.py`) use `@pytest.mark.multigpu`, not a
-  `device_count()` `skipif` — the 2-GPU CI job selects on the marker, and
-  `test/test_multigpu_marker.py` fails the build if one is missing. Gloo/CPU
-  multi-rank tests are not `multigpu`; a scenario needing more than 2 ranks
-  belongs there. `NVALCHEMI_FORCE_MULTIGPU=1` bypasses the skip.
+- Tests needing 2 GPUs must be marked with `@pytest.mark.multigpu`; the 2-GPU
+  CI job selects on it. Gloo/CPU multi-rank tests are not `multigpu`.
 - Add or update regression tests for behavior changes, especially model adapters,
   dynamics hooks, data serialization, training specs, and optional-dependency
   paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@
   (including `"turbo"` for `torch.compile`). See the
   `examples/advanced/09_uma_nve.py` NVE/NVT/NPT walkthrough.
 
+- Multi-GPU CI coverage. Tests requiring 2 GPUs now carry
+  `@pytest.mark.multigpu` instead of a hand-rolled `device_count()` skip, and a
+  new 2-GPU CI job runs them. The domain-decomposition suite previously skipped
+  on every CI tier and was only exercised by hand.
+
 ### Fixed
 
 - **Ewald charge gradients and cell derivatives** — the reciprocal term was only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,11 +91,6 @@
   (including `"turbo"` for `torch.compile`). See the
   `examples/advanced/09_uma_nve.py` NVE/NVT/NPT walkthrough.
 
-- Multi-GPU CI coverage. Tests requiring 2 GPUs now carry
-  `@pytest.mark.multigpu` instead of a hand-rolled `device_count()` skip, and a
-  new 2-GPU CI job runs them. The domain-decomposition suite previously skipped
-  on every CI tier and was only exercised by hand.
-
 ### Fixed
 
 - **Ewald charge gradients and cell derivatives** — the reciprocal term was only

--- a/test/distributed/_core/test_compile_halo_scatter.py
+++ b/test/distributed/_core/test_compile_halo_scatter.py
@@ -339,10 +339,7 @@ def _worker_pass_halo_refresh(rank: int, world_size: int) -> None:
         dist.destroy_process_group()
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Need 2+ CUDA GPUs (static halo op uses NCCL funcol)",
-)
+@pytest.mark.multigpu
 def test_compile_pass_halo_refresh_2ranks() -> None:
     """The compile-refresh pass auto-inserts the real halo correction on a
     no-subclass plain scatter and reproduces the eager dispatch-corrected result
@@ -488,10 +485,7 @@ def _worker_pass_two_layer_mpnn(rank: int, world_size: int) -> None:
         dist.destroy_process_group()
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Need 2+ CUDA GPUs (static halo op uses NCCL funcol)",
-)
+@pytest.mark.multigpu
 def test_compile_pass_two_layer_mpnn_owned_equivalence_2ranks() -> None:
     """A real 2-layer pure-PyTorch MPNN with NO author DD code, compiled under DD
     (``fullgraph=False``) — the compile-refresh pass auto-places the halo refresh
@@ -580,10 +574,7 @@ def _worker_bridge_two_layer(rank: int, world_size: int) -> None:
         dist.destroy_process_group()
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Need 2+ CUDA GPUs (static halo op uses NCCL funcol)",
-)
+@pytest.mark.multigpu
 def test_halo_compile_bridge_two_layer_owned_equivalence_2ranks() -> None:
     """The framework-owned ``HaloCompileBridge`` reproduces the inline pass
     result — a 2-layer MPNN's OWNED outputs match the eager-corrected reference
@@ -690,10 +681,7 @@ def _worker_holder_self_refresh_two_layer(rank: int, world_size: int) -> None:
         dist.destroy_process_group()
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Need 2+ CUDA GPUs (static halo op uses NCCL funcol)",
-)
+@pytest.mark.multigpu
 def test_halo_compile_bridge_holder_self_refresh_2ranks() -> None:
     """The compile-routing holder threads the step's routing from the bridge's
     graph inputs to an in-region ``scatter_to_owners`` call, so a model that

--- a/test/distributed/model/test_aimnet2_compile_recompile_gate.py
+++ b/test/distributed/model/test_aimnet2_compile_recompile_gate.py
@@ -54,11 +54,6 @@ WARMUP_STEPS = 8
 STEADY_STEPS = 8
 JITTER = 0.06  # Å per-step RMS displacement (within cutoff+skin headroom)
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _methane_packing(n_per_side: int = 4, spacing: float = 4.4, dtype=torch.float32):
     """n_per_side**3 methane molecules (5 atoms each) on a cubic PBC lattice."""
@@ -188,7 +183,7 @@ def _aimnet2_recompile_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_aimnet2_compile_dd_equivalence_and_zero_recompiles_2ranks():
     """AIMNet2 halo + compile under DD: owned forces match a single-GPU
     reference, and a jittered MD loop produces zero steady-state recompiles.

--- a/test/distributed/model/test_compile_recompile_gate.py
+++ b/test/distributed/model/test_compile_recompile_gate.py
@@ -62,11 +62,6 @@ WARMUP_STEPS = 8
 STEADY_STEPS = 8
 JITTER = 0.08  # Å per-step RMS displacement (well within cutoff+skin headroom)
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _build_pbc_argon(n_per_side: int = 4, dtype: torch.dtype = torch.float64):
     spacing = 2 ** (1.0 / 6.0) * 3.40 * 1.05  # ~4.007 Å
@@ -165,7 +160,7 @@ def _recompile_gate_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_compile_dd_zero_steady_state_recompiles_2ranks():
     """A compiled DD MACE forward run as a jittered MD loop must compile
     its graph during warmup and then hold it: zero new unique graphs across

--- a/test/distributed/model/test_dftd3_multigpu.py
+++ b/test/distributed/model/test_dftd3_multigpu.py
@@ -56,10 +56,6 @@ from nvalchemi.distributed.config import DomainConfig
 
 WORLD_SIZE = 2
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
 
 # D3(BJ) parameters for PBE (Grimme 2010); a2 in Bohr.
 _A1, _A2, _S8 = 0.4289, 4.4407, 0.7875
@@ -228,7 +224,7 @@ def _dftd3_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_dftd3_dist_model_equivalence_2ranks():
     """``DistributedModel(DFTD3ModelWrapper)`` under halo matches single-GPU."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")

--- a/test/distributed/model/test_distributed_models.py
+++ b/test/distributed/model/test_distributed_models.py
@@ -743,24 +743,20 @@ cuda_model_tier = pytest.mark.skipif(
 )
 
 
+# ======================================================================
+# MACE — multi-step NVE via DomainParallel
+#
 # Real-multi-GPU tier: the full DomainParallel NVE dynamics path (gather +
 # per-step halo migration) needs raw cuda-tensor send/recv, which gloo's TCP
 # transport rejects ("Bad address"). It therefore runs on genuine NCCL across
 # >=2 physical GPUs (rank r -> cuda:r) rather than the N-ranks-share-one-GPU
-# gloo tier. Skipped on <2 GPUs.
-cuda_multigpu_tier = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="full distributed NVE dynamics run on real NCCL across >=2 GPUs",
-)
-
-
-# ======================================================================
-# MACE — multi-step NVE via DomainParallel
+# gloo tier above — hence ``multigpu``, not ``cuda_model_tier``.
+#
 # Shares the parameterized ``_nve_via_domain_parallel_worker`` above.
 # ======================================================================
 
 
-@cuda_multigpu_tier
+@pytest.mark.multigpu
 @pytest.mark.parametrize(
     "system_name,world_size,n_steps,dt_fs,energy_tol", _MACE_NVE_CASES
 )

--- a/test/distributed/model/test_distributed_pipeline_multigpu.py
+++ b/test/distributed/model/test_distributed_pipeline_multigpu.py
@@ -48,11 +48,6 @@ from nvalchemi.distributed.config import DomainConfig
 WORLD_SIZE = 2
 _A1, _A2, _S8 = 0.4289, 4.4407, 0.7875
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 # ====================================================================
 # C1 — DFT-D3 + Ewald (direct-force composition)
@@ -213,7 +208,7 @@ def _de_pipeline_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_distributed_pipeline_dftd3_ewald_2ranks():
     """``DistributedPipelineModel(DFTD3 + Ewald)`` == summed single-models."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -398,7 +393,7 @@ def _md_autograd_pipeline_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_distributed_pipeline_mace_dftd3_2ranks():
     """``DistributedPipelineModel(MACE[use_autograd] + DFTD3)`` == single-GPU pipeline."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -595,7 +590,7 @@ def _ap_wired_pipeline_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_distributed_pipeline_aimnet2_pme_2ranks():
     """``DistributedPipelineModel(AIMNet2 charges -> PME)`` == single-GPU pipeline."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -670,7 +665,7 @@ def _ap_force_path_worker(rank: int, world_size: int, consumer: str) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 @pytest.mark.parametrize("consumer", ["pme", "ewald"])
 def test_distributed_pipeline_wired_force_paths_agree_2ranks(consumer):
     """Wired-group forces are identical with and without stress requested.
@@ -873,7 +868,7 @@ def _mdc_compile_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_distributed_pipeline_compile_mace_dftd3_2ranks():
     """Compiled ``DistributedPipelineModel(MACE + DFTD3)`` == single-GPU; no steady recompiles."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")

--- a/test/distributed/model/test_electrostatics_stress_multigpu.py
+++ b/test/distributed/model/test_electrostatics_stress_multigpu.py
@@ -38,11 +38,6 @@ WORLD_SIZE = 2
 N_SIDE = 10
 BOX = 28.0
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _build_wrapper(kind: str, cutoff: float):
     """Wrapper of the requested flavour on the supported (non-analytic) path."""
@@ -149,7 +144,7 @@ def _stress_equivalence_worker(rank: int, world_size: int, kind: str) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 @pytest.mark.parametrize("kind", ["ewald", "pme"])
 def test_stress_equivalence_2ranks(kind):
     """Halo-DD stress matches single-GPU for Ewald and PME."""

--- a/test/distributed/model/test_ewald_multigpu.py
+++ b/test/distributed/model/test_ewald_multigpu.py
@@ -52,11 +52,6 @@ STEADY_STEPS = 4
 JITTER = 0.05
 _EWALD_CUT = 6.0
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _ewald_equivalence_worker(rank: int, world_size: int) -> None:
     """Single-GPU Ewald reference on rank 0 → broadcast → each rank
@@ -235,7 +230,7 @@ def _ewald_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_ewald_dist_model_equivalence_2ranks():
     """Regression: ``DistributedModel(EwaldModelWrapper)`` under halo
     matches single-GPU Ewald on total energy and per-atom forces.
@@ -394,7 +389,7 @@ def _compile_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_ewald_compile_dd_2ranks():
     """Compiled ``DistributedModel(Ewald, hybrid_forces=False)`` == single-GPU; no steady recompiles."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -544,7 +539,7 @@ def _ewald_gp_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_ewald_gp_dist_model_equivalence_2ranks():
     """``DistributedModel(EwaldModelWrapper, GRAPH_PARTITION)`` matches single-GPU
     Ewald on total energy and per-atom forces (correctness-first GP path)."""

--- a/test/distributed/model/test_mace_cueq_compile_gate.py
+++ b/test/distributed/model/test_mace_cueq_compile_gate.py
@@ -61,11 +61,6 @@ from nvalchemi.distributed.config import DomainConfig
 
 WORLD_SIZE = 2
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 # ======================================================================
 # Process-group / test-harness setup
@@ -284,7 +279,7 @@ def _mace_cueq_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_mace_cueq_COMPILE_dist_model_equivalence_2ranks():
     """Regression: compiled ``DistributedModel(MACEWrapper(enable_cueq=True),
     compile=True)`` matches a single-GPU cueq reference on force + total energy

--- a/test/distributed/model/test_mace_cueq_multigpu.py
+++ b/test/distributed/model/test_mace_cueq_multigpu.py
@@ -66,11 +66,6 @@ from nvalchemi.distributed.config import DomainConfig
 
 WORLD_SIZE = 2
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 # ======================================================================
 # Process-group / test-harness setup
@@ -289,7 +284,7 @@ def _mace_cueq_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_mace_cueq_dist_model_equivalence_2ranks():
     """Regression: ``DistributedModel(MACEWrapper(enable_cueq=True))`` matches a
     single-GPU cueq reference on force + total energy on a **non-degenerate**

--- a/test/distributed/model/test_mace_nocueq_compile_gate.py
+++ b/test/distributed/model/test_mace_nocueq_compile_gate.py
@@ -69,11 +69,6 @@ WARMUP_STEPS = 8
 STEADY_STEPS = 8
 JITTER = 0.06  # Å per-step RMS displacement (within cutoff+skin headroom)
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _build_pbc_argon(nx: int = 12, nyz: int = 3, dtype: torch.dtype = torch.float64):
     """Argon on an ELONGATED cell — long along x (the axis the 2-rank domain
@@ -239,7 +234,7 @@ def _nocueq_gate_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_mace_nocueq_compile_dd_equivalence_and_zero_recompiles_2ranks():
     """Non-cueq MACE halo + compile under DD: owned forces match an eager-DD
     reference (guarding the closure-cell interaction hook that survives the

--- a/test/distributed/model/test_multigpu.py
+++ b/test/distributed/model/test_multigpu.py
@@ -43,11 +43,6 @@ from nvalchemi.models.lj import LennardJonesModelWrapper
 
 WORLD_SIZE = 2
 
-_skip_no_multi_gpu = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ GPUs for distributed tests",
-)
-
 
 # ======================================================================
 # Helpers
@@ -155,7 +150,7 @@ def _test_sharded_batch_roundtrip(rank: int, world_size: int) -> None:
         assert full is None
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_sharded_batch_roundtrip():
     mp.spawn(
         _worker, args=(WORLD_SIZE, _test_sharded_batch_roundtrip), nprocs=WORLD_SIZE
@@ -202,7 +197,7 @@ def _test_reshard(rank: int, world_size: int) -> None:
     assert total.item() == 20  # 10 per rank * 2 ranks
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_reshard():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_reshard), nprocs=WORLD_SIZE)
 
@@ -232,7 +227,7 @@ def _test_dd_step_completes(rank: int, world_size: int) -> None:
     assert local_batch.num_nodes > 0
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_dd_step_completes():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_dd_step_completes), nprocs=WORLD_SIZE)
 
@@ -265,7 +260,7 @@ def _test_atom_conservation(rank: int, world_size: int) -> None:
     )
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_atom_conservation():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_atom_conservation), nprocs=WORLD_SIZE)
 
@@ -300,7 +295,7 @@ def _test_gather(rank: int, world_size: int) -> None:
         assert full.cell is not None
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_gather():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_gather), nprocs=WORLD_SIZE)
 
@@ -339,7 +334,7 @@ def _test_migration_moves_atoms(rank: int, world_size: int) -> None:
     assert final_count.item() == initial_total.item()
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_migration_moves_atoms():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_migration_moves_atoms), nprocs=WORLD_SIZE)
 
@@ -370,6 +365,6 @@ def _test_prime_forces(rank: int, world_size: int) -> None:
     assert local_batch.forces.abs().max() > 0
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_prime_forces():
     mp.spawn(_worker, args=(WORLD_SIZE, _test_prime_forces), nprocs=WORLD_SIZE)

--- a/test/distributed/model/test_pme_multigpu.py
+++ b/test/distributed/model/test_pme_multigpu.py
@@ -52,11 +52,6 @@ STEADY_STEPS = 4
 JITTER = 0.05
 _PME_CUT = 6.0
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _pme_equivalence_worker(rank: int, world_size: int) -> None:
     """Single-GPU PME reference on rank 0 → broadcast → each rank
@@ -231,7 +226,7 @@ def _pme_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_pme_dist_model_equivalence_2ranks():
     """Regression: ``DistributedModel(PMEModelWrapper)`` under halo
     matches single-GPU PME on total energy and per-atom forces.
@@ -401,7 +396,7 @@ def _compile_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_pme_compile_dd_2ranks():
     """Compiled ``DistributedModel(PME, hybrid_forces=False)`` == single-GPU; no steady recompiles."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -548,7 +543,7 @@ def _pme_gp_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_pme_gp_dist_model_equivalence_2ranks():
     """``DistributedModel(PMEModelWrapper, GRAPH_PARTITION)`` matches single-GPU
     PME on total energy and per-atom forces (correctness-first GP path)."""

--- a/test/distributed/model/test_shared_partition_multigpu.py
+++ b/test/distributed/model/test_shared_partition_multigpu.py
@@ -47,11 +47,6 @@ WORLD_SIZE = 2
 _A1, _A2, _S8 = 0.4289, 4.4407, 0.7875
 _CN_SKIN = 4.0  # CN-depth halo margin (DFTD3 ghost CN completeness)
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 def _build_lattice(dtype: torch.dtype = torch.float32, seed: int = 0):
     # Non-degenerate: max cutoff 5 Å + CN-skin 4 Å -> ghost 9 Å, so a 2-rank
@@ -207,7 +202,7 @@ def _shared_partition_worker(rank: int, world_size: int) -> None:
         )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_shared_partition_per_model_halo_2ranks():
     """One owned partition drives two different-cutoff models, each exact."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")

--- a/test/distributed/model/test_slab_multigpu.py
+++ b/test/distributed/model/test_slab_multigpu.py
@@ -45,10 +45,6 @@ from nvalchemi.distributed.config import DomainConfig
 
 WORLD_SIZE = 2
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
 
 _CUTOFF = 8.0
 _SKIN = 2.0
@@ -223,7 +219,7 @@ def _slab_equivalence_worker(rank: int, world_size: int, method: str) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_pme_slab_dist_model_equivalence_2ranks():
     """DistributedModel(PMEModelWrapper, slab_correction=True) matches 1-GPU."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")
@@ -234,7 +230,7 @@ def test_pme_slab_dist_model_equivalence_2ranks():
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_ewald_slab_dist_model_equivalence_2ranks():
     """DistributedModel(EwaldModelWrapper, slab_correction=True) matches 1-GPU."""
     pytest.importorskip("nvalchemiops", reason="nvalchemiops not installed")

--- a/test/distributed/model/test_uma_gp_partition_multigpu.py
+++ b/test/distributed/model/test_uma_gp_partition_multigpu.py
@@ -190,10 +190,7 @@ def _worker(rank: int, world_size: int) -> None:
         dist.destroy_process_group()
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Need 2+ CUDA GPUs",
-)
+@pytest.mark.multigpu
 def test_uma_gp_partition_2ranks() -> None:
     pytest.importorskip("fairchem.core", reason="fairchem-core not installed")
 

--- a/test/distributed/model/test_uma_multigpu.py
+++ b/test/distributed/model/test_uma_multigpu.py
@@ -64,11 +64,6 @@ _INFERENCE = os.environ.get("NVALCHEMI_UMA_INFERENCE", "default")
 # cache but not always for a cold one. Bumping to 30min is cheap insurance.
 _PG_TIMEOUT = datetime.timedelta(minutes=30)
 
-_skip = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ CUDA GPUs",
-)
-
 
 # ======================================================================
 # Harness
@@ -308,7 +303,7 @@ def _uma_equivalence_worker(rank: int, world_size: int) -> None:
     )
 
 
-@_skip
+@pytest.mark.multigpu
 def test_uma_dist_model_equivalence_2ranks():
     """Regression: ``DistributedModel(UMAWrapper)`` matches a single-GPU
     UMA reference on force + total energy under halo storage.

--- a/test/distributed/test_deferred_migration_halo.py
+++ b/test/distributed/test_deferred_migration_halo.py
@@ -110,14 +110,18 @@ def _crossed_atom_reaches_receiver_before_migration(
 def _crossed_atom_force_matches_same_geometry_reference(
     rank: int,
     world_size: int,
-    _queue: Any,
+    _queue: Any = None,
+    device_type: str = "cpu",
 ) -> None:
     """Compare forces at the crossed geometry, without evolving trajectories."""
     assert world_size == 2
     dtype = torch.float64
-    cell = torch.eye(3, dtype=dtype) * 20.0
-    pbc = torch.ones(3, dtype=torch.bool)
-    mesh = DeviceMesh("cpu", list(range(world_size)), mesh_dim_names=("domain",))
+    device = (
+        torch.device(f"cuda:{rank}") if device_type == "cuda" else torch.device("cpu")
+    )
+    cell = torch.eye(3, dtype=dtype, device=device) * 20.0
+    pbc = torch.ones(3, dtype=torch.bool, device=device)
+    mesh = DeviceMesh(device_type, list(range(world_size)), mesh_dim_names=("domain",))
     domain_config = DomainConfig(cutoff=2.0, skin=0.5, mesh=mesh)
     partitioner = SpatialPartitioner(
         config=domain_config,
@@ -129,7 +133,7 @@ def _crossed_atom_force_matches_same_geometry_reference(
     assert len(split_dims) == 1
     split_dim = split_dims[0]
 
-    previous_frac = torch.full((1, 3), 0.5, dtype=dtype)
+    previous_frac = torch.full((1, 3), 0.5, dtype=dtype, device=device)
     previous_frac[0, split_dim] = 0.495
     previous_position = previous_frac @ cell
     crossed_frac = previous_frac.clone()
@@ -165,15 +169,15 @@ def _crossed_atom_force_matches_same_geometry_reference(
     )
     assert torch.equal(
         partitioner.assign_atoms_to_ranks(positions_before_crossing),
-        torch.tensor([0, 0, 1, 1]),
+        torch.tensor([0, 0, 1, 1], device=device),
     )
 
     def _batch(positions: torch.Tensor) -> Batch:
         n_atoms = positions.shape[0]
         data = AtomicData(
             positions=positions.clone(),
-            atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long),
-            atomic_masses=torch.full((n_atoms,), 39.948, dtype=dtype),
+            atomic_numbers=torch.full((n_atoms,), 18, dtype=torch.long, device=device),
+            atomic_masses=torch.full((n_atoms,), 39.948, dtype=dtype, device=device),
             cell=cell.unsqueeze(0),
             pbc=pbc.unsqueeze(0),
         )
@@ -201,13 +205,13 @@ def _crossed_atom_force_matches_same_geometry_reference(
 
     # The reference is a fresh single-process forward at exactly the positions
     # used by the distributed compute. It is not a separately evolved trajectory.
-    reference_forces = torch.zeros(4, 3, dtype=dtype)
+    reference_forces = torch.zeros(4, 3, dtype=dtype, device=device)
     if rank == 0:
         reference_model = LennardJonesModelWrapper(
             epsilon=1.0,
             sigma=1.0,
             cutoff=2.0,
-        )
+        ).to(device)
         reference_batch = _batch(positions_at_compute)
         compute_neighbors(
             reference_batch,
@@ -221,7 +225,7 @@ def _crossed_atom_force_matches_same_geometry_reference(
         epsilon=1.0,
         sigma=1.0,
         cutoff=2.0,
-    )
+    ).to(device)
     with DistributedModel(distributed_model, domain_config) as model:
         distributed_forces = model(sharded)["forces"]
 
@@ -402,22 +406,18 @@ def test_unwrapped_periodic_migrant_force_matches_same_geometry_reference() -> N
 
 
 @pytest.mark.multigpu
-@pytest.mark.skipif(
-    torch.cuda.device_count() < 4,
-    reason="requires >=4 CUDA GPUs",
-)
-def test_unwrapped_periodic_migrant_force_matches_reference_nccl(
+def test_crossed_atom_force_matches_same_geometry_reference_nccl(
     unused_tcp_port: int,
 ) -> None:
-    """The periodic-migrant force regression also fails over a real NCCL halo."""
+    """The same force check over a real NCCL halo instead of gloo."""
     mp.spawn(
         nccl_worker,
         args=(
-            4,
+            2,
             str(unused_tcp_port),
-            _unwrapped_periodic_migrant_force_matches_reference,
+            _crossed_atom_force_matches_same_geometry_reference,
             None,
             "cuda",
         ),
-        nprocs=4,
+        nprocs=2,
     )

--- a/test/dynamics/test_distributed_correctness.py
+++ b/test/dynamics/test_distributed_correctness.py
@@ -53,11 +53,6 @@ NEIGHBOR_SKIN = 0.0
 # Helpers
 # ---------------------------------------------------------------------------
 
-_skip_no_multi_gpu = pytest.mark.skipif(
-    torch.cuda.device_count() < WORLD_SIZE,
-    reason=f"Need {WORLD_SIZE}+ GPUs for distributed tests",
-)
-
 
 def _init_process_group(rank: int, world_size: int) -> None:
     """Initialise NCCL process group for a spawned worker."""
@@ -200,7 +195,7 @@ def _test_single_step_force_correctness(rank: int, world_size: int) -> None:
         )
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_single_step_force_correctness():
     """Per-atom forces must match between 1-GPU reference and 2-GPU DomainParallel."""
     mp.spawn(
@@ -237,7 +232,7 @@ def _test_nve_final_energy_correctness(rank: int, world_size: int) -> None:
         )
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_nve_final_energy_correctness():
     """Final potential energy must match after 100 distributed NVE steps."""
     mp.spawn(
@@ -279,7 +274,7 @@ def _test_atom_count_conservation(rank: int, world_size: int) -> None:
         )
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_atom_count_conservation():
     """Total atoms across all ranks must equal the initial system size."""
     mp.spawn(
@@ -312,7 +307,7 @@ def _test_partition_distributes_atoms(rank: int, world_size: int) -> None:
     assert local_batch.pbc is not None
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_partition_distributes_atoms():
     """After partition(), each rank has atoms and totals match initial count."""
     mp.spawn(
@@ -353,7 +348,7 @@ def _test_step_completes(rank: int, world_size: int) -> None:
     assert torch.isfinite(local_batch.energy).all()
 
 
-@_skip_no_multi_gpu
+@pytest.mark.multigpu
 def test_step_completes():
     """dd.step() must complete 5 steps without crashing."""
     mp.spawn(

--- a/test/test_multigpu_marker.py
+++ b/test/test_multigpu_marker.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static check that multi-GPU tests carry ``@pytest.mark.multigpu``.
+
+An unmarked one runs nowhere: the 1-GPU job skips it for lack of devices and
+the 2-GPU job, which selects on the marker, never picks it up.
+
+Multi-GPU means NCCL with rank ``r`` on ``cuda:r``. Gloo/CPU multi-rank tests,
+and NCCL ranks sharing ``cuda:0``, are not multi-GPU.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+TEST_ROOT = pathlib.Path(__file__).parent
+# This module names the idioms it forbids, so it excludes itself.
+_SELF = pathlib.Path(__file__).resolve()
+
+_HARNESS_SEEDS = {"init_nccl", "nccl_worker"}
+
+
+def _is_multigpu_marker(node: ast.expr) -> bool:
+    """``True`` for a ``@pytest.mark.multigpu`` decorator."""
+    return isinstance(node, ast.Attribute) and node.attr == "multigpu"
+
+
+def _referenced_names(node: ast.AST) -> set[str]:
+    """Every bare name and attribute tail referenced anywhere under *node*."""
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            names.add(child.id)
+        elif isinstance(child, ast.Attribute):
+            names.add(child.attr)
+    return names
+
+
+def _pins_rank_to_gpu(fn: ast.FunctionDef, source: str) -> bool:
+    """``True`` if *fn* opens a NCCL group and pins a GPU.
+
+    Both halves are required — NCCL alone is satisfied by ranks sharing
+    ``cuda:0``, which needs one device.
+    """
+    segment = ast.get_source_segment(source, fn) or ""
+    return "nccl" in segment and "set_device" in segment
+
+
+def _multigpu_functions(tree: ast.Module, source: str) -> set[str]:
+    """Module-level functions that reach a rank-pinned NCCL group.
+
+    Closed transitively, so a test calling a local wrapper around
+    ``mp.spawn(nccl_worker, ...)`` is still caught.
+    """
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    multigpu = {name for name in functions if name in _HARNESS_SEEDS}
+    multigpu |= {
+        name
+        for name, node in functions.items()
+        if isinstance(node, ast.FunctionDef) and _pins_rank_to_gpu(node, source)
+    }
+    # Imported harness helpers are referenced by name, not defined here.
+    multigpu |= _HARNESS_SEEDS
+
+    # Calling a multi-GPU function makes you one.
+    changed = True
+    while changed:
+        changed = False
+        for name, node in functions.items():
+            if name not in multigpu and _referenced_names(node) & multigpu:
+                multigpu.add(name)
+                changed = True
+    return multigpu
+
+
+def _unmarked_multigpu_tests(path: pathlib.Path) -> list[str]:
+    """Test functions in *path* that drive a rank-pinned NCCL group unmarked."""
+    source = path.read_text()
+    tree = ast.parse(source)
+    multigpu = _multigpu_functions(tree, source)
+
+    offenders = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        if any(_is_multigpu_marker(d) for d in node.decorator_list):
+            continue
+        if _referenced_names(node) & multigpu:
+            offenders.append(f"{path.relative_to(TEST_ROOT)}::{node.name}")
+    return offenders
+
+
+def test_every_nccl_multigpu_test_carries_the_marker() -> None:
+    """No test spawns rank-pinned NCCL workers without the marker."""
+    offenders: list[str] = []
+    for path in sorted(TEST_ROOT.rglob("test_*.py")):
+        if path.resolve() != _SELF:
+            offenders.extend(_unmarked_multigpu_tests(path))
+
+    assert not offenders, (
+        "These tests spawn NCCL workers pinned to distinct GPUs but are not "
+        "marked, so no CI tier runs them. Add @pytest.mark.multigpu:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_hand_rolled_device_count_gates() -> None:
+    """GPU-count gating lives in the marker, not in per-file ``skipif``s.
+
+    Such a gate skips on the 1-GPU runner without making the test selectable
+    by ``-m multigpu``, so it runs nowhere.
+    """
+    offenders = [
+        str(path.relative_to(TEST_ROOT))
+        for path in sorted(TEST_ROOT.rglob("test_*.py"))
+        if path.resolve() != _SELF and "device_count()" in path.read_text()
+    ]
+    assert not offenders, (
+        "Use @pytest.mark.multigpu instead of a hand-rolled "
+        "torch.cuda.device_count() skip gate in:\n  " + "\n  ".join(offenders)
+    )

--- a/test/test_multigpu_marker.py
+++ b/test/test_multigpu_marker.py
@@ -60,6 +60,22 @@ def _pins_rank_to_gpu(fn: ast.FunctionDef, source: str) -> bool:
     return "nccl" in segment and "set_device" in segment
 
 
+def _imported_seed_aliases(tree: ast.Module) -> set[str]:
+    """Local names bound to a harness helper, following ``as`` renames.
+
+    Most of the suite imports ``from _dd_harness import nccl_worker as _worker``,
+    so matching the original name alone sees nothing and the check passes
+    vacuously.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom | ast.Import):
+            for a in node.names:
+                if a.name in _HARNESS_SEEDS:
+                    aliases.add(a.asname or a.name)
+    return aliases
+
+
 def _multigpu_functions(tree: ast.Module, source: str) -> set[str]:
     """Module-level functions that reach a rank-pinned NCCL group.
 
@@ -77,8 +93,9 @@ def _multigpu_functions(tree: ast.Module, source: str) -> set[str]:
         for name, node in functions.items()
         if isinstance(node, ast.FunctionDef) and _pins_rank_to_gpu(node, source)
     }
-    # Imported harness helpers are referenced by name, not defined here.
-    multigpu |= _HARNESS_SEEDS
+    # Imported harness helpers are referenced by name, not defined here --
+    # under whatever local name the import bound them to.
+    multigpu |= _HARNESS_SEEDS | _imported_seed_aliases(tree)
 
     # Calling a multi-GPU function makes you one.
     changed = True


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Multi-GPU tests each hand-rolled a `skipif(torch.cuda.device_count() < WORLD_SIZE)`
gate. That skips on the 1-GPU runner and is invisible to `pytest -m multigpu`, so the
domain-decomposition suite ran on **no** CI tier and was only ever exercised by hand.

Now that 2-GPU H100 runners (`nv-gpu-amd64-h100-2gpu`) are available, this replaces
those gates with `@pytest.mark.multigpu` and adds a CI job that runs exactly those tests.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

<!-- none tracked; add "Relates to #NNN" if there is an issue for the 2-GPU runners -->

## Changes Made

- Replaced hand-rolled `device_count()` skip gates with `@pytest.mark.multigpu` across
  19 files (41 applications). `test/conftest.py` is now the single place the skip is
  decided; `pytest -m multigpu` selects **43 tests
- Scoped the marker deliberately: multi-rank **gloo/CPU** tests (`_core/test_topology`,
  `test_gather_primitives`, up to 8 ranks) and NCCL ranks sharing `cuda:0`
  (`validate/test_validate_cuda.py`) are **not** mthe
  1-GPU runner.
- Added `test-multigpu` job on `nv-gpu-amd64-h100-2gpu` running `pytest -m multigpu`,
  plus a `.venv-uma` step for the UMA multi-GPU tepreflight
  so a runner short a GPU fails instead of skipping everything and reporting green.
  No testmon (a second writer would corrupt the 1-GPU job's cached db) and no coverage
  (appending from a separate job would desync the baseline/PR combine).
- Gated the job on a new `dd_changed` path filter, full runs, or a `ciflow:multigpu`
  label; wired into `verify-status`.
- Added `test/test_multigpu_marker.py`: a static `ast` check (no GPU, runs on every
  tier) that fails the build if a rank-pinned NCCL a
  `device_count()` gate reappears.
- Reworked the 4-rank NCCL deferred-migration test into a 2-rank one by parameterizing
  the existing crossed-atom worker by device, so i
  unwrapped-periodic-migrant scenario stays gloo-only — a boundary distinct from the
  global wrap needs at least three domains, so it cannot be reduced to 2 ranks.
- Updated `AGENTS.md` test conventions and `CHANGE

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGEL
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/cla
- [x] I have updated the documentation (if applicable)

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
