### PR TITLE
feat(dynamics): support compiled fused steps with CUDA graphs

### DIFF
--- a/.claude/skills/nvalchemi-dynamics-api/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-api/SKILL.md
@@ -164,19 +164,18 @@ with fused:  # lazy compilation on context entry
     result = fused.run(batch)
 ```
 
-### CUDA stream semantics: `with` vs bare `run()`
+### CUDA streams: `with` vs bare `run()`
 
-- `with dynamics: dynamics.run(batch)` creates a dedicated CUDA stream and
-  enters it jointly on the torch and warp sides — every kernel (eager,
-  compiled, warp custom ops) shares one non-default queue. Use it when
-  overlapping engines, in pipelines, and always for CUDA-graph capture
-  (`mode="reduce-overhead"`). Exit does **not** synchronize: call
-  `torch.cuda.synchronize()` (or `wait_stream`) before consuming results on
-  another stream after the block.
-- Bare `dynamics.run(batch)` uses the caller's current stream; each step
-  transiently binds warp ops to it. Correct for eager and default-compile
-  runs with no action needed. If you manage your own non-default streams,
-  you own the cross-stream ordering in this mode.
+Used as a context manager (`with dynamics: dynamics.run(batch)`), dynamics
+creates a dedicated stream shared by torch and warp. This supports
+overlapping GPU work, multi-stage pipelines, and CUDA-graph capture
+(`mode="reduce-overhead"`). Entry waits for prior work, but exit is
+asynchronous; synchronize before consuming results on another stream.
+
+Without the context manager (calling `run()` directly), dynamics uses the
+caller's current torch stream and binds warp operations to it for each
+step. This is fine for eager and default-compile runs; callers using
+custom streams are responsible for cross-stream ordering.
 
 ### How it works
 

--- a/.claude/skills/nvalchemi-dynamics-api/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-api/SKILL.md
@@ -164,6 +164,20 @@ with fused:  # lazy compilation on context entry
     result = fused.run(batch)
 ```
 
+### CUDA stream semantics: `with` vs bare `run()`
+
+- `with dynamics: dynamics.run(batch)` creates a dedicated CUDA stream and
+  enters it jointly on the torch and warp sides — every kernel (eager,
+  compiled, warp custom ops) shares one non-default queue. Use it when
+  overlapping engines, in pipelines, and always for CUDA-graph capture
+  (`mode="reduce-overhead"`). Exit does **not** synchronize: call
+  `torch.cuda.synchronize()` (or `wait_stream`) before consuming results on
+  another stream after the block.
+- Bare `dynamics.run(batch)` uses the caller's current stream; each step
+  transiently binds warp ops to it. Correct for eager and default-compile
+  runs with no action needed. If you manage your own non-default streams,
+  you own the cross-stream ordering in this mode.
+
 ### How it works
 
 1. Each sample has a `status` field (integer)

--- a/.claude/skills/nvalchemi-dynamics-api/SKILL.md
+++ b/.claude/skills/nvalchemi-dynamics-api/SKILL.md
@@ -166,16 +166,17 @@ with fused:  # lazy compilation on context entry
 
 ### CUDA streams: `with` vs bare `run()`
 
-Used as a context manager (`with dynamics: dynamics.run(batch)`), dynamics
-creates a dedicated stream shared by torch and warp. This supports
-overlapping GPU work, multi-stage pipelines, and CUDA-graph capture
-(`mode="reduce-overhead"`). Entry waits for prior work, but exit is
-asynchronous; synchronize before consuming results on another stream.
+Prefer to use context manager:
 
-Without the context manager (calling `run()` directly), dynamics uses the
-caller's current torch stream and binds warp operations to it for each
-step. This is fine for eager and default-compile runs; callers using
-custom streams are responsible for cross-stream ordering.
+```python
+with dynamics:
+    dynamics.run(batch)
+```
+
+As best pattern, even without explicit CUDA stream usage, as it in turn
+supports `compile(mode="reduce-overhead")`
+
+Calling `dynamics.run(batch)` without context manager will reuse the current stream.
 
 ### How it works
 

--- a/nvalchemi/dynamics/__init__.py
+++ b/nvalchemi/dynamics/__init__.py
@@ -25,6 +25,7 @@ from nvalchemi.dynamics.base import (
     DynamicsStage,
     FusedStage,
     Hook,
+    requires_grad_ctx,
 )
 from nvalchemi.dynamics.demo import DemoDynamics
 from nvalchemi.dynamics.integrators import NPH, NPT, NVE, NVTLangevin, NVTNoseHoover
@@ -63,4 +64,5 @@ __all__ = [
     "initialize_velocities",
     "integrators",
     "optimizers",
+    "requires_grad_ctx",
 ]

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -794,10 +794,11 @@ class _CommunicationMixin:
         it jointly on the torch side (``torch.cuda.StreamContext``) and the
         warp side (``wp.ScopedStream`` over the converted stream), so all
         subsequent GPU operations — including warp-backed custom ops —
-        execute on the one dedicated stream.  On non-CUDA devices this is
-        a no-op.  See the **CUDA stream semantics** notes on
-        :class:`BaseDynamics` for how this differs from calling ``run()``
-        without the context manager.
+        execute on the one dedicated stream. The dedicated stream first waits
+        for work already submitted to the caller's current torch stream. On
+        non-CUDA devices this is a no-op. See the **CUDA stream semantics**
+        notes on :class:`BaseDynamics` for how this differs from calling
+        ``run()`` without the context manager.
 
         Returns
         -------
@@ -805,7 +806,9 @@ class _CommunicationMixin:
             This instance.
         """
         if self.device_type == "cuda" and torch.cuda.is_available():
+            caller_stream = torch.cuda.current_stream(self.device)
             self._stream = torch.cuda.Stream(device=self.device)
+            self._stream.wait_stream(caller_stream)
             self._wp_stream = wp.stream_from_torch(self._stream)
             self._stream_ctx = self._enter_joint_stream_context(
                 self._stream, self._wp_stream

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -124,6 +124,7 @@ def requires_grad_ctx(
     """
     unique: list[torch.Tensor] = []
     seen: set[int] = set()
+    # perform some intial validation of the data
     for tensor in tensors:
         if not isinstance(tensor, torch.Tensor):
             raise TypeError(f"Expected a tensor, got {type(tensor).__name__}")
@@ -138,6 +139,8 @@ def requires_grad_ctx(
             unique.append(tensor)
 
     original = [(tensor, tensor.requires_grad) for tensor in unique]
+    # set gradient tracking, release control flow back, and when it
+    # wraps up, rest to the original tracking state
     try:
         for tensor, state in original:
             if state != requires_grad:

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -52,6 +52,7 @@ import sys
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
+from contextlib import ExitStack, nullcontext
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -62,6 +63,7 @@ from typing import (
 )
 
 import torch
+import warp as wp
 from jaxtyping import Bool
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
@@ -457,11 +459,16 @@ class _CommunicationMixin:
         Stored ``isend`` handle when send is deferred (``"fully_async"``).
         ``None`` when no send is pending.
     _stream : torch.cuda.Stream | None
-        The CUDA stream created when entering the context manager.
+        The torch CUDA stream created when entering the context manager
+        (see :attr:`torch_stream`).  ``None`` when outside a ``with``
+        block or on non-CUDA devices.
+    _wp_stream : wp.Stream | None
+        The warp view of ``_stream`` (see :attr:`warp_stream`).
         ``None`` when outside a ``with`` block or on non-CUDA devices.
-    _stream_ctx : torch.cuda.StreamContext | None
-        The active stream context wrapping ``_stream``.
-        ``None`` when outside a ``with`` block or on non-CUDA devices.
+    _stream_ctx : contextlib.ExitStack | None
+        The active joint stream context entering ``_stream`` on both the
+        torch and warp sides (see :attr:`stream`).  ``None`` when outside
+        a ``with`` block or on non-CUDA devices.
 
     Examples
     --------
@@ -558,7 +565,11 @@ class _CommunicationMixin:
         self._pending_recv_handle: Any = None
         self._pending_send_handle: Any = None
         self._stream: torch.cuda.Stream | None = None
-        self._stream_ctx: torch.cuda.StreamContext | None = None
+        self._wp_stream: wp.Stream | None = None
+        self._stream_ctx: ExitStack | None = None
+        # warp wrappers cached per torch stream: re-wrapping the same CUDA
+        # stream makes a new warp Stream object and invalidates graph capture.
+        self._wp_stream_cache: dict[int, wp.Stream] = {}
         if isinstance(buffer_config, dict):
             buffer_config = BufferConfig(**buffer_config)
         if buffer_config is not None and not isinstance(buffer_config, BufferConfig):
@@ -707,26 +718,86 @@ class _CommunicationMixin:
                     )
 
     @property
-    def stream(self) -> torch.cuda.Stream | None:
-        """Return the active CUDA stream, if any.
+    def stream(self) -> ExitStack | None:
+        """Return the active joint torch+warp stream context, if any.
 
-        Returns ``None`` when outside a ``with`` block or on non-CUDA
-        devices.
+        The joint context is an :class:`contextlib.ExitStack` that entered
+        the dedicated stream on both the torch side
+        (``torch.cuda.stream``) and the warp side (``wp.ScopedStream``).
+        Use :attr:`torch_stream` / :attr:`warp_stream` for the underlying
+        stream objects.  Returns ``None`` when outside a ``with`` block or
+        on non-CUDA devices.
+
+        Returns
+        -------
+        contextlib.ExitStack | None
+            The active joint stream context, or ``None``.
+        """
+        return self._stream_ctx
+
+    @property
+    def torch_stream(self) -> torch.cuda.Stream | None:
+        """Return the dedicated torch CUDA stream, if any.
 
         Returns
         -------
         torch.cuda.Stream | None
-            The CUDA stream created by ``__enter__``, or ``None``.
+            The stream created by ``__enter__``, or ``None``.
         """
         return self._stream
+
+    @property
+    def warp_stream(self) -> wp.Stream | None:
+        """Return the warp view of the dedicated CUDA stream, if any.
+
+        Returns
+        -------
+        wp.Stream | None
+            The converted warp stream, or ``None``.
+        """
+        return self._wp_stream
+
+    @staticmethod
+    def _enter_joint_stream_context(
+        torch_stream: torch.cuda.Stream, warp_stream: wp.Stream
+    ) -> ExitStack:
+        """Enter one CUDA stream jointly on the torch and warp sides.
+
+        The single mechanism behind both the engine context manager
+        (``__enter__``, dedicated stream) and the per-step scope for bare
+        ``run()`` calls (``_stream_scope``, caller's current stream): both
+        sides of the same stream are entered on an
+        :class:`contextlib.ExitStack`, which the caller later unwinds with
+        one ``__exit__``/``close``.
+
+        Parameters
+        ----------
+        torch_stream : torch.cuda.Stream
+            The torch stream to make current.
+        warp_stream : wp.Stream
+            The warp view of the same stream.
+
+        Returns
+        -------
+        contextlib.ExitStack
+            The entered joint context.
+        """
+        stack = ExitStack()
+        stack.enter_context(torch.cuda.stream(torch_stream))
+        stack.enter_context(wp.ScopedStream(warp_stream))
+        return stack
 
     def __enter__(self) -> _CommunicationMixin:
         """Enter the stream context manager.
 
         On CUDA devices, creates a new ``torch.cuda.Stream`` and enters
-        a ``torch.cuda.StreamContext`` so that all subsequent GPU
-        operations execute on the dedicated stream.  On non-CUDA devices
-        this is a no-op.
+        it jointly on the torch side (``torch.cuda.StreamContext``) and the
+        warp side (``wp.ScopedStream`` over the converted stream), so all
+        subsequent GPU operations — including warp-backed custom ops —
+        execute on the one dedicated stream.  On non-CUDA devices this is
+        a no-op.  See the **CUDA stream semantics** notes on
+        :class:`BaseDynamics` for how this differs from calling ``run()``
+        without the context manager.
 
         Returns
         -------
@@ -735,8 +806,10 @@ class _CommunicationMixin:
         """
         if self.device_type == "cuda" and torch.cuda.is_available():
             self._stream = torch.cuda.Stream(device=self.device)
-            self._stream_ctx = torch.cuda.stream(self._stream)
-            self._stream_ctx.__enter__()
+            self._wp_stream = wp.stream_from_torch(self._stream)
+            self._stream_ctx = self._enter_joint_stream_context(
+                self._stream, self._wp_stream
+            )
         return self
 
     def __exit__(
@@ -747,8 +820,10 @@ class _CommunicationMixin:
     ) -> None:
         """Exit the stream context manager.
 
-        Exits the ``torch.cuda.StreamContext`` (if one was entered) and
-        clears the stored stream references.
+        Exits the warp and torch stream contexts (if entered) and clears
+        the stored stream references.  Exiting does **not** synchronize the
+        dedicated stream: enqueue a ``wait_stream``/``synchronize`` before
+        consuming results from a different stream.
 
         Parameters
         ----------
@@ -762,6 +837,7 @@ class _CommunicationMixin:
         if self._stream_ctx is not None:
             self._stream_ctx.__exit__(exc_type, exc_val, exc_tb)
         self._stream = None
+        self._wp_stream = None
         self._stream_ctx = None
 
     @property
@@ -776,6 +852,37 @@ class _CommunicationMixin:
         if self.active_batch is None:
             return 0
         return self.active_batch.num_graphs or 0
+
+    def _stream_scope(self, device: torch.device):
+        """Bind warp launches to the torch stream the step runs on.
+
+        Inside the engine's context manager the joint torch+warp stream from
+        ``__enter__`` is already active and this is a no-op.  Outside it,
+        the current torch stream is converted once (cached) and entered on
+        the warp side only, so warp-backed custom ops stop launching on
+        warp's default per-device stream — which serializes against torch
+        work and invalidates CUDA-graph capture.
+
+        Parameters
+        ----------
+        device : torch.device
+            Device the batch lives on.
+
+        Returns
+        -------
+        ContextManager
+            The entered joint stream context (see
+            ``_enter_joint_stream_context``), or a null context.
+        """
+        if device.type != "cuda" or self._stream_ctx is not None:
+            return nullcontext()
+        torch_stream = torch.cuda.current_stream(device)
+        key = torch_stream.cuda_stream
+        wp_stream = self._wp_stream_cache.get(key)
+        if wp_stream is None:
+            wp_stream = wp.stream_from_torch(torch_stream)
+            self._wp_stream_cache[key] = wp_stream
+        return self._enter_joint_stream_context(torch_stream, wp_stream)
 
     @property
     def active_batch_has_room(self) -> bool:
@@ -1353,6 +1460,29 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
 
     Notes
     -----
+    **CUDA stream semantics.** The engine runs in one of two modes:
+
+    * ``with dynamics: dynamics.run(batch)`` — the context manager creates
+      a dedicated ``torch.cuda.Stream`` and enters it *jointly* on the
+      torch and warp sides, so every kernel of every step (torch eager,
+      inductor-compiled, and warp-backed custom ops) is enqueued on one
+      non-default stream. Use this form when overlapping the engine with
+      other GPU work, in multi-stage pipelines, and for CUDA-graph capture
+      (``compile(mode="reduce-overhead")``), where a single stable stream
+      across capture and replay is essential. Entering the context
+      synchronizes with previously enqueued work (``sync_enter``), but
+      exiting does **not**: synchronize (e.g.
+      ``torch.cuda.current_stream().wait_stream(...)`` or
+      ``torch.cuda.synchronize()``) before consuming results on a
+      different stream after the ``with`` block.
+    * bare ``dynamics.run(batch)`` — no dedicated stream is created. Torch
+      work runs on the caller's current stream (typically the legacy
+      default stream, which implicitly orders against other blocking
+      streams), and each ``step()`` transiently binds warp-backed ops to
+      that same stream via a cached conversion (see ``_stream_scope``).
+      Correct for eager and default-mode compiled runs with no action
+      required; callers that manage their own non-default streams own the
+      cross-stream ordering in this mode.
 
     Developers implementing a new integrator should override
     ``pre_update(batch)`` and ``post_update(batch)`` to implement the
@@ -1952,15 +2082,16 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
                 elif val.shape[0] == batch.num_graphs:
                     saved[field] = val[sys_mask].clone()
 
-        self._call_hooks(DynamicsStage.BEFORE_PRE_UPDATE, batch)
-        self.pre_update(batch)
-        self._call_hooks(DynamicsStage.AFTER_PRE_UPDATE, batch)
-        self._call_hooks(DynamicsStage.BEFORE_COMPUTE, batch)
-        self.compute(batch)
-        self._call_hooks(DynamicsStage.AFTER_COMPUTE, batch)
-        self._call_hooks(DynamicsStage.BEFORE_POST_UPDATE, batch)
-        self.post_update(batch)
-        self._call_hooks(DynamicsStage.AFTER_POST_UPDATE, batch)
+        with self._stream_scope(batch.device):
+            self._call_hooks(DynamicsStage.BEFORE_PRE_UPDATE, batch)
+            self.pre_update(batch)
+            self._call_hooks(DynamicsStage.AFTER_PRE_UPDATE, batch)
+            self._call_hooks(DynamicsStage.BEFORE_COMPUTE, batch)
+            self.compute(batch)
+            self._call_hooks(DynamicsStage.AFTER_COMPUTE, batch)
+            self._call_hooks(DynamicsStage.BEFORE_POST_UPDATE, batch)
+            self.post_update(batch)
+            self._call_hooks(DynamicsStage.AFTER_POST_UPDATE, batch)
         if active_mask is not None:
             with torch.no_grad():
                 for field, sv in saved.items():
@@ -1990,6 +2121,10 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         ``n_steps`` parameter, or passed directly to this method.
         A value passed here takes precedence over the instance
         attribute.
+
+        May be called bare or inside the engine's context manager; the
+        two differ in CUDA stream behavior — see the **CUDA stream
+        semantics** notes on :class:`BaseDynamics`.
 
         Parameters
         ----------
@@ -2897,6 +3032,7 @@ class FusedStage(BaseDynamics):
         super().__enter__()
         for _, dynamics in self.sub_stages:
             dynamics._stream = self._stream
+            dynamics._wp_stream = self._wp_stream
         if self.compile_step and self._compiled_step is None:
             self.compile()
         return self
@@ -2924,6 +3060,7 @@ class FusedStage(BaseDynamics):
         """
         for _, dynamics in self.sub_stages:
             dynamics._stream = None
+            dynamics._wp_stream = None
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def _sync_state_to_batch(
@@ -3198,7 +3335,8 @@ class FusedStage(BaseDynamics):
         step_fn = (
             self._compiled_step if self._compiled_step is not None else self._step_impl
         )
-        batch, newly_graduated = step_fn(batch)
+        with self._stream_scope(batch.device):
+            batch, newly_graduated = step_fn(batch)
         # Mask -> index conversion here, where a host sync is acceptable.
         if newly_graduated is None or not newly_graduated.any():
             return batch, None

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -3002,6 +3002,25 @@ class FusedStage(BaseDynamics):
         self._compiled_step = torch.compile(self._step_impl, **merged)
         return self
 
+    @staticmethod
+    def _mark_cudagraph_static_inputs(batch: Batch) -> None:
+        """Mark CUDA batch tensors as stable buffers for graph replay.
+
+        ``_step_impl`` mutates batch tensors in place. Inductor permits those
+        mutations in CUDA graphs when their inputs have stable addresses.
+        The default unguarded marking lets CUDA graphs re-record if a refill or
+        another batch operation replaces a tensor with a different address.
+
+        Parameters
+        ----------
+        batch : Batch
+            Batch whose current tensor fields will enter the compiled step.
+        """
+        if batch.device.type != "cuda":
+            return
+        for _, tensor in batch:
+            torch._dynamo.mark_static_address(tensor)
+
     def __enter__(self) -> FusedStage:
         """Enter the stream context and propagate to all sub-stages.
 
@@ -3322,6 +3341,8 @@ class FusedStage(BaseDynamics):
         self._ensure_autograd_inputs(batch)
         for _, dynamics in self.sub_stages:
             dynamics._ensure_state_initialized(batch)
+        if self._compiled_step is not None:
+            self._mark_cudagraph_static_inputs(batch)
         step_fn = (
             self._compiled_step if self._compiled_step is not None else self._step_impl
         )

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -3403,6 +3403,8 @@ class FusedStage(BaseDynamics):
         )
         autograd_inputs = self._autograd_input_tensors(batch)
         with (
+            # TODO ideally we unify the API for both fused and single stage dynamics
+            # so that the `_defer_autograd_input_cleanup` is not needed as a shim
             self._defer_autograd_input_cleanup(),
             requires_grad_ctx(*autograd_inputs),
             self._stream_scope(batch.device),

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -51,8 +51,8 @@ from __future__ import annotations
 import sys
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
-from contextlib import ExitStack, nullcontext
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import ExitStack, contextmanager, nullcontext
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -87,7 +87,66 @@ __all__ = [
     "ConvergenceHook",
     "DistributedPipeline",
     "BufferConfig",
+    "requires_grad_ctx",
 ]
+
+
+@contextmanager
+def requires_grad_ctx(
+    *tensors: torch.Tensor,
+    requires_grad: bool = True,
+) -> Iterator[None]:
+    """Temporarily set ``requires_grad`` on leaf tensors.
+
+    Tensor states are restored on exit, including when an exception is raised.
+    Duplicate tensor arguments are handled once, so nested or aliased inputs
+    preserve the state observed when this context was entered.
+
+    Parameters
+    ----------
+    *tensors : torch.Tensor
+        Leaf tensors whose autograd state should be changed temporarily.
+    requires_grad : bool, optional
+        State to apply inside the context. Default is ``True``.
+
+    Yields
+    ------
+    None
+        Control while the requested autograd state is active.
+
+    Raises
+    ------
+    TypeError
+        If an argument is not a tensor.
+    ValueError
+        If a tensor is not a leaf, or if gradients are requested for a tensor
+        that is neither floating-point nor complex.
+    """
+    unique: list[torch.Tensor] = []
+    seen: set[int] = set()
+    for tensor in tensors:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"Expected a tensor, got {type(tensor).__name__}")
+        if not tensor.is_leaf:
+            raise ValueError("requires_grad_ctx requires leaf tensors")
+        if requires_grad and not (tensor.is_floating_point() or tensor.is_complex()):
+            raise ValueError(
+                "requires_grad=True requires floating-point or complex tensors"
+            )
+        if id(tensor) not in seen:
+            seen.add(id(tensor))
+            unique.append(tensor)
+
+    original = [(tensor, tensor.requires_grad) for tensor in unique]
+    try:
+        for tensor, state in original:
+            if state != requires_grad:
+                tensor.requires_grad_(requires_grad)
+        yield
+    finally:
+        for tensor, state in reversed(original):
+            if tensor.requires_grad != state:
+                tensor.requires_grad_(state)
 
 
 class BufferConfig(BaseModel):
@@ -1777,33 +1836,45 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         """
         return None
 
-    def _ensure_autograd_inputs(self, batch: Batch) -> None:
-        """Enable ``requires_grad`` on autograd inputs as durable leaves.
-
-        Only active when ``_persistent_autograd_inputs`` is set (see
-        :class:`FusedStage`).  With the flag on, tensors named in
-        ``model_config.autograd_inputs`` (e.g. ``positions``) keep
-        ``requires_grad=True`` across steps instead of being re-enabled via
-        ``clone().requires_grad_(True)`` inside the model's ``adapt_input``
-        — that per-step re-enable is both an extra allocation and a dynamo
-        graph break ("requires_grad_() intermediate leaked as output").
-        The counterpart contract is that all in-place kinematic updates run
-        under ``no_grad`` and :meth:`compute` skips clearing these flags.
+    def _autograd_input_tensors(
+        self, batch: Batch | AtomsLike
+    ) -> tuple[torch.Tensor, ...]:
+        """Return tensor inputs that require gradients for model evaluation.
 
         Parameters
         ----------
-        batch : Batch
-            The current batch.
+        batch : Batch | AtomsLike
+            Model input containing configured autograd fields.
+
+        Returns
+        -------
+        tuple[torch.Tensor, ...]
+            Present tensor fields requiring gradients. Conservative models
+            include ``positions`` even when a wrapper omits it from
+            ``autograd_inputs``.
         """
-        if not getattr(self, "_persistent_autograd_inputs", False):
-            return
         cfg = self.model_config
-        if not (cfg.autograd_outputs & cfg.active_outputs):
-            return
-        for key in cfg.autograd_inputs:
+        grad_keys = set(cfg.gradient_keys)
+        if cfg.autograd_outputs & cfg.active_outputs:
+            grad_keys |= cfg.autograd_inputs
+            grad_keys.add("positions")
+
+        tensors: list[torch.Tensor] = []
+        for key in grad_keys:
             value = getattr(batch, key, None)
-            if isinstance(value, torch.Tensor) and not value.requires_grad:
-                value.requires_grad_(True)
+            if isinstance(value, torch.Tensor):
+                tensors.append(value)
+        return tuple(tensors)
+
+    @contextmanager
+    def _defer_autograd_input_cleanup(self) -> Iterator[None]:
+        """Defer ``compute`` gradient restoration to an outer context."""
+        previous = getattr(self, "_autograd_cleanup_deferred", False)
+        self._autograd_cleanup_deferred = True
+        try:
+            yield
+        finally:
+            self._autograd_cleanup_deferred = previous
 
     def _ensure_state_initialized(self, batch: Batch) -> None:
         """Lazily initialize per-system integrator state on the first call.
@@ -1926,9 +1997,8 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         5. Detaches all output tensors from the computation graph and
            exposes them as ``_last_outputs`` for custom dynamics subclasses
            that need charges, embeddings, or other non-standard outputs.
-        6. Clears ``requires_grad`` on batch tensors that the model
-           enabled for autograd (e.g. positions), so downstream hooks
-           can safely perform in-place operations.
+        6. Restores the original ``requires_grad`` state of model autograd
+           inputs, so downstream hooks can safely perform in-place operations.
 
         The detach in step 5 is deliberate: model wrappers may return
         tensors that are still attached to the autograd graph (e.g. MACE
@@ -1958,6 +2028,13 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
             If the model outputs do not satisfy the dynamics requirements
             specified by ``__needs_keys__``.
         """
+        if getattr(self, "_autograd_cleanup_deferred", False):
+            return self._compute(batch)
+        with requires_grad_ctx(*self._autograd_input_tensors(batch)):
+            return self._compute(batch)
+
+    def _compute(self, batch: Batch | AtomsLike) -> ModelOutputs:
+        """Execute model evaluation while autograd input state is managed."""
         self._last_outputs = None
 
         # model.forward() is responsible for returning a fully adapted ModelOutputs dict.
@@ -1987,26 +2064,6 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
                 target = getattr(batch, batch_attr, None)
                 if target is not None:
                     target.copy_(value.view(target.shape))
-
-        # Clear requires_grad on batch tensors that the model enabled for
-        # autograd force/stress computation.  After compute() the gradients
-        # have been extracted into forces/stress and the graph is detached,
-        # so keeping requires_grad=True would only cause spurious errors in
-        # downstream hooks that perform in-place operations (e.g. copy_).
-        # Always include "positions" — it is an implicit model input that
-        # may not appear in autograd_inputs but can still carry grad from
-        # the forward pass.
-        # Persistent-leaf mode keeps requires_grad set; see _ensure_autograd_inputs.
-        if not getattr(self, "_persistent_autograd_inputs", False):
-            cfg = self.model_config
-            grad_keys: set[str] = {"positions"}
-            grad_keys |= cfg.gradient_keys
-            if cfg.autograd_outputs & cfg.active_outputs:
-                grad_keys |= cfg.autograd_inputs
-            for key in grad_keys:
-                value = getattr(batch, key, None)
-                if isinstance(value, torch.Tensor) and value.requires_grad:
-                    value.requires_grad_(False)
 
         self._last_outputs = detached
 
@@ -2889,9 +2946,6 @@ class FusedStage(BaseDynamics):
         )
 
         self.entry_status = entry_status
-        # Keep autograd inputs as durable leaves so model wrappers skip their
-        # per-step clone().requires_grad_(True); see _ensure_autograd_inputs.
-        self._persistent_autograd_inputs = True
         self.compile_kwargs: dict[str, Any] = (
             compile_kwargs if compile_kwargs is not None else {}
         )
@@ -3338,7 +3392,6 @@ class FusedStage(BaseDynamics):
         # Lazy state must be created outside the compiled step: in-graph
         # allocations break CUDA-graph replay and fullgraph shape reasoning.
         self._ensure_bookkeeping_fields(batch)
-        self._ensure_autograd_inputs(batch)
         for _, dynamics in self.sub_stages:
             dynamics._ensure_state_initialized(batch)
         if self._compiled_step is not None:
@@ -3346,7 +3399,12 @@ class FusedStage(BaseDynamics):
         step_fn = (
             self._compiled_step if self._compiled_step is not None else self._step_impl
         )
-        with self._stream_scope(batch.device):
+        autograd_inputs = self._autograd_input_tensors(batch)
+        with (
+            self._defer_autograd_input_cleanup(),
+            requires_grad_ctx(*autograd_inputs),
+            self._stream_scope(batch.device),
+        ):
             batch, newly_graduated = step_fn(batch)
         # Mask -> index conversion here, where a host sync is acceptable.
         if newly_graduated is None or not newly_graduated.any():

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -1657,6 +1657,34 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         """
         return None
 
+    def _ensure_autograd_inputs(self, batch: Batch) -> None:
+        """Enable ``requires_grad`` on autograd inputs as durable leaves.
+
+        Only active when ``_persistent_autograd_inputs`` is set (see
+        :class:`FusedStage`).  With the flag on, tensors named in
+        ``model_config.autograd_inputs`` (e.g. ``positions``) keep
+        ``requires_grad=True`` across steps instead of being re-enabled via
+        ``clone().requires_grad_(True)`` inside the model's ``adapt_input``
+        — that per-step re-enable is both an extra allocation and a dynamo
+        graph break ("requires_grad_() intermediate leaked as output").
+        The counterpart contract is that all in-place kinematic updates run
+        under ``no_grad`` and :meth:`compute` skips clearing these flags.
+
+        Parameters
+        ----------
+        batch : Batch
+            The current batch.
+        """
+        if not getattr(self, "_persistent_autograd_inputs", False):
+            return
+        cfg = self.model_config
+        if not (cfg.autograd_outputs & cfg.active_outputs):
+            return
+        for key in cfg.autograd_inputs:
+            value = getattr(batch, key, None)
+            if isinstance(value, torch.Tensor) and not value.requires_grad:
+                value.requires_grad_(True)
+
     def _ensure_state_initialized(self, batch: Batch) -> None:
         """Lazily initialize per-system integrator state on the first call.
 
@@ -1848,15 +1876,17 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         # Always include "positions" — it is an implicit model input that
         # may not appear in autograd_inputs but can still carry grad from
         # the forward pass.
-        cfg = self.model_config
-        grad_keys: set[str] = {"positions"}
-        grad_keys |= cfg.gradient_keys
-        if cfg.autograd_outputs & cfg.active_outputs:
-            grad_keys |= cfg.autograd_inputs
-        for key in grad_keys:
-            value = getattr(batch, key, None)
-            if isinstance(value, torch.Tensor) and value.requires_grad:
-                value.requires_grad_(False)
+        # Persistent-leaf mode keeps requires_grad set; see _ensure_autograd_inputs.
+        if not getattr(self, "_persistent_autograd_inputs", False):
+            cfg = self.model_config
+            grad_keys: set[str] = {"positions"}
+            grad_keys |= cfg.gradient_keys
+            if cfg.autograd_outputs & cfg.active_outputs:
+                grad_keys |= cfg.autograd_inputs
+            for key in grad_keys:
+                value = getattr(batch, key, None)
+                if isinstance(value, torch.Tensor) and value.requires_grad:
+                    value.requires_grad_(False)
 
         self._last_outputs = detached
 
@@ -2205,31 +2235,22 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         sub-stages before the shared compute, so that forces are evaluated at
         the post-pre_update positions (required for BAOAB Langevin and
         velocity-Verlet-based integrators).
+
+        The save/restore uses full-tensor clones blended back with
+        ``torch.where`` rather than boolean-mask fancy indexing: mask
+        indexing lowers to data-dependent ``nonzero`` (dynamic shapes,
+        graph breaks), while the blend is static-shaped, safe for all-False
+        masks, and CUDA-graph friendly.  The whole body runs under
+        ``no_grad``: the integrator is pure kinematics, and in-place updates
+        of a grad-requiring ``positions`` leaf are only legal without grad.
         """
         self._ensure_state_initialized(batch)
 
-        node_mask = mask[batch.batch_idx]
-        sys_mask = ~mask
-
-        saved: dict[str, torch.Tensor] = {}
-        for field in self._mutable_fields:
-            val = getattr(batch, field, None)
-            if val is None:
-                continue
-            if val.shape[0] == batch.num_nodes:
-                saved[field] = val[~node_mask].clone()
-            elif val.shape[0] == batch.num_graphs:
-                saved[field] = val[sys_mask].clone()
-
-        self.pre_update(batch)
-
         with torch.no_grad():
-            for field, sv in saved.items():
-                val = getattr(batch, field)
-                if val.shape[0] == batch.num_nodes:
-                    val[~node_mask] = sv
-                else:
-                    val[sys_mask] = sv
+            node_mask = mask[batch.batch_idx]
+            saved = self._save_mutable_fields(batch)
+            self.pre_update(batch)
+            self._restore_unmasked_fields(batch, saved, mask, node_mask)
 
     def _masked_post_update(
         self,
@@ -2241,29 +2262,38 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
         Called by :class:`FusedStage` after the shared compute so that
         post_update (e.g. the final BAOAB velocity half-kick) uses forces at
         the new positions.
-        """
-        node_mask = mask[batch.batch_idx]
-        sys_mask = ~mask
 
+        Uses the same static-shape save/blend strategy as
+        :meth:`_masked_pre_update` — see that method for the rationale.
+        """
+        with torch.no_grad():
+            node_mask = mask[batch.batch_idx]
+            saved = self._save_mutable_fields(batch)
+            self.post_update(batch)
+            self._restore_unmasked_fields(batch, saved, mask, node_mask)
+
+    def _save_mutable_fields(self, batch: Batch) -> dict[str, torch.Tensor]:
+        """Clone every mutable field in full (static shapes, no mask indexing)."""
         saved: dict[str, torch.Tensor] = {}
         for field in self._mutable_fields:
             val = getattr(batch, field, None)
-            if val is None:
-                continue
-            if val.shape[0] == batch.num_nodes:
-                saved[field] = val[~node_mask].clone()
-            elif val.shape[0] == batch.num_graphs:
-                saved[field] = val[sys_mask].clone()
+            if val is not None:
+                saved[field] = val.clone()
+        return saved
 
-        self.post_update(batch)
-
-        with torch.no_grad():
-            for field, sv in saved.items():
-                val = getattr(batch, field)
-                if val.shape[0] == batch.num_nodes:
-                    val[~node_mask] = sv
-                else:
-                    val[sys_mask] = sv
+    def _restore_unmasked_fields(
+        self,
+        batch: Batch,
+        saved: dict[str, torch.Tensor],
+        mask: torch.Tensor,
+        node_mask: torch.Tensor,
+    ) -> None:
+        """Blend pre-update values back into unmasked rows via ``torch.where``."""
+        for field, sv in saved.items():
+            val = getattr(batch, field)
+            m = node_mask if val.shape[0] == batch.num_nodes else mask
+            m = m.view(m.shape[0], *([1] * (val.dim() - 1)))
+            val.copy_(torch.where(m, val, sv))
 
 
 class ConvergenceHook:
@@ -2734,6 +2764,9 @@ class FusedStage(BaseDynamics):
         )
 
         self.entry_status = entry_status
+        # Keep autograd inputs as durable leaves so model wrappers skip their
+        # per-step clone().requires_grad_(True); see _ensure_autograd_inputs.
+        self._persistent_autograd_inputs = True
         self.compile_kwargs: dict[str, Any] = (
             compile_kwargs if compile_kwargs is not None else {}
         )
@@ -3003,13 +3036,13 @@ class FusedStage(BaseDynamics):
 
         Returns
         -------
-        tuple[Batch, torch.Tensor | None]
-            The updated batch, and a 1-D integer tensor of sample indices
-            that newly graduated (reached ``exit_status``) during this step,
-            or ``None`` if no samples graduated.
+        tuple[Batch, torch.Tensor]
+            The updated batch, and a boolean mask over graphs of samples
+            that newly graduated (reached ``exit_status``) during this step.
+            The mask (rather than an index tensor) keeps the return value
+            static-shaped so the whole method can be captured in a single
+            dynamo graph; :meth:`step` converts it to the index contract.
         """
-        self._ensure_bookkeeping_fields(batch)
-
         self._call_fused_hooks(DynamicsStage.BEFORE_STEP, batch)
         self._call_hooks(DynamicsStage.BEFORE_STEP, batch)
 
@@ -3028,8 +3061,9 @@ class FusedStage(BaseDynamics):
             mask = status == status_code
             stage_active_masks.append(mask)
             dynamics._call_hooks(DynamicsStage.BEFORE_PRE_UPDATE, batch)
-            if mask.any():
-                dynamics._masked_pre_update(batch, mask)
+            # Unconditional: `if mask.any():` would be a graph-breaking host
+            # sync, and the masked update is a no-op for all-False masks.
+            dynamics._masked_pre_update(batch, mask)
 
         # Phase 2 — shared forward pass at the updated positions.
         self._call_hooks(DynamicsStage.BEFORE_COMPUTE, batch)
@@ -3037,8 +3071,9 @@ class FusedStage(BaseDynamics):
         outputs: ModelOutputs = self.compute(batch)
 
         # TODO: update this when `batch` structure is done
+        # Skip None placeholders — writing them only churns dynamo guards.
         for key, tensor in outputs.items():
-            if key not in ("forces", "energy"):
+            if key not in ("forces", "energy") and tensor is not None:
                 batch[key] = tensor
 
         self._call_hooks(DynamicsStage.AFTER_COMPUTE, batch)
@@ -3048,8 +3083,7 @@ class FusedStage(BaseDynamics):
         # Phase 3 — post_update for each sub-stage, now with forces at r(t+dt).
         for status_code, dynamics in self.sub_stages:
             mask = status == status_code
-            if mask.any():
-                dynamics._masked_post_update(batch, mask)
+            dynamics._masked_post_update(batch, mask)
             dynamics._call_hooks(DynamicsStage.AFTER_POST_UPDATE, batch)
 
         # Snapshot before hook and counter migration so both are reported
@@ -3081,7 +3115,8 @@ class FusedStage(BaseDynamics):
             )
             active = cur_status == status_code
 
-            counter[active] += 1
+            # Branchless: mask-indexed writes and `migrate.any()` break capture.
+            counter.add_(active.to(counter.dtype).unsqueeze(-1))
 
             next_status = (
                 self.sub_stages[i + 1][0]
@@ -3090,9 +3125,17 @@ class FusedStage(BaseDynamics):
             )
 
             migrate = active & (counter.squeeze(-1) >= dynamics.n_steps)
-            if migrate.any():
-                batch.status.view(-1)[migrate] = next_status
-                counter[migrate] = 0  # Reset for next system in this slot
+            status_flat = batch.status.view(-1)
+            status_flat.copy_(
+                torch.where(
+                    migrate,
+                    torch.full_like(status_flat, next_status),
+                    status_flat,
+                )
+            )
+            counter.copy_(
+                torch.where(migrate.unsqueeze(-1), torch.zeros_like(counter), counter)
+            )
 
         for active_mask, (_, dynamics) in zip(
             stage_active_masks, self.sub_stages, strict=True
@@ -3125,11 +3168,8 @@ class FusedStage(BaseDynamics):
         newly_graduated = (pre_migration_status < self.exit_status) & (
             post_status >= self.exit_status
         )
-        exit_converged: torch.Tensor | None = (
-            torch.where(newly_graduated)[0] if newly_graduated.any() else None
-        )
 
-        return batch, exit_converged
+        return batch, newly_graduated
 
     def step(self, batch: Batch) -> tuple[Batch, torch.Tensor | None]:
         """Execute one fused step: single forward pass + masked updates.
@@ -3149,9 +3189,20 @@ class FusedStage(BaseDynamics):
             that newly graduated (reached ``exit_status``) during this step,
             or ``None`` if no samples graduated.
         """
-        if self._compiled_step is not None:
-            return self._compiled_step(batch)
-        return self._step_impl(batch)
+        # Lazy state must be created outside the compiled step: in-graph
+        # allocations break CUDA-graph replay and fullgraph shape reasoning.
+        self._ensure_bookkeeping_fields(batch)
+        self._ensure_autograd_inputs(batch)
+        for _, dynamics in self.sub_stages:
+            dynamics._ensure_state_initialized(batch)
+        step_fn = (
+            self._compiled_step if self._compiled_step is not None else self._step_impl
+        )
+        batch, newly_graduated = step_fn(batch)
+        # Mask -> index conversion here, where a host sync is acceptable.
+        if newly_graduated is None or not newly_graduated.any():
+            return batch, None
+        return batch, torch.where(newly_graduated)[0]
 
     def __call__(self, batch: Batch) -> tuple[Batch, torch.Tensor | None]:
         """Call the ``step`` method on a batch."""

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -1460,29 +1460,16 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
 
     Notes
     -----
-    **CUDA stream semantics.** The engine runs in one of two modes:
+    **CUDA streams.** Used as a context manager, dynamics creates a dedicated
+    stream shared by torch and warp. This supports overlapping GPU work,
+    multi-stage pipelines, and CUDA-graph capture. Entry waits for prior work,
+    but exit is asynchronous; synchronize before consuming results on another
+    stream.
 
-    * ``with dynamics: dynamics.run(batch)`` — the context manager creates
-      a dedicated ``torch.cuda.Stream`` and enters it *jointly* on the
-      torch and warp sides, so every kernel of every step (torch eager,
-      inductor-compiled, and warp-backed custom ops) is enqueued on one
-      non-default stream. Use this form when overlapping the engine with
-      other GPU work, in multi-stage pipelines, and for CUDA-graph capture
-      (``compile(mode="reduce-overhead")``), where a single stable stream
-      across capture and replay is essential. Entering the context
-      synchronizes with previously enqueued work (``sync_enter``), but
-      exiting does **not**: synchronize (e.g.
-      ``torch.cuda.current_stream().wait_stream(...)`` or
-      ``torch.cuda.synchronize()``) before consuming results on a
-      different stream after the ``with`` block.
-    * bare ``dynamics.run(batch)`` — no dedicated stream is created. Torch
-      work runs on the caller's current stream (typically the legacy
-      default stream, which implicitly orders against other blocking
-      streams), and each ``step()`` transiently binds warp-backed ops to
-      that same stream via a cached conversion (see ``_stream_scope``).
-      Correct for eager and default-mode compiled runs with no action
-      required; callers that manage their own non-default streams own the
-      cross-stream ordering in this mode.
+    Without the context manager (i.e. when you just call `run()` directly),
+    dynamics uses the caller's current torch stream and binds warp operations
+    to it for each step. Callers using custom streams are responsible for
+    cross-stream ordering.
 
     Developers implementing a new integrator should override
     ``pre_update(batch)`` and ``post_update(batch)`` to implement the

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -2418,7 +2418,7 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
             val = getattr(batch, field)
             m = node_mask if val.shape[0] == batch.num_nodes else mask
             m = m.view(m.shape[0], *([1] * (val.dim() - 1)))
-            val.copy_(torch.where(m, val, sv))
+            torch.where(m, val, sv, out=val)
 
 
 class ConvergenceHook:

--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -3273,7 +3273,6 @@ class FusedStage(BaseDynamics):
 
         outputs: ModelOutputs = self.compute(batch)
 
-        # TODO: update this when `batch` structure is done
         # Skip None placeholders — writing them only churns dynamo guards.
         for key, tensor in outputs.items():
             if key not in ("forces", "energy") and tensor is not None:

--- a/test/dynamics/test_base.py
+++ b/test/dynamics/test_base.py
@@ -27,7 +27,12 @@ import pytest
 import torch
 
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.dynamics.base import BaseDynamics, ConvergenceHook, DynamicsStage
+from nvalchemi.dynamics.base import (
+    BaseDynamics,
+    ConvergenceHook,
+    DynamicsStage,
+    requires_grad_ctx,
+)
 from nvalchemi.dynamics.demo import DemoDynamics
 from nvalchemi.hooks import DynamicsContext, Hook
 from nvalchemi.models.demo import DemoModel, DemoModelWrapper
@@ -160,6 +165,63 @@ class RecordingHook:
 # -----------------------------------------------------------------------------
 # Test Classes
 # -----------------------------------------------------------------------------
+
+
+class TestRequiresGradContext:
+    """Tests for temporary tensor autograd state management."""
+
+    def test_exported_from_dynamics_namespace(self) -> None:
+        """The context should be available from the public dynamics API."""
+        from nvalchemi.dynamics import requires_grad_ctx as exported
+
+        assert exported is requires_grad_ctx
+
+    def test_enables_and_restores_gradients(self) -> None:
+        """The context should restore an initially disabled tensor."""
+        tensor = torch.randn(3)
+
+        with requires_grad_ctx(tensor):
+            assert tensor.requires_grad
+
+        assert not tensor.requires_grad
+
+    def test_preserves_existing_gradient_state(self) -> None:
+        """The context should preserve an initially enabled tensor."""
+        tensor = torch.randn(3, requires_grad=True)
+
+        with requires_grad_ctx(tensor):
+            assert tensor.requires_grad
+
+        assert tensor.requires_grad
+
+    def test_temporarily_disables_gradients(self) -> None:
+        """The context should support the reciprocal disabled state."""
+        tensor = torch.randn(3, requires_grad=True)
+
+        with requires_grad_ctx(tensor, requires_grad=False):
+            assert not tensor.requires_grad
+
+        assert tensor.requires_grad
+
+    def test_restores_gradients_after_exception(self) -> None:
+        """The context should restore state when its body raises."""
+        tensor = torch.randn(3)
+
+        with pytest.raises(RuntimeError, match="expected"):
+            with requires_grad_ctx(tensor):
+                assert tensor.requires_grad
+                raise RuntimeError("expected")
+
+        assert not tensor.requires_grad
+
+    def test_handles_duplicate_tensors_once(self) -> None:
+        """Aliased arguments should preserve their original state."""
+        tensor = torch.randn(3)
+
+        with requires_grad_ctx(tensor, tensor):
+            assert tensor.requires_grad
+
+        assert not tensor.requires_grad
 
 
 class TestDynamicsStage:
@@ -439,8 +501,8 @@ class TestBaseDynamics:
         )
         assert dynamics.convergence_hook is hook
 
-    def test_compute_clears_requires_grad_on_autograd_inputs(self) -> None:
-        """Verify compute() clears requires_grad on positions after forward pass.
+    def test_compute_restores_requires_grad_on_autograd_inputs(self) -> None:
+        """Verify compute() restores requires_grad on positions after forwarding.
 
         Regression test: hooks running after compute() (e.g. WrapPeriodicHook)
         perform in-place operations on batch.positions.  If positions still has
@@ -450,11 +512,28 @@ class TestBaseDynamics:
         """
         dynamics = BaseDynamics(self.model)
         batch = create_simple_batch()
-        # Simulate what the model wrapper does: enable grad on positions
-        batch.positions.requires_grad_(True)
-        assert batch.positions.requires_grad
+        assert not batch.positions.requires_grad
 
         dynamics.compute(batch)
+
+        assert not batch.positions.requires_grad
+
+    def test_compute_preserves_caller_enabled_gradients(self) -> None:
+        """Verify compute() preserves a caller's enabled gradient state."""
+        dynamics = BaseDynamics(self.model)
+        batch = create_simple_batch()
+        batch.positions.requires_grad_(True)
+
+        dynamics.compute(batch)
+
+        assert batch.positions.requires_grad
+
+    def test_step_restores_requires_grad_on_autograd_inputs(self) -> None:
+        """Verify an individual dynamics step restores autograd input state."""
+        dynamics = BaseDynamics(self.model)
+        batch = create_simple_batch()
+
+        dynamics.step(batch)
 
         assert not batch.positions.requires_grad
 

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -109,6 +109,37 @@ class CountingNonConservativeDemoModel(NonConservativeDemoModel):
         return super().forward(*args, **kwargs)
 
 
+class CompilerFriendlyModel(torch.nn.Module, BaseModelMixin):
+    """Minimal analytical model for end-to-end compilation tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces"}),
+            autograd_outputs=frozenset(),
+            autograd_inputs=frozenset(),
+            neighbor_config=None,
+            needs_pbc=False,
+        )
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        """Return no embedding outputs for this test model."""
+        return {}
+
+    def compute_embeddings(self, data: Batch) -> Batch:
+        """Return the batch unchanged because embeddings are not used."""
+        return data
+
+    def forward(self, batch: Batch) -> dict[str, torch.Tensor]:
+        """Compute analytical per-atom energies and forces."""
+        positions = batch.positions
+        return {
+            "energy": positions.square().sum(dim=-1, keepdim=True),
+            "forces": -2 * positions,
+        }
+
+
 # -----------------------------------------------------------------------------
 # Helper Functions
 # -----------------------------------------------------------------------------
@@ -549,6 +580,37 @@ class TestFusedStage:
         # Verify that _compiled_step is set (compiled function)
         assert fused._compiled_step is not None
         assert callable(fused._compiled_step)
+
+    @pytest.mark.slow
+    def test_compiled_step_executes_on_cuda(self, gpu_device: str) -> None:
+        """A compiled fused step should execute repeatedly on CUDA."""
+        torch.compiler.reset()
+        model = CompilerFriendlyModel().to(gpu_device)
+        dynamics = BaseDynamics(model=model, device_type="cuda")
+        fused = FusedStage(
+            sub_stages=[(0, dynamics)],
+            compile_step=True,
+            compile_kwargs={"mode": "reduce-overhead"},
+            device_type="cuda",
+        )
+        batch = create_batch_with_status(n_graphs=3, device=gpu_device)
+        expected_positions = batch.positions.clone()
+
+        try:
+            with fused:
+                for _ in range(3):
+                    fused.step(batch)
+            torch.cuda.synchronize()
+
+            assert fused.step_count == 3
+            torch.testing.assert_close(batch.positions, expected_positions)
+            torch.testing.assert_close(batch.forces, -2 * expected_positions)
+            torch.testing.assert_close(
+                batch.energy,
+                expected_positions.square().sum(dim=-1, keepdim=True),
+            )
+        finally:
+            torch.compiler.reset()
 
     def test_fused_stage_or_produces_pipeline(self) -> None:
         """FusedStage | BaseDynamics should produce DistributedPipeline."""

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from torch._dynamo.utils import counters
 
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.dynamics.base import (
@@ -583,33 +584,38 @@ class TestFusedStage:
 
     @pytest.mark.slow
     def test_compiled_step_executes_on_cuda(self, gpu_device: str) -> None:
-        """A compiled fused step should execute repeatedly on CUDA."""
+        """A compiled fused step should execute with CUDA-graph capture."""
         torch.compiler.reset()
-        model = CompilerFriendlyModel().to(gpu_device)
-        dynamics = BaseDynamics(model=model, device_type="cuda")
-        fused = FusedStage(
-            sub_stages=[(0, dynamics)],
-            compile_step=True,
-            compile_kwargs={"mode": "reduce-overhead"},
-            device_type="cuda",
-        )
-        batch = create_batch_with_status(n_graphs=3, device=gpu_device)
-        expected_positions = batch.positions.clone()
+        counters.clear()
 
         try:
-            with fused:
-                for _ in range(3):
-                    fused.step(batch)
-            torch.cuda.synchronize()
+            with torch.compiler.config.patch(force_disable_caches=True):
+                model = CompilerFriendlyModel().to(gpu_device)
+                dynamics = BaseDynamics(model=model, device_type="cuda")
+                fused = FusedStage(
+                    sub_stages=[(0, dynamics)],
+                    compile_step=True,
+                    compile_kwargs={"mode": "reduce-overhead"},
+                    device_type="cuda",
+                )
+                batch = create_batch_with_status(n_graphs=3, device=gpu_device)
+                expected_positions = batch.positions.clone()
 
-            assert fused.step_count == 3
-            torch.testing.assert_close(batch.positions, expected_positions)
-            torch.testing.assert_close(batch.forces, -2 * expected_positions)
-            torch.testing.assert_close(
-                batch.energy,
-                expected_positions.square().sum(dim=-1, keepdim=True),
-            )
+                with fused:
+                    for _ in range(3):
+                        fused.step(batch)
+                torch.cuda.synchronize()
+
+                assert fused.step_count == 3
+                assert counters["inductor"]["cudagraph_skips"] == 0
+                torch.testing.assert_close(batch.positions, expected_positions)
+                torch.testing.assert_close(batch.forces, -2 * expected_positions)
+                torch.testing.assert_close(
+                    batch.energy,
+                    expected_positions.square().sum(dim=-1, keepdim=True),
+                )
         finally:
+            counters.clear()
             torch.compiler.reset()
 
     def test_fused_stage_or_produces_pipeline(self) -> None:

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -141,6 +141,20 @@ class CompilerFriendlyModel(torch.nn.Module, BaseModelMixin):
         }
 
 
+class CompilerFriendlyAutogradModel(CompilerFriendlyModel):
+    """Analytical test model declaring positions as an autograd input."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces"}),
+            autograd_outputs=frozenset({"forces"}),
+            autograd_inputs=frozenset({"positions"}),
+            neighbor_config=None,
+            needs_pbc=False,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Helper Functions
 # -----------------------------------------------------------------------------
@@ -590,7 +604,7 @@ class TestFusedStage:
 
         try:
             with torch.compiler.config.patch(force_disable_caches=True):
-                model = CompilerFriendlyModel().to(gpu_device)
+                model = CompilerFriendlyAutogradModel().to(gpu_device)
                 dynamics = BaseDynamics(model=model, device_type="cuda")
                 fused = FusedStage(
                     sub_stages=[(0, dynamics)],
@@ -604,6 +618,7 @@ class TestFusedStage:
                 with fused:
                     for _ in range(3):
                         fused.step(batch)
+                        assert not batch.positions.requires_grad
                 torch.cuda.synchronize()
 
                 assert fused.step_count == 3
@@ -617,6 +632,21 @@ class TestFusedStage:
         finally:
             counters.clear()
             torch.compiler.reset()
+
+    def test_eager_step_restores_autograd_inputs(self) -> None:
+        """An eager fused step should restore its input gradient state."""
+        model = CompilerFriendlyAutogradModel()
+        dynamics = BaseDynamics(model=model, device_type="cpu")
+        fused = FusedStage(
+            sub_stages=[(0, dynamics)],
+            compile_step=False,
+            device_type="cpu",
+        )
+        batch = create_batch_with_status(n_graphs=3)
+
+        fused.step(batch)
+
+        assert not batch.positions.requires_grad
 
     def test_fused_stage_or_produces_pipeline(self) -> None:
         """FusedStage | BaseDynamics should produce DistributedPipeline."""

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -954,6 +954,15 @@ class TestFusedStageDeviceValidation:
 class TestCommunicationMixinStreamContext:
     """Tests for _CommunicationMixin.__enter__ / __exit__ stream context."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_warp(self):
+        """Mock the warp stream API — real conversion rejects mocked streams."""
+        with patch("nvalchemi.dynamics.base.wp") as mock_wp:
+            mock_wp.stream_from_torch.return_value = MagicMock()
+            mock_wp.ScopedStream.return_value = MagicMock()
+            self.mock_wp = mock_wp
+            yield
+
     def setup_method(self) -> None:
         """Set up test fixtures before each test method."""
         self.model = DemoModelWrapper(DemoModel())
@@ -990,11 +999,15 @@ class TestCommunicationMixinStreamContext:
                         # Assert the context was entered
                         mock_stream_ctx.__enter__.assert_called_once()
 
-                        # Assert _stream is the mock stream
-                        assert dyn._stream is mock_stream
+                        # Assert both stream views are exposed
+                        assert dyn.torch_stream is mock_stream
+                        assert (
+                            dyn.warp_stream
+                            is self.mock_wp.stream_from_torch.return_value
+                        )
 
-                        # Assert _stream_ctx is the mock context
-                        assert dyn._stream_ctx is mock_stream_ctx
+                        # The joint context entered the torch side
+                        assert dyn._stream_ctx is not None
 
                         # Assert returns self
                         assert result is dyn
@@ -1016,6 +1029,40 @@ class TestCommunicationMixinStreamContext:
         # Should return self
         assert result is dyn
 
+    def test_enter_and_exit_bind_warp_stream(self) -> None:
+        """__enter__ converts the torch stream to warp and enters both; __exit__ clears."""
+        mock_stream = MagicMock(spec=torch.cuda.Stream)
+        mock_stream_ctx = MagicMock()
+
+        with patch("torch.cuda.is_available", return_value=True):
+            with patch("torch.cuda.Stream", return_value=mock_stream):
+                with patch("torch.cuda.stream", return_value=mock_stream_ctx):
+                    dyn = BaseDynamics(model=self.model, device_type="cuda")
+
+                    with patch.object(
+                        type(dyn), "device", property(lambda s: torch.device("cuda:0"))
+                    ):
+                        dyn.__enter__()
+
+                        self.mock_wp.stream_from_torch.assert_called_once_with(
+                            mock_stream
+                        )
+                        assert (
+                            dyn.warp_stream
+                            is self.mock_wp.stream_from_torch.return_value
+                        )
+                        wp_ctx = self.mock_wp.ScopedStream.return_value
+                        wp_ctx.__enter__.assert_called_once()
+
+                        dyn.__exit__(None, None, None)
+                        assert wp_ctx.__exit__.call_count == 1
+                        assert wp_ctx.__exit__.call_args.args[-3:] == (
+                            None,
+                            None,
+                            None,
+                        )
+                        assert dyn.warp_stream is None
+
     def test_exit_clears_stream(self) -> None:
         """__exit__ exits the StreamContext and clears stream references."""
         mock_stream = MagicMock(spec=torch.cuda.Stream)
@@ -1033,19 +1080,25 @@ class TestCommunicationMixinStreamContext:
                         dyn.__enter__()
 
                         # Verify stream is set
-                        assert dyn._stream is mock_stream
-                        assert dyn._stream_ctx is mock_stream_ctx
+                        assert dyn.torch_stream is mock_stream
+                        assert dyn._stream_ctx is not None
 
                         # Exit the context
                         dyn.__exit__(None, None, None)
 
                         # Assert __exit__ was called on the stream context
-                        mock_stream_ctx.__exit__.assert_called_once_with(
-                            None, None, None
+                        # (ExitStack invokes it via the type, so the mock
+                        # records itself as the first argument).
+                        assert mock_stream_ctx.__exit__.call_count == 1
+                        assert mock_stream_ctx.__exit__.call_args.args[-3:] == (
+                            None,
+                            None,
+                            None,
                         )
 
-                        # Assert stream and context are cleared
-                        assert dyn._stream is None
+                        # Assert streams and context are cleared
+                        assert dyn.torch_stream is None
+                        assert dyn.warp_stream is None
                         assert dyn._stream_ctx is None
 
     def test_stream_property_returns_active_stream(self) -> None:
@@ -1061,16 +1114,19 @@ class TestCommunicationMixinStreamContext:
                     with patch.object(
                         type(dyn), "device", property(lambda s: torch.device("cuda:0"))
                     ):
-                        # Before __enter__, stream is None
+                        # Before __enter__, nothing is active
                         assert dyn.stream is None
+                        assert dyn.torch_stream is None
 
-                        # After __enter__, stream is the mock stream
+                        # After __enter__, the joint context and streams exist
                         dyn.__enter__()
-                        assert dyn.stream is mock_stream
+                        assert dyn.stream is dyn._stream_ctx
+                        assert dyn.torch_stream is mock_stream
 
-                        # After __exit__, stream is None again
+                        # After __exit__, everything clears again
                         dyn.__exit__(None, None, None)
                         assert dyn.stream is None
+                        assert dyn.torch_stream is None
 
     def test_context_manager_protocol(self) -> None:
         """'with dynamics_instance:' works end-to-end."""
@@ -1087,21 +1143,30 @@ class TestCommunicationMixinStreamContext:
                     ):
                         # Use the context manager protocol
                         with dyn:
-                            # Inside the with block, stream should be active
-                            assert dyn.stream is mock_stream
-                            assert dyn._stream_ctx is mock_stream_ctx
+                            # Inside the with block, streams should be active
+                            assert dyn.torch_stream is mock_stream
+                            assert dyn.stream is not None
 
-                        # After exiting, stream should be cleared
+                        # After exiting, everything should be cleared
                         assert dyn.stream is None
-                        assert dyn._stream_ctx is None
+                        assert dyn.torch_stream is None
 
                         # Verify __enter__ and __exit__ were called on the stream context
                         mock_stream_ctx.__enter__.assert_called_once()
-                        mock_stream_ctx.__exit__.assert_called_once()
+                        assert mock_stream_ctx.__exit__.call_count == 1
 
 
 class TestFusedStageStreamContext:
     """Tests for FusedStage.__enter__ / __exit__ stream propagation to sub-stages."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_warp(self):
+        """Mock the warp stream API — real conversion rejects mocked streams."""
+        with patch("nvalchemi.dynamics.base.wp") as mock_wp:
+            mock_wp.stream_from_torch.return_value = MagicMock()
+            mock_wp.ScopedStream.return_value = MagicMock()
+            self.mock_wp = mock_wp
+            yield
 
     def setup_method(self) -> None:
         """Set up test fixtures."""
@@ -1179,12 +1244,12 @@ class TestFusedStageStreamContext:
                     ):
                         with fused:
                             # Inside: all sub-stages share the stream
-                            assert fused.stream is mock_stream
+                            assert fused.torch_stream is mock_stream
                             assert dyn0._stream is mock_stream
                             assert dyn1._stream is mock_stream
 
                         # Outside: everything is cleaned up
-                        assert fused.stream is None
+                        assert fused.torch_stream is None
                         assert dyn0._stream is None
                         assert dyn1._stream is None
 

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -617,8 +617,13 @@ class TestFusedStage:
         with pytest.raises(TypeError, match="other must be a BaseDynamics instance"):
             fused + mixin
 
-    def test_empty_status_mask_skips_update(self) -> None:
-        """Dynamics should not be called if no samples match its status."""
+    def test_empty_status_mask_is_noop_update(self) -> None:
+        """An all-False stage mask must leave positions/velocities untouched.
+
+        The masked update is invoked unconditionally (a data-dependent
+        ``if mask.any():`` would break full-graph compilation) but must be
+        a strict no-op for samples outside the stage's status.
+        """
         dynamics0 = TrackingDynamics(model=self.model)
         dynamics1 = TrackingDynamics(model=self.model)
 
@@ -631,11 +636,13 @@ class TestFusedStage:
 
         fused.step(batch)
 
-        # dynamics0 should not have been called (no samples with status=0)
-        assert len(dynamics0.updated_masks) == 0
+        # dynamics0 is called with an all-False mask (branchless dispatch).
+        assert len(dynamics0.updated_masks) == 1
+        assert not dynamics0.updated_masks[0].any()
 
-        # dynamics1 should have been called
+        # dynamics1 processed every sample.
         assert len(dynamics1.updated_masks) == 1
+        assert dynamics1.updated_masks[0].all()
 
     def test_three_stage_fusion(self) -> None:
         """FusedStage should support three or more sub-stages."""

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -957,10 +957,17 @@ class TestCommunicationMixinStreamContext:
     @pytest.fixture(autouse=True)
     def _mock_warp(self):
         """Mock the warp stream API — real conversion rejects mocked streams."""
-        with patch("nvalchemi.dynamics.base.wp") as mock_wp:
+        with (
+            patch("nvalchemi.dynamics.base.wp") as mock_wp,
+            patch(
+                "torch.cuda.current_stream",
+                return_value=MagicMock(spec=torch.cuda.Stream),
+            ) as mock_current_stream,
+        ):
             mock_wp.stream_from_torch.return_value = MagicMock()
             mock_wp.ScopedStream.return_value = MagicMock()
             self.mock_wp = mock_wp
+            self.mock_current_stream = mock_current_stream
             yield
 
     def setup_method(self) -> None:
@@ -991,6 +998,14 @@ class TestCommunicationMixinStreamContext:
                         # Assert Stream was created with the device
                         mock_stream_cls.assert_called_once_with(
                             device=torch.device("cuda:0")
+                        )
+
+                        # The dedicated stream waits for work submitted before entry.
+                        self.mock_current_stream.assert_called_once_with(
+                            torch.device("cuda:0")
+                        )
+                        mock_stream.wait_stream.assert_called_once_with(
+                            self.mock_current_stream.return_value
                         )
 
                         # Assert torch.cuda.stream() was called with the stream
@@ -1162,7 +1177,13 @@ class TestFusedStageStreamContext:
     @pytest.fixture(autouse=True)
     def _mock_warp(self):
         """Mock the warp stream API — real conversion rejects mocked streams."""
-        with patch("nvalchemi.dynamics.base.wp") as mock_wp:
+        with (
+            patch("nvalchemi.dynamics.base.wp") as mock_wp,
+            patch(
+                "torch.cuda.current_stream",
+                return_value=MagicMock(spec=torch.cuda.Stream),
+            ),
+        ):
             mock_wp.stream_from_torch.return_value = MagicMock()
             mock_wp.ScopedStream.return_value = MagicMock()
             self.mock_wp = mock_wp


### PR DESCRIPTION
## Description

Make `FusedStage.step()` compatible with `torch.compile` and CUDA graphs, and coordinate Torch and Warp work on the same CUDA stream.

Previously, lazy allocations and data-dependent branches inside the fused step prevented full-graph capture, while Warp could launch on a separate stream from Torch and invalidate CUDA-graph capture. This change moves setup outside the compiled region, uses static-shape masked updates, and introduces a joint stream context for both runtimes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Documentation update

## Changes Made

- Restructure the fused dynamics step to avoid lazy allocation and data-dependent control flow in the compiled region.
- Keep autograd inputs and masked updates capture-safe across repeated CUDA-graph replays.
- Run Torch and Warp kernels on one dedicated stream when dynamics is used as a context manager, while binding Warp to the caller's current stream for bare runs.
- Add regression coverage for compilation, masked updates, stream propagation, and context-manager behavior.
- Document the CUDA stream behavior in the dynamics API guidance.

## Testing

- [x] `uv run --extra cu13 pytest test/dynamics/test_single_loop.py -q` (87 passed on NVIDIA GB10)
- [x] Pre-commit hooks pass for all changed files
- [x] New regression tests added
- [ ] Full test suite not run

## Checklist

- [x] I have read and understand the contributing guidelines.
- [ ] `CHANGELOG.md` was not updated.
- [x] I have performed a self-review of the changes.
- [x] Documentation was updated where applicable.

