### PR TITLE
feat(dynamics): make convergence migration compile-safe

### DIFF
--- a/nvalchemi/dynamics/base.py
+++ b/nvalchemi/dynamics/base.py
@@ -1674,13 +1674,16 @@ class BaseDynamics(HookRegistryMixin, _CommunicationMixin):
 
     def _build_context(self, batch: Batch) -> DynamicsContext:
         """Build a dynamics-specific hook context."""
-        if self._last_converged is not None:
+        if self._last_converged is None:
+            _mask = None
+        elif self._last_converged.dtype == torch.bool:
+            # Fused path stores a mask: index extraction breaks the graph.
+            _mask = self._last_converged
+        else:
             _mask = torch.zeros(
                 batch.num_graphs, dtype=torch.bool, device=batch.positions.device
             )
             _mask[self._last_converged] = True
-        else:
-            _mask = None
         return DynamicsContext(
             batch=batch,
             step_count=self.step_count,
@@ -2706,6 +2709,30 @@ class ConvergenceHook:
             1-D integer tensor of converged sample indices, or ``None``
             if no samples satisfy all criteria.
         """
+        converged_mask = self.evaluate_mask(batch)
+
+        if not converged_mask.any():
+            return None
+        return torch.where(converged_mask)[0]
+
+    def evaluate_mask(self, batch: Batch) -> torch.Tensor:
+        """Evaluate all criteria and return a boolean converged mask.
+
+        Branchless, static-shape core of :meth:`evaluate`: no host sync and
+        no data-dependent index extraction, so it can run inside a compiled
+        step (:meth:`FusedStage._step_impl`) without breaking the graph.
+
+        Parameters
+        ----------
+        batch : Batch
+            The current batch of atomic data.
+
+        Returns
+        -------
+        torch.Tensor
+            Boolean tensor of shape ``(B,)``; ``True`` where every
+            criterion is satisfied.
+        """
         n_criteria = len(self.criteria)
         n_graphs = batch.num_graphs
 
@@ -2719,11 +2746,7 @@ class ConvergenceHook:
         for i, criterion in enumerate(self.criteria):
             results[i] = criterion(batch)
 
-        converged_mask = torch.all(results, dim=0)
-
-        if not converged_mask.any():
-            return None
-        return torch.where(converged_mask)[0]
+        return torch.all(results, dim=0)
 
     def __call__(self, ctx: DynamicsContext, stage: Enum) -> None:
         """Evaluate convergence and optionally migrate sample status.
@@ -2743,31 +2766,30 @@ class ConvergenceHook:
             The stage being dispatched.
         """
         batch = ctx.batch
-        converged = self.evaluate(batch)
-        if converged is None:
-            return
 
         if self.source_status is not None and self.target_status is not None:
             if not hasattr(batch, "status") or batch.status is None:
                 return
 
+            # Blend via torch.where: mask indexing and .any() gating would
+            # host-sync and break the compiled graph.
+            converged_mask = self.evaluate_mask(batch)
+
             status = batch.status
             if status.dim() == 2:
                 status = status.squeeze(-1)
+            migrate = converged_mask & (status == self.source_status)
 
-            converged_mask = torch.zeros(
-                batch.num_graphs, dtype=torch.bool, device=status.device
+            flat_status = (
+                batch.status.view(-1) if batch.status.dim() == 2 else batch.status
             )
-            converged_mask[converged] = True
-
-            status_mask = status == self.source_status
-            migrate = converged_mask & status_mask
-
-            if migrate.any():
-                flat_status = (
-                    batch.status.view(-1) if batch.status.dim() == 2 else batch.status
+            flat_status.copy_(
+                torch.where(
+                    migrate,
+                    torch.full_like(flat_status, self.target_status),
+                    flat_status,
                 )
-                flat_status[migrate] = self.target_status
+            )
 
 
 class FusedStage(BaseDynamics):
@@ -3342,23 +3364,18 @@ class FusedStage(BaseDynamics):
         for active_mask, (_, dynamics) in zip(
             stage_active_masks, self.sub_stages, strict=True
         ):
-            converged = dynamics._check_convergence(batch)
-            if converged is None:
+            hook = dynamics.convergence_hook
+            if hook is None:
                 dynamics._last_converged = None
                 continue
 
-            stage_converged = torch.zeros(
-                batch.num_graphs, dtype=torch.bool, device=batch.device
-            )
-            stage_converged[converged] = True
-            stage_converged &= active_mask
-
-            if not stage_converged.any():
-                dynamics._last_converged = None
-                continue
-
-            dynamics._last_converged = torch.where(stage_converged)[0]
-            dynamics._call_hooks(DynamicsStage.ON_CONVERGE, batch)
+            # Gating on `stage_converged.any()` would host-sync every step,
+            # so registered ON_CONVERGE hooks always fire and must consult
+            # ctx.converged_mask themselves.
+            stage_converged = hook.evaluate_mask(batch) & active_mask
+            dynamics._last_converged = stage_converged
+            if dynamics._has_hooks_for_stage(DynamicsStage.ON_CONVERGE):
+                dynamics._call_hooks(DynamicsStage.ON_CONVERGE, batch)
 
         self.step_count += 1
         for _, dynamics in self.sub_stages:

--- a/nvalchemi/hooks/_registry.py
+++ b/nvalchemi/hooks/_registry.py
@@ -152,6 +152,32 @@ class HookRegistryMixin:
             workflow=self,
         )
 
+    def _has_hooks_for_stage(self, stage: Enum) -> bool:
+        """Return whether any registered hook would fire at *stage*.
+
+        A static (data-independent) query used by compiled step paths to
+        skip stage dispatch entirely when no hook is registered, without
+        consulting tensor values.
+
+        Parameters
+        ----------
+        stage : Enum
+            Workflow stage to query.
+
+        Returns
+        -------
+        bool
+            ``True`` if at least one hook is registered for *stage*.
+        """
+        for hook in self.hooks:
+            runs_on_stage = getattr(hook, "_runs_on_stage", None)
+            if runs_on_stage is not None:
+                if runs_on_stage(stage):
+                    return True
+            elif stage == hook.stage:
+                return True
+        return False
+
     def _call_hooks(self, stage: Enum, batch: Batch | None) -> None:
         """Call hooks registered for the given stage, gated by frequency.
 

--- a/test/dynamics/test_single_loop.py
+++ b/test/dynamics/test_single_loop.py
@@ -302,12 +302,16 @@ class TestConvergenceHook:
         assert (batch.status == 1).all()
 
     def test_no_forces_raises_key_error(self) -> None:
-        """Hook should raise KeyError if batch has no forces attribute."""
+        """Hook should raise KeyError if batch has no forces attribute.
+
+        Migration statuses are set so the hook evaluates its criteria;
+        without them ``__call__`` is a no-op and never touches the batch.
+        """
         batch = create_batch_with_status(n_graphs=3)
         batch.status = torch.tensor([0, 0, 0])
         batch.forces = None  # Clear forces
 
-        hook = ConvergenceHook()
+        hook = ConvergenceHook(source_status=0, target_status=1)
         ctx = DynamicsContext(batch=batch, step_count=0)
 
         with pytest.raises(KeyError, match="forces"):
@@ -1604,11 +1608,13 @@ class _TrackingHook:
         self.frequency = frequency
         self.call_count = 0
         self.call_step_counts: list[int] = []
+        self.converged_masks: list[torch.Tensor | None] = []
 
     def __call__(self, ctx: DynamicsContext, stage: DynamicsStage) -> None:
-        """Record the call and current step count."""
+        """Record the call, step count, and converged mask."""
         self.call_count += 1
         self.call_step_counts.append(ctx.step_count)
+        self.converged_masks.append(ctx.converged_mask)
 
 
 # -----------------------------------------------------------------------------
@@ -1757,11 +1763,14 @@ class TestFusedStageSubstageHooks:
 
         assert hook.call_count == 1
 
-    def test_substage_on_converge_does_not_fire_when_not_converged(self) -> None:
-        """ON_CONVERGE hooks should NOT fire when samples are not converged.
+    def test_substage_on_converge_mask_all_false_when_not_converged(self) -> None:
+        """ON_CONVERGE hooks fire unconditionally but see an all-False mask.
 
-        Uses threshold of 0 so DemoModel forces never satisfy convergence,
-        and verifies the ON_CONVERGE hook did not fire.
+        Gating the dispatch on ``converged.any()`` would be a per-step host
+        sync inside the compiled step, so registered ON_CONVERGE hooks are
+        always called and must consult ``ctx.converged_mask``. With a
+        threshold of 0 the DemoModel forces never converge, so the mask
+        must be all-False.
         """
         dynamics0 = BaseDynamics(
             model=self.model,
@@ -1778,7 +1787,9 @@ class TestFusedStageSubstageHooks:
 
         fused.step(batch)
 
-        assert hook.call_count == 0
+        assert hook.call_count == 1
+        assert hook.converged_masks[-1] is not None
+        assert not hook.converged_masks[-1].any()
 
     def test_on_converge_only_fires_for_active_samples(self) -> None:
         """ON_CONVERGE converged_mask should only include samples active in that stage.


### PR DESCRIPTION
# ALCHEMI Toolkit Pull Request

## Description

Make convergence evaluation and status migration compile-safe so multi-stage pipelines such as FIRE2 to NVT can keep the convergence machinery inside the compiled region.

The previous path performed host-synchronizing, data-dependent operations on every step: `evaluate()` gated on `converged_mask.any()` and returned dynamically shaped `torch.where(mask)[0]` indices, migration used boolean fancy indexing behind another `.any()`, and the fused step conditionally dispatched `ON_CONVERGE` hooks based on a host-evaluated tensor. These operations introduce graph breaks or per-step GPU-to-CPU stalls.

This PR is stacked on #168. Until that PR merges, GitHub will show the parent compile-step commits in this PR as well.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Depends on #168.

## Changes Made

- Add `ConvergenceHook.evaluate_mask()`, a branchless core that returns a static-shape boolean `(B,)` mask without host synchronization, while retaining `evaluate()` as the index-returning wrapper for uncompiled callers.
- Blend migrated statuses with `torch.where` instead of `.any()` gating and boolean fancy indexing.
- Store per-substage convergence masks in `_last_converged` and dispatch registered `ON_CONVERGE` hooks unconditionally with the current mask in `ctx.converged_mask`.
- Add a static hook-stage lookup used to decide whether an `ON_CONVERGE` hook is registered without inspecting tensor data.
- Update fused-stage regression tests for all-false masks and stage-local active masks.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Focused verification performed for this PR:

```text
uv run --extra cu13 pytest --no-cov \
  test/dynamics/test_single_loop.py \
  test/dynamics/test_base.py \
  test/hooks/test_registry.py
# 189 passed

uv run --extra cu13 ruff check \
  nvalchemi/dynamics/base.py \
  nvalchemi/hooks/_registry.py \
  test/dynamics/test_single_loop.py
# All checks passed

uv run --extra cu13 ruff format --check \
  nvalchemi/dynamics/base.py \
  nvalchemi/hooks/_registry.py \
  test/dynamics/test_single_loop.py
# 3 files already formatted
```

The broader compiled FIRE2 to NVT benchmark measured 7 graph breaks, matching single-stage NVT, with convergence and migration contributing zero breaks. The compiled default run measured 14.0 ms/step versus 21.8 ms/step eager. Those benchmark measurements were not rerun during this publishing pass.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The user-visible contract change is that registered fused-stage `ON_CONVERGE` hooks now run every step and must consult `ctx.converged_mask`; an all-false mask means no samples converged during that step. The ordinary uncompiled `BaseDynamics` path retains its existing conditional callback behavior.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
