### PR TITLE
feat(gen): the AtomisticGenerator driver and generative model contract (1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Add support for PEFT fine-tuning within `FineTuningStrategy`, including
   LoRA workflows with `LoRAConfig`, `load_peft_checkpoint_into_model`,
   and base-model fingerprint checks for PEFT checkpoint loading.
+- Toolkit-level generative API (`nvalchemi.gen`): an abstract
+  `AtomGenerator` interface for generation with a fixed condition →
+  generate pipeline — the raw sample is materialized into a `Batch` inline,
+  before `AFTER_GENERATE` hooks fire — lifecycle hooks sharing a per-call
+  `GenerationContext`, `stream()`, and session context managers (dedicated
+  CUDA stream, session RNG, lazy `torch.compile`). Generating functions
+  return `TensorDict` samples.
 - Domain decomposition for distributed inference and dynamics: a spatial halo
   strategy and a graph-parallel strategy, both driven by a declarative
   `MLIPSpec` a model wrapper publishes as `distribution_spec`. Ewald, PME,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   `GenerationContext`, `stream()`, and session context managers (dedicated
   CUDA stream, session RNG, lazy `torch.compile`). Generating functions
   return `TensorDict` samples.
+- Demo generative models (`nvalchemi.models.gen.demo`): `DemoGANModel` and
+  `DemoDiffusionModel` — minimal `GenerativeModelMixin` placeholders for
+  testing and debugging (the generative counterpart to
+  `DemoModel`/`DemoModelWrapper`) — plus `demo_nonparametric_generation`, a
+  synthetic-structure source for tests and debugging.
 - Domain decomposition for distributed inference and dynamics: a spatial halo
   strategy and a graph-parallel strategy, both driven by a declarative
   `MLIPSpec` a model wrapper publishes as `distribution_spec`. Ewald, PME,

--- a/nvalchemi/gen/__init__.py
+++ b/nvalchemi/gen/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Toolkit-level generative API surface.
+
+This package provides the abstract
+:class:`~nvalchemi.gen.generator.AtomGenerator` inference driver — a fixed
+condition → generate pipeline with lifecycle hooks
+(:class:`~nvalchemi.gen.stages.GenerationStage`,
+:class:`~nvalchemi.hooks.GenerationContext`).
+"""
+
+from __future__ import annotations
+
+from nvalchemi.gen.enums import GenerativeIntent, Modality
+from nvalchemi.gen.generator import (
+    AtomGenerator,
+    GeneratingFunction,
+    default_condition,
+)
+from nvalchemi.gen.stages import GenerationStage
+from nvalchemi.hooks import GenerationContext
+
+__all__ = [
+    "AtomGenerator",
+    "GenerationContext",
+    "GenerationStage",
+    "GenerativeIntent",
+    "GeneratingFunction",
+    "Modality",
+    "default_condition",
+]

--- a/nvalchemi/gen/enums.py
+++ b/nvalchemi/gen/enums.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Modality and intent enums for the toolkit-level generative API.
+
+The enums here describe *what* a generative model produces (its
+modalities) and *how* it is used (its intents). They are deliberately
+generic. ``Modality`` enumerates the artifact kinds a
+generative model may ingest or emit; ``GenerativeIntent`` enumerates the
+operational roles a model can play. A
+:class:`~nvalchemi.models.gen.base.GenerativeModelConfig` binds a set of
+intents to the modalities each intent operates on.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ["GenerativeIntent", "Modality"]
+
+
+class Modality(str, Enum):
+    """Artifact kinds a generative model may ingest or emit.
+
+    The set is intentionally broad so the same config schema can describe
+    atomic point clouds, periodic crystals, and non-atomic modalities (text,
+    spectra, embeddings, images). Atomic generative models in this toolkit
+    typically operate on :attr:`point_cloud`, :attr:`graph`, or
+    :attr:`crystal`.
+
+    Attributes
+    ----------
+    POINT_CLOUD
+        An unordered set of atoms without connectivity (coordinates + numbers).
+    GRAPH
+        An atomic graph with explicit edges (a neighbor list).
+    CRYSTAL
+        A periodic crystal: atoms plus a lattice/cell and periodicity flags.
+    TEXT
+        A text / SMILES / string conditioning artifact.
+    SPECTRA
+        A one-dimensional spectroscopic or signal artifact.
+    EMBEDDING
+        A dense latent embedding artifact.
+    IMAGE
+        A gridded image artifact.
+    """
+
+    POINT_CLOUD = "point_cloud"
+    GRAPH = "graph"
+    CRYSTAL = "crystal"
+    TEXT = "text"
+    SPECTRA = "spectra"
+    EMBEDDING = "embedding"
+    IMAGE = "image"
+
+
+class GenerativeIntent(str, Enum):
+    """Operational roles a generative model can play.
+
+    Intents are split into **output-producing** roles (the model *creates* an
+    artifact) and **input-facing** roles (the model *consumes* an artifact as a
+    condition, completion target, or transformation input).
+    :class:`~nvalchemi.models.gen.base.GenerativeModelConfig` uses this
+    classification to derive :attr:`input_modalities` and
+    :attr:`output_modalities`.
+
+    Attributes
+    ----------
+    CREATE
+        Generate an artifact from a prior (unconditional generation).
+    CONDITION
+        Generate an artifact conditioned on a given input artifact.
+    COMPLETE
+        Complete a partially-specified artifact.
+    TRANSFORM
+        Transform one artifact into another (e.g. map a structure to a latent).
+    CONNECT
+        Connect two artifacts (e.g. embed two modalities into a shared space).
+    DECODE
+        Decode a latent/embedding into a concrete artifact.
+    SAMPLE
+        Draw samples from a learned distribution.
+    PROPOSE
+        Propose candidate artifacts (e.g. crystal structure proposal).
+    """
+
+    CREATE = "create"
+    CONDITION = "condition"
+    COMPLETE = "complete"
+    TRANSFORM = "transform"
+    CONNECT = "connect"
+    DECODE = "decode"
+    SAMPLE = "sample"
+    PROPOSE = "propose"

--- a/nvalchemi/gen/generator.py
+++ b/nvalchemi/gen/generator.py
@@ -1,0 +1,846 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The :class:`AtomGenerator`: the toolkit's abstract interface for generative inference.
+
+Conceptually, :class:`AtomGenerator` is a high-level wrapper that ensures
+generative _workflows_ can be readily pipelined into the general dynamics
+interface, as well as the ability to generate samples. It is intentionally
+kept abstract so as to support a wide range of generative modeling
+approaches — GANs, VAEs, flow matching and diffusion, genetic algorithms, and so on.
+
+It wires a generative ``model`` to a user-supplied :class:`GeneratingFunction`
+— the callable that owns the family-specific generation procedure — and maps
+the result to a :class:`~nvalchemi.data.Batch`. The fixed pipeline per
+:meth:`AtomGenerator.sample` is::
+
+    BEFORE_CONDITION    hooks
+                        ctx.batch = condition(ctx.cond, num_samples_per_batch)
+    AFTER_CONDITION     hooks
+                        sample = generator_func(model, ..., cond=ctx.batch)
+                        ctx.batch = to_batch(sample, ctx.batch)  # materialize
+    AFTER_GENERATE      hooks  (filtering = subsetting ctx.batch)
+    return ctx.batch
+
+Hooks registered at the three
+:class:`~nvalchemi.gen.stages.GenerationStage` points all receive one shared
+:class:`~nvalchemi.hooks.GenerationContext` per call and mutate it by
+replacing its fields; the ``AtomGenerator`` re-reads the context after each
+dispatch. See the stage enum for what may change where.
+
+Model contract — defaults everywhere
+------------------------------------
+``model`` is typed ``Any``: no protocol accurately describes a fully
+defaulted contract. What the pipeline reads from the model:
+
+* ``condition(cond, num_samples)`` — optional; falls back to
+  :func:`~nvalchemi.gen.default_condition` (passthrough + tile).
+* ``generate(*, num_samples, rng, cond, **kwargs)`` — required only when no
+  ``generator_func`` is supplied (checked by a construction validator).
+* ``to_batch(sample, batch)`` — required only when no ``output_to_batch_func``
+  is supplied (checked by a construction validator).
+
+``forward`` / ``adapt_output`` are never read by the ``AtomGenerator``; they
+belong to the model-side contract
+(:class:`~nvalchemi.models.gen.base.GenerativeModelMixin`) that typed
+generating functions rely on.
+
+Composition examples
+--------------------
+**GAN** (noise → net, one forward pass)::
+
+    def gan_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
+        z = torch.randn(num_samples, model.latent_dim, generator=rng)
+        return TensorDict({"x1": model.decode(z)}, batch_size=[num_samples])
+
+    gan = AtomGenerator(
+        model=GANModel(), generator_func=gan_generate,
+        output_to_batch_func=to_batch,
+    )
+
+**Streaming** — one ``sample()`` call per conditioning item; ``None`` means
+repeated unconditional draws::
+
+    for batch in gan.stream(conds=None, max_batches=10):
+        ...
+
+**Sessions: streams, RNG, and compile** — an ``AtomGenerator`` is a context
+manager. Entering a session (``with gen:``) creates a dedicated CUDA stream
+when the model is CUDA-resident, seeds a session-scoped
+:class:`torch.Generator` (advanced per draw), compiles the generating
+function when ``compile_generate`` is set, and opens context-manager hooks;
+exiting unwinds all of it::
+
+    with gen.compile(fullgraph=True):
+        for batch in gen.stream(conds):
+            ...
+"""
+
+from __future__ import annotations
+
+import inspect
+import itertools
+from collections.abc import Iterator
+from contextlib import nullcontext
+from typing import Any, Callable, Protocol, runtime_checkable
+
+import torch
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from tensordict import TensorDict, TensorDictBase
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.gen.stages import GenerationStage
+from nvalchemi.hooks import GenerationContext, Hook, HookRegistryMixin
+
+__all__ = ["GeneratingFunction", "AtomGenerator", "default_condition"]
+
+
+@runtime_checkable
+class GeneratingFunction(Protocol):
+    """Callable that encapsulates a family-specific generation strategy.
+
+    A :class:`GeneratingFunction` samples from a generative model and emits a
+    sample :class:`~tensordict.TensorDict` — a collection of named tensors
+    (positions, atom types, lattice, ...), so multi-tensor families are
+    first-class. It is the single extension point that lets the
+    :class:`AtomGenerator` support diffusion, flow matching, GANs, VAEs,
+    normalizing flows, and population-based methods without the toolkit
+    hardcoding any one workflow.
+
+    The contract is deliberately minimal — one calling
+    convention for every family:
+
+    * ``model`` — the generative model (the only required argument).
+    * ``num_samples`` — number of independent draws requested for this call.
+    * ``rng`` — optional :class:`torch.Generator` for reproducibility.
+    * ``cond`` — the conditioning batch built by ``model.condition`` (or the
+      module-level default), ``None`` for unconditional generation.
+    * ``**kwargs`` — family-specific per-call options (e.g. ``mask`` for
+      inpainting). Family-specific *config* a generating function needs
+      (e.g. a diffusion schedule/sampler) is bound in the closure via an
+      importable factory, not threaded by the :class:`AtomGenerator`.
+
+    There is exactly one calling convention — no signature inspection or
+    dispatch in the core. External sampler ecosystems (e.g. physicsnemo
+    diffusion samplers) plug in through a thin user-side adapter function
+    with the same signature.
+
+    The returned :class:`~tensordict.TensorDict` is mapped to a
+    :class:`~nvalchemi.data.Batch` by the :class:`AtomGenerator` via
+    ``output_to_batch_func`` or ``model.to_batch``.
+
+    A model may alternatively provide the same contract as a ``generate``
+    method, minus the leading ``model`` argument; the :class:`AtomGenerator`
+    calls that fallback when no ``generator_func`` is supplied.
+    """
+
+    def __call__(
+        self,
+        model: Any,
+        *,
+        num_samples: int = 1,
+        rng: torch.Generator | None = None,
+        cond: Any = None,
+        **kwargs: Any,
+    ) -> TensorDict: ...
+
+
+def default_condition(cond: Any, num_samples: int = 1) -> Any:
+    """Default conditioning: pass through an already-built batch, tiled.
+
+    Mirrors the default
+    :meth:`~nvalchemi.models.gen.base.GenerativeModelMixin.condition`; the
+    :class:`AtomGenerator` falls back to this function when the model defines
+    no ``condition`` of its own.
+
+    Parameters
+    ----------
+    cond
+        An already-built :class:`~nvalchemi.data.Batch` or
+        :class:`~nvalchemi.data.AtomicData`, another tensor container (e.g.
+        :class:`~tensordict.TensorDict`), or ``None`` for unconditional
+        generation.
+    num_samples
+        Number of independent draws per conditioning graph.
+
+    Returns
+    -------
+    Any
+        For a :class:`~nvalchemi.data.Batch` /
+        :class:`~nvalchemi.data.AtomicData`, a ``Batch`` with each
+        conditioning graph repeated ``num_samples`` times; ``None`` passes
+        through as ``None``; any other container passes through unchanged
+        (replication semantics for non-batch containers belong to the model
+        or generating function).
+
+    Raises
+    ------
+    ValueError
+        If ``num_samples`` is not positive.
+    """
+    if cond is None:
+        return None
+    if num_samples < 1:
+        raise ValueError(f"num_samples must be positive, got {num_samples}")
+    if isinstance(cond, Batch):
+        graphs = [
+            cond.get_data(i) for i in range(cond.num_graphs) for _ in range(num_samples)
+        ]
+        return Batch.from_data_list(graphs, device=cond.device)
+    if isinstance(cond, AtomicData):
+        return Batch.from_data_list([cond] * num_samples, device=cond.device)
+    return cond
+
+
+class AtomGenerator(BaseModel, HookRegistryMixin):
+    """Abstract generative inference pipeline.
+
+    Attributes
+    ----------
+    model
+        The generative model. Typed ``Any`` with a documented contract (see
+        the module docstring): ``condition``/``generate``/``to_batch`` are
+        all optional-with-default or conditionally required;
+        ``model.model_config`` may supply default field declarations.
+        Non-serializable (weights live in the checkpoint machinery).
+    generator_func
+        User-supplied :class:`GeneratingFunction`; takes precedence over
+        ``model.generate``. Non-serializable.
+    output_to_batch_func
+        Optional callable ``output_to_batch_func(sample, batch) -> Batch``
+        overriding ``model.to_batch`` for mapping a sample
+        :class:`~tensordict.TensorDict` to a :class:`~nvalchemi.data.Batch`.
+        Swapping it lets the same model emit a ``Batch`` for dynamics or a
+        different artifact for file-writing.
+    hooks
+        Generation hooks, each with a :class:`GenerationStage` ``stage``.
+        Validated at registration; see :class:`~nvalchemi.hooks.HookRegistryMixin`.
+    consumes_fields
+        Batch fields this generator's conditioning reads (empty means
+        unconditional). Defaults from ``model.model_config`` when the model
+        provides one; required by
+        :class:`~nvalchemi.gen.pipeline.GenerationPipeline` for link
+        validation.
+    produces_fields
+        Batch fields this generator's output carries (written or forwarded).
+        Defaults from ``model.model_config`` when present.
+    num_samples_per_batch
+        Independent draws **per conditioning entry**, fed to
+        ``model.condition``. The model emits a batch of
+        ``len(cond) * num_samples_per_batch`` samples per call.
+    seed
+        Optional base seed. Inside a session (``with gen:``) one
+        :class:`torch.Generator` is seeded at entry and advanced per draw;
+        outside a session each call derives
+        ``torch.Generator().manual_seed(seed + step_count)``. A per-call
+        ``rng=`` kwarg overrides both.
+    step_count
+        Runtime counter of completed generation calls; drives hook frequency
+        gating. Excluded from serialization.
+    compile_generate
+        Compile the generating function with ``torch.compile`` — immediately
+        via :meth:`compile`, or lazily at session entry. Default ``False``.
+    compile_kwargs
+        Keyword arguments forwarded to ``torch.compile``.
+
+    Notes
+    -----
+    ``model`` and ``generator_func`` are held as arbitrary types
+    (``arbitrary_types_allowed=True``); they are the non-serializable fields.
+
+    ``AtomGenerator`` is a context manager (``with gen:``): a session owns a
+    dedicated CUDA stream (when the model is CUDA-resident), a
+    session-scoped RNG, lazy compilation, and context-manager hooks. See
+    :meth:`__enter__`.
+
+    At least one generation source (``generator_func`` or ``model.generate``)
+    and one materialization target (``output_to_batch_func`` or
+    ``model.to_batch``) are required; construction validators
+    enforce both.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    model: Any
+    generator_func: GeneratingFunction | None = None
+    output_to_batch_func: Callable[[TensorDict, Any], Batch] | None = None
+    hooks: list[Hook] = Field(
+        default_factory=list,
+        description=(
+            "Generation hooks, fired at GenerationStage points with a shared "
+            "GenerationContext per call."
+        ),
+    )
+    consumes_fields: frozenset[str] | None = Field(
+        default=None,
+        description=(
+            "Batch fields conditioning reads (empty = unconditional). "
+            "Defaults from model.model_config when available."
+        ),
+    )
+    produces_fields: frozenset[str] | None = Field(
+        default=None,
+        description=(
+            "Batch fields the output carries (written or forwarded). "
+            "Defaults from model.model_config when available."
+        ),
+    )
+    num_samples_per_batch: int = Field(
+        default=1,
+        ge=1,
+        description="Independent draws per conditioning entry, fed to model.condition.",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Base seed for per-draw RNGs (seed + step_count per call).",
+    )
+    step_count: int = Field(
+        default=0,
+        ge=0,
+        exclude=True,
+        description="Runtime counter of completed generation calls (hook frequency).",
+    )
+    compile_generate: bool = Field(
+        default=False,
+        description=(
+            "Compile the generating function with torch.compile (immediate via "
+            "compile(), or lazily at session entry)."
+        ),
+    )
+    compile_kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Keyword arguments forwarded to torch.compile; validated against "
+            "its signature at construction and in compile()."
+        ),
+    )
+
+    @property
+    def _stage_type(self) -> type[GenerationStage]:
+        """Hook stage enum accepted by this engine (see :class:`HookRegistryMixin`).
+
+        A property rather than a class attribute: pydantic collects the
+        mixin's ``_stage_type`` annotation as a private attribute initialised
+        to ``None``, and a plain class assignment does not override that on
+        instances.
+        """
+        return GenerationStage
+
+    def model_post_init(self, __context: Any) -> None:
+        """Register hooks (validating stages) and initialize run state.
+
+        Hook ``stage`` values arriving as raw ints or name strings (e.g.
+        rehydrated from a spec) are coerced to :class:`GenerationStage`
+        before registration.
+        """
+        for hook in self.hooks:
+            stage = getattr(hook, "stage", None)
+            if isinstance(stage, str):
+                hook.stage = GenerationStage[stage]
+            elif isinstance(stage, int):
+                hook.stage = GenerationStage(stage)
+        self._init_hooks(list(self.hooks))
+        self._ctx: GenerationContext | None = None
+        self._stream: torch.cuda.Stream | None = None
+        self._stream_ctx: Any = None
+        self._session_rng: torch.Generator | None = None
+        self._compiled_generate: Any = None
+
+    @model_validator(mode="after")
+    def _require_generation_source(self) -> AtomGenerator:
+        """Ensure a generation source is available.
+
+        Returns
+        -------
+        AtomGenerator
+            The validated generator.
+
+        Raises
+        ------
+        TypeError
+            If neither ``generator_func`` nor a callable ``model.generate``
+            is present.
+        """
+        if self.generator_func is None and not callable(
+            getattr(self.model, "generate", None)
+        ):
+            raise TypeError(
+                "AtomGenerator requires a generation source: pass generator_func= "
+                "or implement model.generate(*, num_samples, rng, cond, **kwargs)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_materialization(self) -> AtomGenerator:
+        """Ensure a materialization target is available.
+
+        Returns
+        -------
+        AtomGenerator
+            The validated generator.
+
+        Raises
+        ------
+        TypeError
+            If neither ``output_to_batch_func`` nor a callable
+            ``model.to_batch`` is present.
+        """
+        if self.output_to_batch_func is None and not callable(
+            getattr(self.model, "to_batch", None)
+        ):
+            raise TypeError(
+                "AtomGenerator requires a materialization target: pass "
+                "output_to_batch_func= or implement model.to_batch(sample, batch)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _default_field_declarations(self) -> AtomGenerator:
+        """Default field declarations from ``model.model_config`` when present.
+
+        Explicit constructor values always win; declarations stay ``None``
+        (undeclared) when the model carries no config or its config has no
+        such attributes.
+
+        Returns
+        -------
+        AtomGenerator
+            The generator with declarations defaulted.
+        """
+        config = getattr(self.model, "model_config", None)
+        if config is not None:
+            consumes = getattr(config, "consumes_fields", None)
+            if self.consumes_fields is None and consumes is not None:
+                self.consumes_fields = frozenset(consumes)
+            produces = getattr(config, "produces_fields", None)
+            if self.produces_fields is None and produces is not None:
+                self.produces_fields = frozenset(produces)
+        return self
+
+    @staticmethod
+    def _check_compile_kwargs(kwargs: dict[str, Any]) -> None:
+        """Raise ``ValueError`` for kwargs that are not ``torch.compile`` keywords.
+
+        Parameters
+        ----------
+        kwargs
+            The kwargs to check against the installed ``torch.compile``
+            signature.
+
+        Raises
+        ------
+        ValueError
+            If a key is not a keyword argument of ``torch.compile``, or is
+            ``model`` (the compile target, filled by :meth:`compile` with the
+            generating function).
+        """
+        if not kwargs:
+            return
+        if "model" in kwargs:
+            raise ValueError(
+                "compile_kwargs must not contain 'model': compile() passes the "
+                "generating function as the torch.compile target."
+            )
+        params = inspect.signature(torch.compile).parameters
+        valid = {
+            name
+            for name, param in params.items()
+            if param.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        invalid = set(kwargs) - valid
+        if invalid:
+            raise ValueError(
+                f"compile_kwargs {sorted(invalid)} are not keyword arguments of "
+                f"torch.compile; valid options: {sorted(valid)}."
+            )
+
+    @model_validator(mode="after")
+    def _validate_compile_kwargs(self) -> AtomGenerator:
+        """Check ``compile_kwargs`` against the installed ``torch.compile`` signature.
+
+        Returns
+        -------
+        AtomGenerator
+            The validated generator.
+        """
+        self._check_compile_kwargs(self.compile_kwargs)
+        return self
+
+    def compile(self, **kwargs: Any) -> AtomGenerator:
+        """Compile the generating function with ``torch.compile``.
+
+        Merges *kwargs* with :attr:`compile_kwargs` (values passed here win),
+        sets :attr:`compile_generate`, and wraps the resolved generating
+        function (``generator_func``, or ``model.generate`` when no
+        ``generator_func`` is set). Idempotent in intent but **will**
+        re-compile if called again (e.g. with different kwargs).
+
+        The compiled unit is deliberately the generating function only:
+        conditioning, materialization, and hook dispatch stay eager (they
+        build data structures — graph breaks anyway). ``torch.compile`` on an
+        arbitrary user callable is best-effort; non-tensor-pure code will
+        graph-break. Users with exotic generating functions can instead
+        compile their model themselves.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to ``torch.compile``.
+
+        Returns
+        -------
+        AtomGenerator
+            This instance, for fluent chaining.
+        """
+        merged = {**self.compile_kwargs, **kwargs}
+        self._check_compile_kwargs(merged)
+        self.compile_kwargs = merged
+        self.compile_generate = True
+        target = (
+            self.generator_func
+            if self.generator_func is not None
+            else self.model.generate
+        )
+        self._compiled_generate = torch.compile(target, **merged)
+        return self
+
+    def _infer_device(self) -> torch.device | None:
+        """Best-effort device inference from the model (parameters first).
+
+        Returns
+        -------
+        torch.device | None
+            The model's device, or ``None`` when it cannot be inferred.
+        """
+        model = self.model
+        if isinstance(model, torch.nn.Module):
+            try:
+                return next(model.parameters()).device
+            except StopIteration:
+                pass
+        device = getattr(model, "device", None)
+        return device if isinstance(device, torch.device) else None
+
+    def __enter__(self) -> AtomGenerator:
+        """Enter a generation session.
+
+        Creates and enters a dedicated CUDA stream when the model is
+        CUDA-resident (skipped when a pipeline has already supplied one),
+        seeds the session RNG from :attr:`seed`, compiles the generating
+        function when :attr:`compile_generate` is set, and opens any
+        context-manager hooks.
+
+        Returns
+        -------
+        AtomGenerator
+            This instance.
+        """
+        if self._stream is None:
+            device = self._infer_device()
+            if device is not None and device.type == "cuda":
+                self._stream = torch.cuda.Stream(device=device)
+                self._stream_ctx = torch.cuda.stream(self._stream)
+                self._stream_ctx.__enter__()
+        if self.seed is not None and self._session_rng is None:
+            device = self._infer_device()
+            rng_device = (
+                device if device is not None and device.type == "cuda" else "cpu"
+            )
+            self._session_rng = torch.Generator(device=rng_device).manual_seed(
+                self.seed
+            )
+        if self.compile_generate and self._compiled_generate is None:
+            self.compile()
+        for hook in self.hooks:
+            enter = getattr(hook, "__enter__", None)
+            if enter is not None:
+                enter()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the session: close hooks, exit the stream, drop session RNG.
+
+        Parameters
+        ----------
+        exc_type, exc_val, exc_tb
+            The active exception, if any.
+        """
+        for hook in self.hooks:
+            exit_ = getattr(hook, "__exit__", None)
+            if exit_ is not None:
+                exit_(None, None, None)
+            else:
+                close = getattr(hook, "close", None)
+                if close is not None:
+                    close()
+        if self._stream_ctx is not None:
+            self._stream_ctx.__exit__(exc_type, exc_val, exc_tb)
+        self._stream = None
+        self._stream_ctx = None
+        self._session_rng = None
+
+    def _build_context(self, batch: Batch | None) -> GenerationContext:
+        """Return the live per-call context built by :meth:`sample`.
+
+        Hooks always see the same context object within a call, so mutations
+        made at one stage are visible to later stages and to the core steps
+        in between. Outside a call, a minimal context is built on demand.
+
+        Parameters
+        ----------
+        batch : Batch | None
+            Current batch; used only when no per-call context is live.
+
+        Returns
+        -------
+        GenerationContext
+            The live or freshly built context.
+        """
+        ctx = getattr(self, "_ctx", None)
+        if ctx is not None:
+            return ctx
+        from nvalchemi.training.distributed import get_rank
+
+        return GenerationContext(
+            batch=batch,
+            model=self.model,
+            global_rank=get_rank(None),
+            workflow=self,
+            step_count=self.step_count,
+        )
+
+    def _generate(
+        self, ctx: GenerationContext, num_samples: int, **kwargs: Any
+    ) -> TensorDict:
+        """Invoke the generating function and enforce the TensorDict contract.
+
+        Parameters
+        ----------
+        ctx
+            The live generation context (``ctx.batch`` is the conditioning
+            batch).
+        num_samples
+            Number of independent draws requested for this call.
+        **kwargs
+            Per-call options forwarded to the generating function; ``rng``
+            is consumed here.
+
+        Returns
+        -------
+        TensorDict
+            The sample as a collection of named tensors.
+
+        Raises
+        ------
+        TypeError
+            If the generating function does not return a TensorDict.
+        """
+        rng = kwargs.pop("rng", None)
+        if rng is None:
+            if self._session_rng is not None:
+                rng = self._session_rng
+            elif self.seed is not None:
+                rng = torch.Generator().manual_seed(self.seed + ctx.step_count)
+        if self.generator_func is not None:
+            gen_fn = self._compiled_generate or self.generator_func
+            sample = gen_fn(
+                self.model,
+                num_samples=num_samples,
+                rng=rng,
+                cond=ctx.batch,
+                **kwargs,
+            )
+        else:
+            gen_fn = self._compiled_generate or self.model.generate
+            sample = gen_fn(
+                num_samples=num_samples,
+                rng=rng,
+                cond=ctx.batch,
+                **kwargs,
+            )
+        if not isinstance(sample, TensorDictBase):
+            raise TypeError(
+                "Generating functions must return a TensorDict of named sample "
+                f"tensors, got {type(sample).__name__}. Wrap the output, e.g. "
+                "TensorDict({'x1': x1}, batch_size=[x1.shape[0]])."
+            )
+        return sample
+
+    def sample(
+        self,
+        cond: Any = None,
+        *,
+        num_samples_per_batch: int | None = None,
+        **kwargs: Any,
+    ) -> Batch:
+        """Generate samples for a conditioning spec.
+
+        Runs the fixed pipeline (condition → generate, with the raw sample
+        materialized into a :class:`~nvalchemi.data.Batch` as part of the
+        generate step) with hook dispatch at the three
+        :class:`~nvalchemi.gen.stages.GenerationStage` points, sharing one
+        :class:`~nvalchemi.hooks.GenerationContext` across the call.
+
+        Parameters
+        ----------
+        cond
+            Conditioning input — a :class:`~nvalchemi.data.Batch`, another
+            tensor container, or ``None`` for unconditional generation.
+            Passed to ``model.condition`` (or the module-level default) to
+            build the conditioning batch.
+        num_samples_per_batch
+            Per-call override for :attr:`num_samples_per_batch` (draws per
+            conditioning entry).
+        **kwargs
+            Per-call options forwarded to the generating function (e.g.
+            ``mask`` for inpainting); ``rng`` is consumed here.
+
+        Returns
+        -------
+        Batch
+            The generated batch — post-filter, so possibly with fewer graphs
+            than were sampled. (A filter that rejects every graph currently
+            raises ``IndexError``: :class:`~nvalchemi.data.Batch` does not
+            support zero-graph selections.)
+        """
+        from nvalchemi.training.distributed import get_rank
+
+        ctx = GenerationContext(
+            batch=None,
+            model=self.model,
+            global_rank=get_rank(None),
+            workflow=self,
+            cond=cond,
+            step_count=self.step_count,
+        )
+        self._ctx = ctx
+        try:
+            self._call_hooks(GenerationStage.BEFORE_CONDITION, None)
+
+            condition = getattr(self.model, "condition", None)
+            if not callable(condition):
+                condition = default_condition
+            n_draws = (
+                num_samples_per_batch
+                if num_samples_per_batch is not None
+                else self.num_samples_per_batch
+            )
+            if n_draws < 1:
+                raise ValueError(
+                    f"num_samples_per_batch must be positive, got {n_draws}"
+                )
+            ctx.batch = condition(ctx.cond, n_draws)
+            self._call_hooks(GenerationStage.AFTER_CONDITION, None)
+
+            with (
+                torch.cuda.stream(self._stream)
+                if self._stream is not None
+                else nullcontext()
+            ):
+                sample = self._generate(ctx, num_samples=n_draws, **kwargs)
+                recon = self.output_to_batch_func or getattr(
+                    self.model, "to_batch", None
+                )
+                if (
+                    recon is None
+                ):  # pragma: no cover - guarded by a construction validator
+                    raise TypeError(
+                        "AtomGenerator needs output_to_batch_func or model.to_batch "
+                        "to materialize generation outputs into a Batch."
+                    )
+                ctx.batch = recon(sample, ctx.batch)
+            if not isinstance(ctx.batch, Batch):
+                raise TypeError(
+                    "Materialization must return a Batch; got "
+                    f"{type(ctx.batch).__name__}."
+                )
+            self._call_hooks(GenerationStage.AFTER_GENERATE, None)
+            batch = ctx.batch
+            if not isinstance(batch, Batch):
+                raise TypeError(
+                    "AFTER_GENERATE hooks must leave ctx.batch a Batch, got "
+                    f"{type(batch).__name__}."
+                )
+            return batch
+        finally:
+            self._ctx = None
+            self.step_count += 1
+
+    def __call__(self, cond: Any = None, **kwargs: Any) -> Batch:
+        """Syntactic sugar for :meth:`sample`.
+
+        Parameters
+        ----------
+        cond
+            Conditioning input; forwarded to :meth:`sample`.
+        **kwargs
+            Forwarded to :meth:`sample`.
+
+        Returns
+        -------
+        Batch
+            The generated batch.
+        """
+        return self.sample(cond, **kwargs)
+
+    def stream(
+        self,
+        conds: Any = None,
+        *,
+        max_batches: int | None = None,
+        **kwargs: Any,
+    ) -> Iterator[Batch]:
+        """Stream generated batches as a dynamics data source.
+
+        One :meth:`sample` call per conditioning item. ``conds`` *is* the data
+        source: pass any iterable of conditioning inputs, or ``None`` for
+        repeated unconditional draws.
+
+        Parameters
+        ----------
+        conds
+            Iterable of conditioning inputs, or ``None`` for unconditional
+            draws.
+        max_batches
+            Cap on batches yielded (``None`` means unbounded — follow
+            ``conds``).
+        **kwargs
+            Per-call options forwarded to :meth:`sample`.
+
+        Yields
+        ------
+        Batch
+            One batch per call, exactly as produced, so consumers count
+            graphs themselves. Retries/resampling belong to the consuming
+            loop, not the stream. Note a filter that empties a batch raises
+            ``IndexError`` from :class:`~nvalchemi.data.Batch` (no zero-graph
+            selections); rejection-rate-aware streaming needs that data-layer
+            change first.
+        """
+        if conds is None:
+            conds = itertools.repeat(None)
+        for index, cond in enumerate(conds):
+            if max_batches is not None and index >= max_batches:
+                return
+            yield self.sample(cond, **kwargs)
+
+    def __iter__(self) -> Iterator[Batch]:
+        """Thin sugar for :meth:`stream` with default arguments.
+
+        Returns
+        -------
+        Iterator
+            ``self.stream()`` — an unbounded stream of unconditional draws.
+        """
+        return self.stream()

--- a/nvalchemi/gen/stages.py
+++ b/nvalchemi/gen/stages.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lifecycle stages of the generative pipeline at which hooks can fire."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+__all__ = ["GenerationStage"]
+
+
+class GenerationStage(Enum):
+    """Stages of the :class:`~nvalchemi.gen.generator.AtomGenerator` pipeline.
+
+    One stage per distinct point of the fixed pipeline (condition →
+    generate; the raw sample is materialized into a
+    :class:`~nvalchemi.data.Batch` inline, as part of the generate step).
+    Before/after pairs collapse into single stages because hooks mutate the
+    :class:`~nvalchemi.hooks.GenerationContext` by replacing its fields,
+    and the next step re-reads the context — so a "before generate" hook and
+    an "after condition" hook are the same point.
+
+    Attributes
+    ----------
+    BEFORE_CONDITION
+        Fired before the conditioning batch is built; ``ctx.batch`` is
+        ``None``. Edit or replace ``ctx.cond`` here. (Text encodings are
+        expected to happen before the ``AtomGenerator`` is entered, so ``cond``
+        already holds tensor data.)
+    AFTER_CONDITION
+        Fired after conditioning; ``ctx.batch`` holds the conditioning
+        batch, tiled by ``num_samples_per_batch``. Attach conditioning
+        metadata (e.g. text embeddings for classifier-free guidance) or
+        replace the conditioning batch here.
+    AFTER_GENERATE
+        Fired after the raw sample has been materialized into the generated
+        :class:`~nvalchemi.data.Batch`; ``ctx.batch`` holds it. Filter or
+        mutate the generated batch here — filtering is graph-level
+        subsetting (``ctx.batch = ctx.batch[keep]``).
+        :class:`~nvalchemi.data.Batch` does not support zero-graph
+        selections (``IndexError``), so a filter must keep at least one
+        graph; empty-batch semantics are a separate data-layer decision.
+    """
+
+    BEFORE_CONDITION = auto()
+    AFTER_CONDITION = auto()
+    AFTER_GENERATE = auto()

--- a/nvalchemi/hooks/__init__.py
+++ b/nvalchemi/hooks/__init__.py
@@ -16,7 +16,12 @@
 
 from __future__ import annotations
 
-from nvalchemi.hooks._context import DynamicsContext, HookContext, TrainContext
+from nvalchemi.hooks._context import (
+    DynamicsContext,
+    GenerationContext,
+    HookContext,
+    TrainContext,
+)
 from nvalchemi.hooks._protocol import CheckpointableHook, Hook
 from nvalchemi.hooks._registry import HookRegistryMixin
 from nvalchemi.hooks.bias import BiasedPotentialHook
@@ -51,6 +56,7 @@ __all__ = [
     "BiasedPotentialHook",
     "CheckpointableHook",
     "DynamicsContext",
+    "GenerationContext",
     "DynamicsRichLayout",
     "Hook",
     "HookContext",

--- a/nvalchemi/hooks/_context.py
+++ b/nvalchemi/hooks/_context.py
@@ -24,6 +24,8 @@ from torch.nn import ModuleDict
 from torch.optim.lr_scheduler import LRScheduler
 
 if TYPE_CHECKING:
+    from tensordict import TensorDictBase
+
     from nvalchemi.data.batch import Batch
     from nvalchemi.models.base import BaseModelMixin
 
@@ -137,3 +139,46 @@ class TrainContext(HookContext):
     gradients: dict[str, torch.Tensor] | None = None
     grad_scaler: torch.amp.GradScaler | None = None
     validation: dict[str, Any] | None = None
+
+
+@dataclass(kw_only=True)
+class GenerationContext(HookContext):
+    """Context object passed to generation hooks.
+
+    One context instance spans a single
+    :meth:`~nvalchemi.gen.generator.AtomGenerator.sample` call: the same
+    object is dispatched at every
+    :class:`~nvalchemi.gen.stages.GenerationStage` and the
+    :class:`~nvalchemi.gen.generator.AtomGenerator` re-reads it after each
+    dispatch, so hooks mutate generation state by *replacing* context fields
+    (``ctx.batch = ctx.batch[keep]``), not by editing in place.
+
+    Attributes
+    ----------
+    batch : Batch | TensorDict | None
+        The single canonical batch for this call. Built by conditioning
+        (tiled by ``num_samples_per_batch``), read by the generating
+        function, and materialized into the generated
+        :class:`~nvalchemi.data.Batch` before ``AFTER_GENERATE`` hooks fire.
+        There is deliberately no separate ``cond_batch`` — conditioning
+        writes the same field that materialization replaces. Widened from
+        :attr:`~nvalchemi.hooks.HookContext.batch` to admit
+        :class:`~tensordict.TensorDict` conditioning for non-graph-native
+        families; from ``AFTER_GENERATE`` on it always holds a ``Batch``.
+    cond : Any
+        The conditioning input for the current call — a tensor container
+        (``Batch``, ``TensorDict``, ...) with text or other raw modalities
+        already encoded. Editable at ``BEFORE_CONDITION``.
+    intermediates : dict[str, Any]
+        Scratch space for hook-to-hook state within one call (e.g. a
+        conditioning embedding computed at ``AFTER_CONDITION`` and consumed
+        at ``AFTER_GENERATE``).
+    step_count : int
+        Which generation call this is within a stream; ``0`` for a one-shot
+        call. Drives hook frequency gating.
+    """
+
+    batch: Batch | TensorDictBase | None = None
+    cond: Any = None
+    intermediates: dict[str, Any] = field(default_factory=dict)
+    step_count: int = 0

--- a/nvalchemi/models/gen/__init__.py
+++ b/nvalchemi/models/gen/__init__.py
@@ -31,11 +31,19 @@ from nvalchemi.models.gen.base import (
     GenerativeModelConfig,
     GenerativeModelMixin,
 )
+from nvalchemi.models.gen.demo import (
+    DemoDiffusionModel,
+    DemoGANModel,
+    demo_nonparametric_generation,
+)
 
 __all__ = [
     "ArtifactT",
+    "DemoDiffusionModel",
+    "DemoGANModel",
     "GenerativeIntent",
     "GenerativeModelConfig",
     "GenerativeModelMixin",
     "Modality",
+    "demo_nonparametric_generation",
 ]

--- a/nvalchemi/models/gen/__init__.py
+++ b/nvalchemi/models/gen/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model-side generative API.
+
+This subpackage holds the model-specific generative surface — the
+non-energy counterpart to :mod:`nvalchemi.models.base`. The mixin owns
+only the raw model output (predicted flow/velocity) from one forward
+call, plus the model↔:class:`~nvalchemi.data.Batch` translation methods.
+It owns no scheduler, sampler, or guidance; those compose on the
+:class:`~nvalchemi.gen.generator.AtomGenerator` via a
+:class:`~nvalchemi.gen.generator.GeneratingFunction`.
+"""
+
+from __future__ import annotations
+
+from nvalchemi.gen.enums import GenerativeIntent, Modality
+from nvalchemi.models.gen.base import (
+    ArtifactT,
+    GenerativeModelConfig,
+    GenerativeModelMixin,
+)
+
+__all__ = [
+    "ArtifactT",
+    "GenerativeIntent",
+    "GenerativeModelConfig",
+    "GenerativeModelMixin",
+    "Modality",
+]

--- a/nvalchemi/models/gen/base.py
+++ b/nvalchemi/models/gen/base.py
@@ -1,0 +1,432 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model-side generative API: config and mixin.
+
+This is the *non-energy* counterpart to
+:class:`~nvalchemi.models.base.BaseModelMixin`. Where ``BaseModelMixin`` is
+MLIP/energy-oriented (energy, forces, stress, neighbor lists, autograd,
+pipeline composition), a generative flow model predicts a velocity field over a
+flow state and shares none of that energy machinery. The two are therefore kept
+**separate** (see :class:`GenerativeModelMixin`): a generative model inherits
+this mixin, not ``BaseModelMixin``.
+
+Two pieces live here:
+
+* :class:`GenerativeModelConfig` — a pydantic config schema describing a
+  generative model's intents, modalities, and variable-atom support. It is set
+  as ``self.model_config`` in a wrapper's ``__init__`, mirroring the
+  ``BaseModelMixin`` pattern (the config lives with the model, not on the
+  :class:`~nvalchemi.gen.generator.AtomGenerator`).
+* :class:`GenerativeModelMixin` — the model mixin providing
+  ``forward`` (raw output), ``adapt_output`` (raw -> :class:`ModelOutputs`),
+  and ``condition`` (required), plus optional ``to_batch`` and
+  ``prior_template`` hooks. It owns no scheduler, sampler, or guidance.
+
+The ``Modality`` and ``GenerativeIntent`` enums are defined in
+:mod:`nvalchemi.gen.enums` and re-exported here for convenience.
+"""
+
+from __future__ import annotations
+
+import abc
+from collections import OrderedDict
+from collections.abc import Mapping
+from typing import Annotated, Any, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from torch import Tensor
+
+from nvalchemi._typing import ModelOutputs
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.gen.enums import GenerativeIntent, Modality
+from nvalchemi.gen.generator import default_condition
+
+__all__ = [
+    "ArtifactT",
+    "GenerativeIntent",
+    "GenerativeModelConfig",
+    "GenerativeModelMixin",
+    "Modality",
+]
+
+
+#: Type alias for the output artifact field of :class:`GenerativeModelConfig`.
+#:
+#: The artifact a generative model produces is identified by its
+#: :class:`Modality` (e.g. :attr:`Modality.CRYSTAL`).
+ArtifactT: TypeAlias = Modality
+
+#: Intents that *produce* an output artifact. Used to split
+#: :attr:`GenerativeModelConfig.intent_modality_map` into input-facing and
+#: output-facing modalities. The remaining intents (``condition``, ``complete``,
+#: ``transform``, ``connect``) are input-facing.
+_OUTPUT_INTENTS: frozenset[GenerativeIntent] = frozenset(
+    {
+        GenerativeIntent.CREATE,
+        GenerativeIntent.SAMPLE,
+        GenerativeIntent.PROPOSE,
+        GenerativeIntent.DECODE,
+    }
+)
+
+
+class GenerativeModelConfig(BaseModel):
+    """Pydantic config schema for a generative (non-energy) model.
+
+    A :class:`GenerativeModelConfig` is the contract between a generative model
+    wrapper and the rest of nvalchemi. Every
+    :class:`GenerativeModelMixin` subclass must set a ``self.model_config``
+    instance in its ``__init__`` (there is deliberately no class-level default,
+    so each wrapper owns its own config object — mirroring
+    :class:`~nvalchemi.models.base.BaseModelMixin`).
+
+    Attributes
+    ----------
+    intents
+        The operational roles the model can play.
+    supports_variable_atoms
+        Whether the model accepts systems with varying atom counts.
+    output_artifact
+        The primary output artifact modality (e.g. :attr:`Modality.CRYSTAL`).
+    intent_modality_map
+        Mapping from each supported intent to the modalities that intent
+        operates on. Every intent in :attr:`intents` must have an entry here.
+    consumes_fields
+        Batch fields the model's conditioning reads (empty means
+        unconditional). Declared here so a
+        :class:`~nvalchemi.gen.pipeline.GenerationPipeline` can validate stage
+        links at construction; a generator writes *something* by definition,
+        so declarations are required, not optional.
+    produces_fields
+        Batch fields the model's generated output carries (written or
+        forwarded). Distinct namespace from
+        :attr:`active_prediction_outputs`, which keys ``ModelOutputs`` (e.g.
+        ``"flow"``), not batch fields.
+    active_prediction_outputs
+        Output keys the model predicts (e.g. ``{"flow"}``). ``None`` defaults
+        to ``{"flow"}`` at use time.
+
+    Examples
+    --------
+    >>> from nvalchemi.models.gen.base import GenerativeModelConfig
+    >>> from nvalchemi.gen.enums import GenerativeIntent, Modality
+    >>> cfg = GenerativeModelConfig(
+    ...     intents={GenerativeIntent.CREATE, GenerativeIntent.SAMPLE},
+    ...     supports_variable_atoms=True,
+    ...     output_artifact=Modality.CRYSTAL,
+    ...     intent_modality_map={
+    ...         GenerativeIntent.CREATE: frozenset({Modality.CRYSTAL}),
+    ...         GenerativeIntent.SAMPLE: frozenset({Modality.CRYSTAL}),
+    ...     },
+    ...     consumes_fields=frozenset({"positions", "atomic_numbers"}),
+    ...     produces_fields=frozenset({"positions", "atomic_numbers", "cell"}),
+    ... )
+    >>> Modality.CRYSTAL in cfg.output_modalities
+    True
+
+    Notes
+    -----
+    ``extra="forbid"``: unknown constructor keywords raise
+    :class:`pydantic.ValidationError`, matching the
+    :class:`~nvalchemi.models.base.ModelConfig` pattern.
+    """
+
+    model_config = ConfigDict(extra="forbid", use_enum_values=False)
+
+    intents: Annotated[
+        set[GenerativeIntent],
+        Field(description="Operational roles the model can play."),
+    ]
+    supports_variable_atoms: Annotated[
+        bool,
+        Field(description="Whether the model accepts variable atom counts."),
+    ]
+    output_artifact: Annotated[
+        ArtifactT,
+        Field(description="Primary output artifact modality."),
+    ]
+    intent_modality_map: Annotated[
+        dict[GenerativeIntent, frozenset[Modality]],
+        Field(
+            description=(
+                "Mapping from each supported intent to the modalities it "
+                "operates on. Every intent in `intents` must have an entry."
+            )
+        ),
+    ]
+    consumes_fields: Annotated[
+        frozenset[str],
+        Field(
+            description=(
+                "Batch fields the model's conditioning reads (empty = "
+                "unconditional). Required: feeds GenerationPipeline link "
+                "validation."
+            )
+        ),
+    ]
+    produces_fields: Annotated[
+        frozenset[str],
+        Field(
+            description=(
+                "Batch fields the model's generated output carries "
+                "(written or forwarded). Required: feeds GenerationPipeline "
+                "link validation."
+            )
+        ),
+    ]
+    active_prediction_outputs: Annotated[
+        set[str] | None,
+        Field(
+            default=None,
+            description=(
+                "Output keys the model predicts (e.g. {'flow'}). None "
+                "defaults to {'flow'} at use time."
+            ),
+        ),
+    ] = None
+
+    @model_validator(mode="after")
+    def assert_intents_in_map(self) -> GenerativeModelConfig:
+        """Assert every intent in :attr:`intents` has a map entry.
+
+        Returns
+        -------
+        GenerativeModelConfig
+            The validated config.
+
+        Raises
+        ------
+        ValueError
+            If any intent in :attr:`intents` is missing from
+            :attr:`intent_modality_map`.
+        """
+        missing = self.intents - set(self.intent_modality_map)
+        if missing:
+            missing_str = ", ".join(sorted(i.value for i in missing))
+            raise ValueError(f"intents missing from intent_modality_map: {missing_str}")
+        return self
+
+    @property
+    def input_modalities(self) -> frozenset[Modality]:
+        """Modalities consumed by the model's input-facing intents.
+
+        Returns
+        -------
+        frozenset of Modality
+            Union of modalities over intents that are NOT output-producing
+            (``condition``, ``complete``, ``transform``, ``connect``).
+        """
+        input_intents = self.intents - _OUTPUT_INTENTS
+        return (
+            frozenset().union(*(self.intent_modality_map[i] for i in input_intents))
+            if input_intents
+            else frozenset()
+        )
+
+    @property
+    def output_modalities(self) -> frozenset[Modality]:
+        """Modalities produced by the model's output-producing intents.
+
+        Returns
+        -------
+        frozenset of Modality
+            Union of modalities over output-producing intents
+            (``create``, ``sample``, ``propose``, ``decode``), plus
+            :attr:`output_artifact`.
+        """
+        output_intents = self.intents & _OUTPUT_INTENTS
+        produced = (
+            frozenset().union(*(self.intent_modality_map[i] for i in output_intents))
+            if output_intents
+            else frozenset()
+        )
+        return produced | {self.output_artifact}
+
+
+class GenerativeModelMixin(abc.ABC):
+    """Mixin class for models designed for generative workflows.
+
+    This is the counterpart to :class:`~nvalchemi.models.base.BaseModelMixin`.
+    It mirrors the two-step output pattern — ``forward`` returns raw output,
+    :meth:`adapt_output` structures it into :class:`ModelOutputs` — but for a
+    velocity/flow model rather than an energy/MLIP model.
+
+    Concrete implementations must provide:
+
+    - ``model_config`` attribute — a :class:`GenerativeModelConfig` set in
+      ``__init__`` (enforced by :meth:`__init_subclass__`).
+    - :meth:`forward` — raw model output for one forward call.
+
+    The mixin provides defaults for:
+
+    - :meth:`adapt_output` — maps raw output to :class:`ModelOutputs`.
+    - :meth:`condition` — passes an already-built :class:`Batch` (or
+      :class:`AtomicData`) through, replicated by ``num_samples``;
+      delegates to the module-level
+      :func:`~nvalchemi.gen.default_condition`, the same default the
+      :class:`~nvalchemi.gen.generator.AtomGenerator` falls back to.
+
+    Optional hooks (define on subclasses as needed; the base does not
+    provide them, so the :class:`~nvalchemi.gen.generator.AtomGenerator`
+    raises :class:`TypeError` when they are absent):
+
+    - ``to_batch(sample, cond_batch) -> Batch`` — map a sample
+      :class:`~tensordict.TensorDict` (e.g. the denoised endpoint under
+      ``"x1"``) into a :class:`Batch`. ``cond_batch``
+      is ``None`` for unconditional generation. Built by the
+      :class:`~nvalchemi.gen.generator.AtomGenerator` via
+      ``model.condition`` and passed here for materialization context.
+    - ``generate(*, num_samples=1, rng=None, cond=None, **kwargs)
+      -> TensorDict`` — a model-supplied
+      :class:`~nvalchemi.gen.generator.GeneratingFunction` (without the
+      leading ``model`` argument, since it is a method). When present, the
+      :class:`~nvalchemi.gen.generator.AtomGenerator` uses it as the fallback
+      generation source when no ``generator_func`` is supplied.
+
+    Note that the intention behind classes that include this mixin is
+    to not fully own the generation process: instead that's offloaded
+    to the :class:`~nvalchemi.gen.generator.AtomGenerator`, which in
+    turn allows you to define a workflow that *uses* this model for
+    generation.
+    """
+
+    model_config: GenerativeModelConfig
+
+    # model_config must be set as an instance attribute in each subclass
+    # __init__: self.model_config = GenerativeModelConfig(...). There is
+    # intentionally NO class-level default (see BaseModelMixin for the same
+    # rationale). __init_subclass__ wraps __init__ to enforce this at
+    # construction time.
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Hook applied to every concrete subclass at class-creation time.
+
+        Wraps the subclass ``__init__`` so that after construction,
+        ``self.model_config`` is verified to exist and be a
+        :class:`GenerativeModelConfig`. This catches the common mistake of
+        forgetting to set ``model_config`` with a clear error instead of a late
+        ``AttributeError`` deep in a forward pass.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to the superclass hook.
+        """
+        super().__init_subclass__(**kwargs)
+        # Inject extra_repr onto the concrete class so it takes precedence over
+        # ``nn.Module.extra_repr`` (which precedes this mixin in the MRO when a
+        # wrapper is declared as ``class W(nn.Module, GenerativeModelMixin)``).
+        if "extra_repr" not in cls.__dict__:
+            cls.extra_repr = GenerativeModelMixin._config_extra_repr
+        if "__init__" in cls.__dict__:
+            import functools
+
+            original_init = cls.__init__
+
+            @functools.wraps(original_init)
+            def _checked_init(self: Any, *args: Any, **kw: Any) -> None:
+                original_init(self, *args, **kw)
+                cfg = getattr(self, "model_config", None)
+                if not isinstance(cfg, GenerativeModelConfig):
+                    raise TypeError(
+                        f"{type(self).__name__}.__init__() must set "
+                        f"self.model_config = GenerativeModelConfig(...). "
+                        f"See GenerativeModelMixin docstring for details."
+                    )
+
+            cls.__init__ = _checked_init  # type: ignore[attr-defined]
+
+    def adapt_output(self, raw: Any, data: AtomicData | Batch) -> ModelOutputs:
+        """Map raw model output to :class:`ModelOutputs`.
+
+        The default builds an :class:`OrderedDict` keyed by
+        :attr:`GenerativeModelConfig.active_prediction_outputs` (defaulting to
+        ``{"flow"}``). A dict-like ``raw`` fills matching keys; a single
+        :class:`~torch.Tensor` is placed under the ``"flow"`` key (or the
+        single configured key).
+
+        Parameters
+        ----------
+        raw
+            Raw output from :meth:`forward`.
+        data
+            Source structure data (for context/metadata).
+
+        Returns
+        -------
+        ModelOutputs
+            ``OrderedDict`` with the active prediction outputs.
+        """
+        keys = self.model_config.active_prediction_outputs or {"flow"}
+        output: ModelOutputs = OrderedDict((k, None) for k in sorted(keys))
+        if isinstance(raw, Mapping):
+            for key in output:
+                if key in raw:
+                    output[key] = raw[key]
+        elif isinstance(raw, Tensor):
+            key = "flow" if "flow" in output else next(iter(output))
+            output[key] = raw
+        return output
+
+    def condition(
+        self, cond: AtomicData | Batch | None, num_samples: int = 1
+    ) -> Batch | None:
+        """Ingest a conditioning spec into a conditioning :class:`Batch`.
+
+        Delegates to the module-level
+        :func:`~nvalchemi.gen.default_condition` — the same default
+        the :class:`~nvalchemi.gen.generator.AtomGenerator` falls back to when a
+        model defines no ``condition`` of its own. An already-built
+        :class:`Batch` (or :class:`AtomicData`) passes through with each
+        conditioning graph replicated ``num_samples`` times; ``None`` passes
+        through as ``None`` for unconditional generation; any other tensor
+        container passes through unchanged (replication semantics for
+        non-batch containers belong to the model or generating function).
+
+        Parameters
+        ----------
+        cond
+            An already-built :class:`Batch` or :class:`AtomicData`,
+            or ``None`` for unconditional generation.
+        num_samples
+            Number of independent draws per conditioning graph.
+
+        Returns
+        -------
+        Batch | None
+            The conditioning batch, tiled so each conditioning graph appears
+            ``num_samples`` times, or ``None`` for unconditional generation.
+        """
+        return default_condition(cond, num_samples)
+
+    @staticmethod
+    def _config_extra_repr(self: Any) -> str:
+        """Format the generative config for ``nn.Module.__repr__``.
+
+        Parameters
+        ----------
+        self
+            The wrapper instance (injected onto concrete subclasses).
+
+        Returns
+        -------
+        str
+            A short summary of intents and output artifact.
+        """
+        cfg = getattr(self, "model_config", None)
+        if not isinstance(cfg, GenerativeModelConfig):
+            return "model_config=<not set>"
+        intents = ", ".join(sorted(i.value for i in cfg.intents))
+        return f"intents={{{intents}}}, output_artifact={cfg.output_artifact.value}"

--- a/nvalchemi/models/gen/demo.py
+++ b/nvalchemi/models/gen/demo.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Demo generative models for testing and debugging.
+
+The generative counterpart to :mod:`nvalchemi.models.demo`: minimal,
+self-contained placeholders that satisfy the
+:class:`~nvalchemi.models.gen.base.GenerativeModelMixin` contract and run
+through the :class:`~nvalchemi.gen.generator.AtomGenerator` with no external
+weights or optional dependencies. Each demo model provides both fallback
+entry points (``generate`` and ``to_batch``), so a bare
+``AtomGenerator(model=...)`` works end to end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from tensordict import TensorDict
+from torch import nn
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.gen.enums import GenerativeIntent, Modality
+from nvalchemi.models.gen.base import GenerativeModelConfig, GenerativeModelMixin
+
+__all__ = [
+    "DemoDiffusionModel",
+    "DemoGANModel",
+    "demo_nonparametric_generation",
+]
+
+
+def _demo_config() -> GenerativeModelConfig:
+    """Build the shared demo config: unconditional point-cloud generation.
+
+    Returns
+    -------
+    GenerativeModelConfig
+        Create/sample intents over point clouds; consumes nothing (the demos
+        are unconditional), produces positions and atomic numbers.
+    """
+    return GenerativeModelConfig(
+        intents={GenerativeIntent.CREATE, GenerativeIntent.SAMPLE},
+        supports_variable_atoms=False,
+        output_artifact=Modality.POINT_CLOUD,
+        intent_modality_map={
+            GenerativeIntent.CREATE: frozenset({Modality.POINT_CLOUD}),
+            GenerativeIntent.SAMPLE: frozenset({Modality.POINT_CLOUD}),
+        },
+        consumes_fields=frozenset(),
+        produces_fields=frozenset({"positions", "atomic_numbers"}),
+    )
+
+
+def _sample_to_batch(sample: TensorDict, num_atoms: int) -> Batch:
+    """Materialize a demo sample: one point-cloud graph per draw.
+
+    Parameters
+    ----------
+    sample
+        Sample TensorDict with flat positions under ``"x1"``.
+    num_atoms
+        Number of atoms per graph; the sample's entries are reshaped to
+        ``(-1, num_atoms, 3)``.
+
+    Returns
+    -------
+    Batch
+        One carbon point cloud per draw.
+    """
+    positions = sample["x1"].reshape(-1, num_atoms, 3)
+    numbers = positions.new_full((num_atoms,), 6, dtype=torch.long)
+    return Batch.from_data_list(
+        [AtomicData(positions=p, atomic_numbers=numbers) for p in positions]
+    )
+
+
+class DemoGANModel(nn.Module, GenerativeModelMixin):
+    """Minimal GAN-side demo: a latent draw decoded to a point cloud.
+
+    The generative analogue of :class:`~nvalchemi.models.demo.DemoModel` — a
+    placeholder for testing and debugging generative workflows. ``forward``
+    follows the mixin convention (``forward(data, *, x)``) and decodes the
+    latent ``x`` to flat positions; ``generate`` is the generation-source
+    fallback (draw a latent, decode it), so the model runs through an
+    :class:`~nvalchemi.gen.generator.AtomGenerator` with no
+    ``generator_func``.
+    """
+
+    def __init__(
+        self, num_atoms: int = 3, latent_dim: int = 4, hidden: int = 32
+    ) -> None:
+        super().__init__()
+        self.num_atoms = num_atoms
+        self.latent_dim = latent_dim
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, num_atoms * 3),
+        )
+        self.model_config = _demo_config()
+
+    def forward(self, data: Any, *, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
+        """Decode a latent draw ``x`` of shape ``(B, latent_dim)``."""
+        del data, kwargs
+        return self.decoder(x)
+
+    def decode(self, z: torch.Tensor) -> torch.Tensor:
+        """Decode latent ``z`` to positions of shape ``(B, num_atoms, 3)``."""
+        return self.decoder(z).reshape(-1, self.num_atoms, 3)
+
+    def generate(
+        self,
+        *,
+        num_samples: int = 1,
+        rng: torch.Generator | None = None,
+        cond: Batch | None = None,
+        **kwargs: Any,
+    ) -> TensorDict:
+        """Draw latents from the prior and decode them (one pass).
+
+        Parameters
+        ----------
+        num_samples
+            Number of draws (used only when ``cond`` is ``None``).
+        rng
+            Optional generator for reproducible draws.
+        cond
+            Conditioning batch, if any; one draw per conditioning graph.
+        **kwargs
+            Family-specific options (ignored).
+
+        Returns
+        -------
+        TensorDict
+            Decoded positions under ``"x1"``, one entry per draw.
+        """
+        del kwargs
+        n = cond.num_graphs if isinstance(cond, Batch) else num_samples
+        device = next(self.parameters()).device
+        z = torch.randn(n, self.latent_dim, generator=rng, device=device)
+        return TensorDict({"x1": self.decode(z)}, batch_size=[n])
+
+    def to_batch(self, sample: TensorDict, cond_batch: Batch | None) -> Batch:
+        """Materialize the sample: one point-cloud graph per draw."""
+        del cond_batch
+        return _sample_to_batch(sample, self.num_atoms)
+
+
+class DemoDiffusionModel(nn.Module, GenerativeModelMixin):
+    """Minimal diffusion-side demo: an x0-predictor over point clouds.
+
+    ``forward`` follows the PhysicsNeMo calling convention —
+    ``forward(x, sigma)`` predicts clean positions from noisy ones — so the
+    model slots directly into ``physicsnemo.diffusion`` preconditioners and
+    samplers (see the generative user guide). ``generate`` runs a small
+    self-contained EDM Euler loop, so the model also works with no
+    ``generator_func`` and no PhysicsNeMo involvement at all.
+    """
+
+    def __init__(self, num_atoms: int = 3, hidden: int = 32) -> None:
+        super().__init__()
+        self.num_atoms = num_atoms
+        self.net = nn.Sequential(
+            nn.Linear(num_atoms * 3 + 1, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, num_atoms * 3),
+        )
+        self.model_config = _demo_config()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        sigma: torch.Tensor,
+        class_labels: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Predict clean positions from noisy ones.
+
+        Flattens ``x`` from ``(B, N, 3)``, appends the noise level ``sigma``
+        as a per-draw feature, and maps back to ``(B, N, 3)`` through the
+        MLP. ``class_labels`` is accepted for the PhysicsNeMo calling
+        convention and unused here.
+        """
+        del class_labels
+        b = x.shape[0]
+        s = sigma.reshape(b, 1)
+        return self.net(torch.cat([x.reshape(b, -1), s], dim=-1)).reshape_as(x)
+
+    def generate(
+        self,
+        *,
+        num_samples: int = 1,
+        rng: torch.Generator | None = None,
+        cond: Batch | None = None,
+        num_steps: int = 4,
+        sigma_max: float = 2.0,
+        sigma_min: float = 0.01,
+        **kwargs: Any,
+    ) -> TensorDict:
+        """Sample with a small EDM Euler loop (first-order, deterministic).
+
+        Starts from Gaussian noise at ``sigma_max`` and integrates
+        ``dx/dσ = (x − D(x, σ))/σ`` down to ``sigma_min``, where ``D`` is
+        this model's x0-prediction. With all randomness in the initial
+        noise, a seeded ``rng`` reproduces draws exactly.
+
+        Parameters
+        ----------
+        num_samples
+            Number of draws (used only when ``cond`` is ``None``).
+        rng
+            Optional generator for reproducible initial noise.
+        cond
+            Conditioning batch, if any; one draw per conditioning graph.
+        num_steps
+            Number of Euler steps.
+        sigma_max, sigma_min
+            The noise-level endpoints.
+        **kwargs
+            Family-specific options (ignored).
+
+        Returns
+        -------
+        TensorDict
+            Denoised positions under ``"x1"``, one entry per draw.
+        """
+        del kwargs
+        n = cond.num_graphs if isinstance(cond, Batch) else num_samples
+        device = next(self.parameters()).device
+        sigmas = torch.linspace(sigma_max, sigma_min, num_steps + 1, device=device)
+        x = torch.randn(n, self.num_atoms, 3, generator=rng, device=device)
+        x = x * sigmas[0]
+        for i in range(num_steps):
+            s_cur, s_next = sigmas[i], sigmas[i + 1]
+            drift = (x - self.forward(x, s_cur.expand(n))) / s_cur
+            x = x + (s_next - s_cur) * drift
+        return TensorDict({"x1": x}, batch_size=[n])
+
+    def to_batch(self, sample: TensorDict, cond_batch: Batch | None) -> Batch:
+        """Materialize the sample: one point-cloud graph per draw."""
+        del cond_batch
+        return _sample_to_batch(sample, self.num_atoms)
+
+
+def demo_nonparametric_generation(
+    cond: Any = None,
+    *,
+    num_samples: int = 1,
+    rng: torch.Generator | None = None,
+    num_atoms: int = 3,
+    box: float = 5.0,
+    **kwargs: Any,
+) -> Batch:
+    """Emit a batch of synthetic structures — no model, no learned anything.
+
+    Positions are uniform in a cube of side ``box``; atomic numbers are
+    sampled from H/C/N/O. If ``cond`` is a :class:`~nvalchemi.data.Batch`,
+    one synthetic graph is emitted per conditioning graph, so the function
+    can serve as a source stage in a
+    :class:`~nvalchemi.gen.pipeline.GenerationPipeline`; otherwise
+    ``num_samples`` graphs are emitted.
+
+    Parameters
+    ----------
+    cond
+        Conditioning batch, if any; only its graph count is read.
+    num_samples
+        Number of structures to emit when ``cond`` is not a batch.
+    rng
+        Optional generator for reproducible structures.
+    num_atoms
+        Number of atoms per structure.
+    box
+        Side length of the cube positions are drawn in.
+    **kwargs
+        Ignored; kept for call-site compatibility.
+
+    Returns
+    -------
+    Batch
+        The synthetic structures.
+    """
+    del kwargs
+    n = cond.num_graphs if isinstance(cond, Batch) else num_samples
+    positions = torch.rand(n, num_atoms, 3, generator=rng) * box
+    choices = torch.tensor([1, 6, 7, 8], dtype=torch.long)
+    picks = torch.randint(0, len(choices), (n, num_atoms), generator=rng)
+    return Batch.from_data_list(
+        [
+            AtomicData(positions=positions[i], atomic_numbers=choices[picks[i]])
+            for i in range(n)
+        ]
+    )

--- a/test/gen/__init__.py
+++ b/test/gen/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/gen/conftest.py
+++ b/test/gen/conftest.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helpers for the generative API test suite.
+
+Mirrors the dynamics/training convention: dummy-data builders and trivial
+generating/materialization functions live in a per-suite ``conftest.py`` and
+are imported by the test modules (``from test.gen.conftest import
+make_batch``) instead of being redefined per module.
+"""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from nvalchemi.data import AtomicData, Batch
+
+
+def make_atomic_data(num_atoms: int = 3) -> AtomicData:
+    """Build a minimal :class:`AtomicData` for tests.
+
+    Parameters
+    ----------
+    num_atoms
+        Number of atoms in the dummy structure.
+
+    Returns
+    -------
+    AtomicData
+        A small structure with random positions and carbon atomic numbers.
+    """
+    return AtomicData(
+        positions=torch.randn(num_atoms, 3),
+        atomic_numbers=torch.full((num_atoms,), 6, dtype=torch.long),
+    )
+
+
+def make_batch(num_graphs: int = 2) -> Batch:
+    """Build a small :class:`Batch` for tests.
+
+    Parameters
+    ----------
+    num_graphs
+        Number of graphs to batch.
+
+    Returns
+    -------
+    Batch
+        A batch of dummy structures.
+    """
+    return Batch.from_data_list([make_atomic_data() for _ in range(num_graphs)])
+
+
+def trivial_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
+    """A minimal :class:`~nvalchemi.gen.GeneratingFunction` for tests.
+
+    Parameters
+    ----------
+    model
+        Generative model (ignored).
+    num_samples
+        Number of draws (used only when ``cond`` is ``None``).
+    rng
+        Optional generator (ignored).
+    cond
+        Conditioning batch, if any; the sample's leading size matches it.
+    **kwargs
+        Family-specific options (ignored).
+
+    Returns
+    -------
+    TensorDict
+        Zeros under the ``"x1"`` key, aligned with ``cond``.
+    """
+    del model, rng, kwargs
+    n = cond.num_graphs if isinstance(cond, Batch) else num_samples
+    return TensorDict({"x1": torch.zeros(n, 1, 3)}, batch_size=[n])
+
+
+def zeros_to_batch(sample: TensorDict, batch) -> Batch:
+    """Materialization building a fresh batch sized like the sample.
+
+    Parameters
+    ----------
+    sample
+        Sample TensorDict; its leading size sets the graph count.
+    batch
+        Conditioning batch (ignored).
+
+    Returns
+    -------
+    Batch
+        ``sample.batch_size[0]`` dummy graphs.
+    """
+    del batch
+    return make_batch(sample.batch_size[0])

--- a/test/gen/test_gen_generator.py
+++ b/test/gen/test_gen_generator.py
@@ -73,7 +73,10 @@ def _rng_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
     """
     del model, kwargs
     n = cond.num_graphs if isinstance(cond, Batch) else num_samples
-    return TensorDict({"x1": torch.randn(n, 1, 3, generator=rng)}, batch_size=[n])
+    return TensorDict(
+        {"x1": torch.randn(n, 1, 3, generator=rng, device=rng.device if rng else None)},
+        batch_size=[n],
+    )
 
 
 class _CaptureRecon:

--- a/test/gen/test_gen_generator.py
+++ b/test/gen/test_gen_generator.py
@@ -1,0 +1,716 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structural tests for the generative API.
+
+Covers the abstract :class:`~nvalchemi.gen.generator.AtomGenerator`
+with its fixed two-step core and
+:class:`~nvalchemi.gen.stages.GenerationStage` hooks: the defaults-everywhere
+model contract, the :class:`~tensordict.TensorDict` sample contract, hook
+firing order / frequency gating /
+mutation-by-replacement / filter-by-subsetting, ``stream()`` semantics, the
+``sample()``/``__call__`` sugar split, the ``torch.compile`` surface, and
+session (context-manager) lifecycle. CPU-only, GPU-free, no optional deps.
+"""
+
+from __future__ import annotations
+
+import itertools
+from enum import Enum, auto
+
+import pytest
+import torch
+from tensordict import TensorDict
+from torch import nn
+
+from nvalchemi.data import Batch
+from nvalchemi.gen.generator import AtomGenerator
+from nvalchemi.gen.stages import GenerationStage
+from nvalchemi.models.gen.demo import DemoDiffusionModel, DemoGANModel
+from test.gen.conftest import make_batch, trivial_generate, zeros_to_batch
+
+
+class _PlainModel(nn.Module):
+    """A bare ``nn.Module`` — no mixin, no ``model_config``, no methods.
+
+    Exercises the defaults-everywhere contract: the :class:`AtomGenerator`
+    falls back to the module-level default condition and never reads
+    ``forward``.
+    """
+
+
+def _rng_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
+    """A generating function that draws from ``rng`` (seed-path tests).
+
+    Parameters
+    ----------
+    model
+        Generative model (ignored).
+    num_samples
+        Number of draws (used only when ``cond`` is ``None``).
+    rng
+        :class:`torch.Generator` to draw from.
+    cond
+        Conditioning batch, if any.
+    **kwargs
+        Family-specific options (ignored).
+
+    Returns
+    -------
+    TensorDict
+        Random values under the ``"x1"`` key.
+    """
+    del model, kwargs
+    n = cond.num_graphs if isinstance(cond, Batch) else num_samples
+    return TensorDict({"x1": torch.randn(n, 1, 3, generator=rng)}, batch_size=[n])
+
+
+class _CaptureRecon:
+    """Materialization that records the raw sample TensorDict it receives."""
+
+    def __init__(self) -> None:
+        self.samples: list[TensorDict] = []
+
+    def __call__(self, sample: TensorDict, batch) -> Batch:
+        """Record ``sample`` and return a batch sized like it.
+
+        Parameters
+        ----------
+        sample
+            Sample TensorDict to record.
+        batch
+            Conditioning batch (ignored).
+
+        Returns
+        -------
+        Batch
+            Dummy graphs matching the sample's leading size.
+        """
+        self.samples.append(sample)
+        return make_batch(sample.batch_size[0])
+
+
+class TestBaseGenerator:
+    """Core :class:`AtomGenerator` tests."""
+
+    def test_unconditional_generate_returns_batch(self) -> None:
+        """A free generating function + ``output_to_batch_func`` yields a batch."""
+        sentinel = make_batch(num_graphs=1)
+
+        def recon(sample: TensorDict, batch) -> Batch:
+            """Reconstruction override returning a sentinel batch.
+
+            Parameters
+            ----------
+            sample
+                Sample TensorDict (ignored).
+            batch
+                Conditioning batch (ignored).
+
+            Returns
+            -------
+            Batch
+                The sentinel batch.
+            """
+            del sample, batch
+            return sentinel
+
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=trivial_generate,
+            output_to_batch_func=recon,
+        )
+        out = gen(num_samples_per_batch=2)
+        assert out is sentinel
+
+    def test_conditional_generate_via_model_generate(self, device: str) -> None:
+        """A ``model.generate`` fallback returns a batch sized by conditioning."""
+        gen = AtomGenerator(model=DemoGANModel().to(device), num_samples_per_batch=3)
+        out = gen(make_batch(num_graphs=2).to(device))
+        assert isinstance(out, Batch)
+        assert out.num_graphs == 6
+        assert out["positions"].device.type == device
+
+    def test_construct_raises_without_generation_source(self) -> None:
+        """``TypeError`` at construction with no ``generator_func`` or ``generate``."""
+        with pytest.raises(TypeError, match="generation source"):
+            AtomGenerator(model=_PlainModel())
+
+    def test_construct_raises_without_materialization(self) -> None:
+        """``TypeError`` at construction with no ``output_to_batch_func``/``to_batch``."""
+        with pytest.raises(TypeError, match="materialization target"):
+            AtomGenerator(model=_PlainModel(), generator_func=trivial_generate)
+
+    def test_generate_must_return_tensordict(self) -> None:
+        """A generating function returning a bare tensor raises ``TypeError``."""
+
+        def _bad_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
+            """Return a bare tensor, violating the TensorDict contract."""
+            del model, num_samples, rng, cond, kwargs
+            return torch.zeros(1, 1, 3)
+
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=_bad_generate,
+            output_to_batch_func=zeros_to_batch,
+        )
+        with pytest.raises(TypeError, match="TensorDict"):
+            gen()
+
+    def test_materialization_must_return_batch(self) -> None:
+        """A materialization callable returning a non-Batch raises ``TypeError``."""
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=trivial_generate,
+            output_to_batch_func=lambda sample, batch: sample,
+        )
+        with pytest.raises(TypeError, match="must return a Batch"):
+            gen()
+
+    def test_condition_default_tiles_for_plain_model(self) -> None:
+        """A model without ``condition`` gets the module-level passthrough+tile."""
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=trivial_generate,
+            output_to_batch_func=lambda sample, batch: batch,
+            num_samples_per_batch=3,
+        )
+        out = gen(make_batch(num_graphs=2))
+        assert out.num_graphs == 6
+
+    def test_field_declarations_default_from_config(self) -> None:
+        """``consumes_fields``/``produces_fields`` default from ``model_config``."""
+        gen = AtomGenerator(model=DemoGANModel())
+        assert gen.consumes_fields == frozenset()
+        assert gen.produces_fields == frozenset({"positions", "atomic_numbers"})
+
+    def test_field_declarations_explicit_override(self) -> None:
+        """Explicit declarations win over ``model_config`` defaults."""
+        gen = AtomGenerator(
+            model=DemoGANModel(),
+            consumes_fields=frozenset({"charges"}),
+        )
+        assert gen.consumes_fields == frozenset({"charges"})
+        assert gen.produces_fields == frozenset({"positions", "atomic_numbers"})
+
+    def test_field_declarations_none_without_config(self) -> None:
+        """A model with no ``model_config`` leaves declarations undeclared."""
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=trivial_generate,
+            output_to_batch_func=zeros_to_batch,
+        )
+        assert gen.consumes_fields is None
+        assert gen.produces_fields is None
+
+
+class TestGenerationHooks:
+    """Hook dispatch, mutation, and filtering on the three generation stages."""
+
+    def _generator(self, hooks: list) -> AtomGenerator:
+        """Build a demo generator carrying ``hooks``.
+
+        Parameters
+        ----------
+        hooks
+            Hooks to register.
+
+        Returns
+        -------
+        AtomGenerator
+            A ``DemoGANModel``-backed generator.
+        """
+        return AtomGenerator(model=DemoGANModel(), hooks=hooks)
+
+    def test_hook_firing_order(self) -> None:
+        """Hooks fire once per call, in pipeline order."""
+
+        class _Recorder:
+            def __init__(self, stage: GenerationStage, log: list) -> None:
+                self.stage = stage
+                self.frequency = 1
+                self._log = log
+
+            def __call__(self, ctx, stage) -> None:
+                """Record the dispatched stage."""
+                self._log.append(stage)
+
+        log: list = []
+        gen = self._generator([_Recorder(stage, log) for stage in GenerationStage])
+        gen()
+        assert log == [
+            GenerationStage.BEFORE_CONDITION,
+            GenerationStage.AFTER_CONDITION,
+            GenerationStage.AFTER_GENERATE,
+        ]
+
+    def test_hook_frequency_gating_across_stream(self) -> None:
+        """A ``frequency=2`` hook fires every other generation call."""
+
+        class _EveryOther:
+            def __init__(self, log: list) -> None:
+                self.stage = GenerationStage.AFTER_GENERATE
+                self.frequency = 2
+                self._log = log
+
+            def __call__(self, ctx, stage) -> None:
+                """Record the step count seen."""
+                self._log.append(ctx.step_count)
+
+        log: list = []
+        gen = self._generator([_EveryOther(log)])
+        list(gen.stream([None] * 4))
+        assert log == [0, 2]
+
+    def test_hook_mutation_replaces_batch(self) -> None:
+        """An ``AFTER_GENERATE`` hook replaces the materialized batch."""
+
+        sentinel = make_batch(num_graphs=1)
+
+        class _Swap:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Swap the generated batch for a sentinel."""
+                ctx.batch = sentinel
+
+        gen = self._generator([_Swap()])
+        out = gen(make_batch(num_graphs=3))
+        assert out is sentinel
+
+    def test_intermediates_scratch_between_stages(self) -> None:
+        """``ctx.intermediates`` carries hook-to-hook state within one call."""
+        seen: list = []
+
+        class _Producer:
+            stage = GenerationStage.AFTER_CONDITION
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Stash a value for a later stage."""
+                ctx.intermediates["tag"] = "from-condition"
+
+        class _Consumer:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Read the stashed value."""
+                seen.append(ctx.intermediates.get("tag"))
+
+        gen = self._generator([_Producer(), _Consumer()])
+        gen()
+        assert seen == ["from-condition"]
+
+    def test_cond_rewrite_before_condition(self) -> None:
+        """A BEFORE_CONDITION hook replaces ``ctx.cond`` before conditioning."""
+
+        class _SwapCond:
+            stage = GenerationStage.BEFORE_CONDITION
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Replace a 3-graph cond with a 1-graph cond."""
+                ctx.cond = make_batch(num_graphs=1)
+
+        gen = AtomGenerator(
+            model=_PlainModel(),
+            generator_func=trivial_generate,
+            output_to_batch_func=lambda sample, batch: batch,
+            hooks=[_SwapCond()],
+        )
+        out = gen(make_batch(num_graphs=3))
+        assert out.num_graphs == 1
+
+    def test_filter_hook_subsets_batch(self, device: str) -> None:
+        """Filtering is graph-level subsetting at AFTER_GENERATE."""
+
+        class _KeepFirst:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Keep only the first graph."""
+                ctx.batch = ctx.batch[[0]]
+
+        gen = self._generator([_KeepFirst()])
+        gen.model.to(device)
+        out = gen(make_batch(num_graphs=3).to(device))
+        assert out.num_graphs == 1
+        assert out["positions"].device.type == device
+
+    def test_filter_to_empty_raises(self) -> None:
+        """A filter rejecting every graph raises ``IndexError`` from ``Batch``.
+
+        Current data-layer behavior: zero-graph selections are not supported.
+        If empty-batch semantics land in ``Batch``, this test flips to assert
+        the empty batch is yielded.
+        """
+
+        class _RejectAll:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Reject every graph with an all-False mask."""
+                mask = torch.zeros(ctx.batch.num_graphs, dtype=torch.bool)
+                ctx.batch = ctx.batch[mask]
+
+        gen = self._generator([_RejectAll()])
+        with pytest.raises(IndexError, match="Index is empty"):
+            gen(make_batch(num_graphs=3))
+
+    def test_wrong_stage_enum_rejected(self) -> None:
+        """A hook with a non-GenerationStage stage is rejected at construction."""
+
+        class _OtherStage(Enum):
+            AFTER_STEP = auto()
+
+        class _WrongStage:
+            stage = _OtherStage.AFTER_STEP
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """No-op."""
+
+        with pytest.raises(TypeError, match="only accepts"):
+            self._generator([_WrongStage()])
+
+    def test_missing_stage_rejected(self) -> None:
+        """A hook with ``stage=None`` is rejected at construction."""
+
+        class _NoStage:
+            stage = None
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """No-op."""
+
+        with pytest.raises(TypeError, match="no stage"):
+            self._generator([_NoStage()])
+
+    def test_string_stage_coerced(self) -> None:
+        """A string stage (e.g. spec-rehydrated) is coerced to GenerationStage."""
+
+        class _StringStage:
+            def __init__(self) -> None:
+                self.stage = "AFTER_GENERATE"
+                self.frequency = 1
+                self.calls = 0
+
+            def __call__(self, ctx, stage) -> None:
+                """Count firings."""
+                self.calls += 1
+
+        hook = _StringStage()
+        gen = self._generator([hook])
+        assert hook.stage is GenerationStage.AFTER_GENERATE
+        gen()
+        assert hook.calls == 1
+
+
+class TestStreaming:
+    """``stream()`` semantics: cond iteration, caps, filtered batches, seeds."""
+
+    def _generator(self, **kwargs) -> AtomGenerator:
+        """Build a minimal streaming generator.
+
+        Parameters
+        ----------
+        **kwargs
+            Extra constructor arguments.
+
+        Returns
+        -------
+        AtomGenerator
+            A ``DemoGANModel``-backed generator (extra kwargs forwarded).
+        """
+        return AtomGenerator(model=DemoGANModel(), **kwargs)
+
+    def test_stream_caps_with_max_batches(self) -> None:
+        """``stream(None, max_batches=3)`` yields exactly 3 unconditional draws."""
+        gen = self._generator()
+        batches = list(gen.stream(max_batches=3))
+        assert len(batches) == 3
+        assert gen.step_count == 3
+
+    def test_stream_iterates_conds(self) -> None:
+        """Each cond item drives exactly one call."""
+        gen = self._generator()
+        conds = [make_batch(num_graphs=1), make_batch(num_graphs=2)]
+        out = list(gen.stream(conds))
+        assert [b.num_graphs for b in out] == [1, 2]
+        assert gen.step_count == 2
+
+    def test_stream_yields_filtered_batches_as_produced(self) -> None:
+        """A subsetting filter shrinks each streamed batch; nothing is dropped."""
+
+        class _KeepFirst:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Keep only the first graph."""
+                ctx.batch = ctx.batch[[0]]
+
+        gen = self._generator(hooks=[_KeepFirst()])
+        out = list(gen.stream([make_batch(num_graphs=2), make_batch(num_graphs=3)]))
+        assert [b.num_graphs for b in out] == [1, 1]
+
+    def test_iter_is_stream_sugar(self) -> None:
+        """``__iter__`` streams unconditional draws; callers bound externally."""
+        gen = self._generator()
+        batches = list(itertools.islice(gen, 2))
+        assert len(batches) == 2
+
+    def test_seed_makes_streams_reproducible(self) -> None:
+        """Two generators with the same ``seed`` produce identical streams."""
+        recon_a, recon_b = _CaptureRecon(), _CaptureRecon()
+        gen_a = self._generator(
+            generator_func=_rng_generate, output_to_batch_func=recon_a, seed=7
+        )
+        gen_b = self._generator(
+            generator_func=_rng_generate, output_to_batch_func=recon_b, seed=7
+        )
+        list(gen_a.stream(max_batches=2))
+        list(gen_b.stream(max_batches=2))
+        for sample_a, sample_b in zip(recon_a.samples, recon_b.samples):
+            assert torch.equal(sample_a["x1"], sample_b["x1"])
+        # Per-draw seeds (seed + step_count) make consecutive draws differ.
+        assert not torch.equal(recon_a.samples[0]["x1"], recon_a.samples[1]["x1"])
+
+
+class TestSampleSugar:
+    """``sample()`` is the real method; ``__call__`` delegates to it."""
+
+    def test_call_matches_sample(self) -> None:
+        """``__call__`` and ``sample`` produce identical behavior."""
+        capture_a, capture_b = _CaptureRecon(), _CaptureRecon()
+        gen_a = AtomGenerator(
+            model=DemoGANModel(),
+            generator_func=_rng_generate,
+            output_to_batch_func=capture_a,
+            seed=5,
+        )
+        gen_b = AtomGenerator(
+            model=DemoGANModel(),
+            generator_func=_rng_generate,
+            output_to_batch_func=capture_b,
+            seed=5,
+        )
+        out_a = gen_a(make_batch(num_graphs=2))
+        out_b = gen_b.sample(make_batch(num_graphs=2))
+        assert out_a.num_graphs == out_b.num_graphs
+        assert torch.equal(capture_a.samples[0]["x1"], capture_b.samples[0]["x1"])
+
+    def test_sample_runs_full_dispatch(self) -> None:
+        """``sample()`` fires all three stages in pipeline order."""
+
+        class _Recorder:
+            def __init__(self, stage: GenerationStage, log: list) -> None:
+                self.stage = stage
+                self.frequency = 1
+                self._log = log
+
+            def __call__(self, ctx, stage) -> None:
+                """Record the dispatched stage."""
+                self._log.append(stage)
+
+        log: list = []
+        gen = AtomGenerator(
+            model=DemoGANModel(),
+            hooks=[_Recorder(stage, log) for stage in GenerationStage],
+        )
+        gen.sample()
+        assert log == list(GenerationStage)
+
+    def test_stream_calls_sample(self) -> None:
+        """``stream()`` drives ``sample()`` once per cond item."""
+        gen = AtomGenerator(model=DemoGANModel())
+        calls = 0
+        original = gen.sample
+
+        def _spy(*args, **kwargs):
+            """Count calls and delegate."""
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        object.__setattr__(gen, "sample", _spy)
+        list(gen.stream([make_batch(num_graphs=1)] * 3))
+        assert calls == 3
+
+
+class TestCompile:
+    """The ``torch.compile`` surface (``backend="eager"`` keeps CPU tests fast)."""
+
+    def _generator(self, **kwargs) -> AtomGenerator:
+        """Build a trivial generator with compile-related kwargs.
+
+        Parameters
+        ----------
+        **kwargs
+            Extra constructor arguments.
+
+        Returns
+        -------
+        AtomGenerator
+            A ``DemoGANModel``-backed generator.
+        """
+        return AtomGenerator(model=DemoGANModel(), **kwargs)
+
+    def test_compile_wraps_generator_func(self) -> None:
+        """``compile()`` wraps the generating function and sets the flag."""
+        gen = self._generator()
+        assert gen._compiled_generate is None
+        out = gen.compile(backend="eager")
+        assert out is gen
+        assert gen.compile_generate is True
+        assert gen._compiled_generate is not None
+        assert gen(make_batch(num_graphs=1)).num_graphs == 1
+
+    def test_compile_merges_kwargs(self) -> None:
+        """Call-time kwargs merge over constructor ``compile_kwargs``."""
+        gen = self._generator(compile_kwargs={"backend": "eager", "dynamic": True})
+        gen.compile(dynamic=False)
+        assert gen.compile_kwargs == {"backend": "eager", "dynamic": False}
+
+    def test_compile_model_generate_fallback(self) -> None:
+        """With no ``generator_func``, ``compile()`` wraps ``model.generate``."""
+        gen = AtomGenerator(model=DemoDiffusionModel())
+        gen.compile(backend="eager")
+        assert gen(make_batch(num_graphs=2)).num_graphs == 2
+
+    def test_lazy_compile_at_session_entry(self) -> None:
+        """``compile_generate=True`` defers compilation to session entry."""
+        gen = self._generator(
+            compile_generate=True, compile_kwargs={"backend": "eager"}
+        )
+        assert gen._compiled_generate is None
+        with gen:
+            assert gen._compiled_generate is not None
+            assert gen(make_batch(num_graphs=1)).num_graphs == 1
+
+    def test_compile_kwargs_validated_against_torch_compile(self) -> None:
+        """Unknown compile kwargs raise ``ValueError`` at construction."""
+        with pytest.raises(ValueError, match="not keyword arguments of"):
+            self._generator(compile_kwargs={"bogus_kwarg": True})
+
+    def test_compile_kwargs_valid_keys_accepted(self) -> None:
+        """Real torch.compile kwargs (e.g. ``fullgraph``/``backend``) pass."""
+        gen = self._generator(compile_kwargs={"fullgraph": False, "backend": "eager"})
+        assert gen.compile_kwargs == {"fullgraph": False, "backend": "eager"}
+
+    def test_compile_kwargs_rejects_model_key(self) -> None:
+        """``model`` is the compile target, not a user kwarg."""
+        with pytest.raises(ValueError, match="'model'"):
+            self._generator(compile_kwargs={"model": nn.Linear(1, 1)})
+
+    def test_compile_method_validates_merged_kwargs(self) -> None:
+        """``compile(**kwargs)`` applies the same validation after merging."""
+        gen = self._generator()
+        with pytest.raises(ValueError, match="not keyword arguments of"):
+            gen.compile(bogus_kwarg=True)
+
+
+class TestSession:
+    """``with gen:`` — stream, session RNG, and hook lifecycle."""
+
+    def _generator(self, **kwargs) -> AtomGenerator:
+        """Build a trivial generator with session-related kwargs.
+
+        Parameters
+        ----------
+        **kwargs
+            Extra constructor arguments.
+
+        Returns
+        -------
+        AtomGenerator
+            RNG-drawing generator with a capture recon.
+        """
+        kwargs.setdefault("generator_func", _rng_generate)
+        kwargs.setdefault("output_to_batch_func", _CaptureRecon())
+        return AtomGenerator(model=DemoGANModel(), **kwargs)
+
+    def test_session_stream_matches_model_device(self, device: str) -> None:
+        """A CUDA-resident model gets a dedicated session stream; CPU does not."""
+        gen = self._generator()
+        gen.model.to(device)
+        with gen:
+            if device == "cuda":
+                assert gen._stream is not None
+                assert gen._stream_ctx is not None
+            else:
+                assert gen._stream is None
+                assert gen._stream_ctx is None
+            assert gen._session_rng is None  # no seed set
+        assert gen._stream is None
+
+    def test_context_manager_hooks_open_and_close(self) -> None:
+        """Hooks with ``__enter__``/``__exit__`` wrap the session."""
+        log: list = []
+
+        class _CMHook:
+            def __init__(self) -> None:
+                self.stage = GenerationStage.AFTER_GENERATE
+                self.frequency = 1
+
+            def __enter__(self) -> None:
+                """Record session entry."""
+                log.append("enter")
+
+            def __exit__(self, *args) -> None:
+                """Record session exit."""
+                log.append("exit")
+
+            def __call__(self, ctx, stage) -> None:
+                """No-op."""
+
+        gen = self._generator(hooks=[_CMHook()])
+        with gen:
+            gen.sample()
+        assert log == ["enter", "exit"]
+
+    def test_session_rng_reproducible_and_advancing(self, device: str) -> None:
+        """Same seed → identical sessions; draws advance within a session."""
+        recon_a, recon_b = _CaptureRecon(), _CaptureRecon()
+        gen_a = self._generator(output_to_batch_func=recon_a, seed=11)
+        gen_b = self._generator(output_to_batch_func=recon_b, seed=11)
+        gen_a.model.to(device)
+        gen_b.model.to(device)
+        with gen_a:
+            gen_a.sample(make_batch(num_graphs=1).to(device))
+            gen_a.sample(make_batch(num_graphs=1).to(device))
+        with gen_b:
+            gen_b.sample(make_batch(num_graphs=1).to(device))
+            gen_b.sample(make_batch(num_graphs=1).to(device))
+        for sa, sb in zip(recon_a.samples, recon_b.samples):
+            assert torch.equal(sa["x1"], sb["x1"])
+        assert not torch.equal(recon_a.samples[0]["x1"], recon_a.samples[1]["x1"])
+        # Session RNG is dropped on exit.
+        assert gen_a._session_rng is None
+
+    def test_rng_kwarg_overrides_session_rng(self) -> None:
+        """A per-call ``rng=`` wins over the session generator."""
+        recon_a, recon_b = _CaptureRecon(), _CaptureRecon()
+        gen_a = self._generator(output_to_batch_func=recon_a, seed=11)
+        gen_b = self._generator(output_to_batch_func=recon_b)  # no seed, no session
+        with gen_a:
+            gen_a.sample(
+                make_batch(num_graphs=1), rng=torch.Generator().manual_seed(99)
+            )
+        gen_b.sample(make_batch(num_graphs=1), rng=torch.Generator().manual_seed(99))
+        assert torch.equal(recon_a.samples[0]["x1"], recon_b.samples[0]["x1"])

--- a/test/models/test_gen_demo.py
+++ b/test/models/test_gen_demo.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the demo generative models (:mod:`nvalchemi.models.gen.demo`).
+
+Covers mixin conformance and config validity, the defaults-everywhere path
+(a bare ``AtomGenerator(model=...)`` runs via the model's ``generate`` /
+``to_batch`` fallbacks), seeding reproducibility, PhysicsNeMo interop for
+the diffusion demo, and the nonparametric synthetic-structure source.
+CPU-only, GPU-free.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nvalchemi.data import Batch
+from nvalchemi.gen import AtomGenerator, GenerativeIntent, Modality
+from nvalchemi.models.gen import (
+    DemoDiffusionModel,
+    DemoGANModel,
+    GenerativeModelMixin,
+    demo_nonparametric_generation,
+)
+
+
+class TestDemoGANModel:
+    """``DemoGANModel``: mixin surface, config, and the bare-generator path."""
+
+    def test_mixin_conformance_and_config(self) -> None:
+        """The demo satisfies the mixin contract and declares its config."""
+        model = DemoGANModel()
+        assert isinstance(model, GenerativeModelMixin)
+        assert model.model_config.output_artifact is Modality.POINT_CLOUD
+        assert model.model_config.intents == {
+            GenerativeIntent.CREATE,
+            GenerativeIntent.SAMPLE,
+        }
+        assert model.model_config.consumes_fields == frozenset()
+        assert model.model_config.produces_fields == frozenset(
+            {"positions", "atomic_numbers"}
+        )
+
+    def test_bare_generator_runs_via_model_fallbacks(self) -> None:
+        """``AtomGenerator(model=...)`` needs neither generating function nor
+        materialization argument — the model's ``generate``/``to_batch`` serve.
+        """
+        gen = AtomGenerator(model=DemoGANModel(num_atoms=4))
+        out = gen(num_samples_per_batch=3)
+        assert isinstance(out, Batch)
+        assert out.num_graphs == 3
+        assert out["positions"].shape == (12, 3)
+
+    def test_seeded_sessions_reproduce(self) -> None:
+        """Same model + same seed across sessions gives identical draws."""
+        model = DemoGANModel()
+        gen = AtomGenerator(model=model, seed=7)
+        with gen:
+            first = gen.sample(num_samples_per_batch=2)
+        with gen:
+            second = gen.sample(num_samples_per_batch=2)
+        assert torch.equal(first["positions"], second["positions"])
+
+
+class TestDemoDiffusionModel:
+    """``DemoDiffusionModel``: the physicsnemo-convention forward and sampler."""
+
+    def test_bare_generator_runs_via_model_fallbacks(self) -> None:
+        """The built-in EDM Euler loop drives a bare ``AtomGenerator``."""
+        gen = AtomGenerator(model=DemoDiffusionModel(num_atoms=5))
+        out = gen(num_samples_per_batch=2, num_steps=2)
+        assert out.num_graphs == 2
+        assert out["positions"].shape == (10, 3)
+
+    def test_forward_physicsnemo_compatible(self) -> None:
+        """The demo wraps in ``EDMPreconditioner`` and runs ``sample`` — the
+        integration pattern from the generative user guide."""
+        from physicsnemo.diffusion.noise_schedulers import EDMNoiseScheduler
+        from physicsnemo.diffusion.preconditioners import EDMPreconditioner
+        from physicsnemo.diffusion.samplers import sample as pn_sample
+
+        model = DemoDiffusionModel(num_atoms=3)
+        scheduler = EDMNoiseScheduler(sigma_max=5.0)
+        denoiser = scheduler.get_denoiser(x0_predictor=EDMPreconditioner(model))
+        xN = torch.randn(2, 3, 3, generator=torch.Generator().manual_seed(0)) * 5.0
+        out = pn_sample(denoiser, xN, scheduler, num_steps=2, solver="heun")
+        assert out.shape == (2, 3, 3)
+        assert torch.isfinite(out).all()
+
+    def test_seeded_sessions_reproduce(self) -> None:
+        """All randomness is the initial noise, so seeds reproduce draws."""
+        model = DemoDiffusionModel()
+        gen = AtomGenerator(model=model, seed=3)
+        with gen:
+            first = gen.sample(num_samples_per_batch=2)
+        with gen:
+            second = gen.sample(num_samples_per_batch=2)
+        assert torch.equal(first["positions"], second["positions"])
+
+
+class TestDemoNonparametricGeneration:
+    """``demo_nonparametric_generation``: synthetic structures, no model."""
+
+    def test_emits_requested_count(self) -> None:
+        """``num_samples`` controls the graph count; positions stay in the box."""
+        out = demo_nonparametric_generation(
+            num_samples=4, num_atoms=6, box=3.0, rng=torch.Generator().manual_seed(0)
+        )
+        assert isinstance(out, Batch)
+        assert out.num_graphs == 4
+        assert out["positions"].shape == (24, 3)
+        assert (out["positions"] >= 0.0).all()
+        assert (out["positions"] < 3.0).all()
+
+    def test_sizes_by_conditioning_batch(self) -> None:
+        """A ``Batch`` conditioning input sets the emitted graph count."""
+        source = demo_nonparametric_generation(num_samples=3)
+        out = demo_nonparametric_generation(source)
+        assert out.num_graphs == 3
+
+    def test_reproducible_with_rng(self) -> None:
+        """The same seeded generator gives identical structures."""
+        a = demo_nonparametric_generation(
+            num_samples=2, rng=torch.Generator().manual_seed(1)
+        )
+        b = demo_nonparametric_generation(
+            num_samples=2, rng=torch.Generator().manual_seed(1)
+        )
+        assert torch.equal(a["positions"], b["positions"])
+        assert torch.equal(a["atomic_numbers"], b["atomic_numbers"])

--- a/test/models/test_generative_base.py
+++ b/test/models/test_generative_base.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structural tests for the generative model config and mixin.
+
+Covers:
+
+* :class:`~nvalchemi.models.gen.base.GenerativeModelConfig` construction,
+  validation (intents-in-map), ``input_modalities``/``output_modalities``
+  properties, and config round-trip (serialize -> deserialize -> equality).
+* :class:`~nvalchemi.models.gen.base.GenerativeModelMixin` contract via a tiny
+  demo subclass: ``model_config`` enforcement, ``forward``/
+  ``adapt_output`` (emitting ``{"flow": velocity}``), ``condition`` replication
+  by ``num_samples``, and the optional ``to_batch``/``prior_template`` hooks.
+
+These tests are CPU-only, GPU-free and import no optional deps.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import pytest
+import torch
+from tensordict import TensorDict
+from torch import Tensor, nn
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.gen.enums import GenerativeIntent, Modality
+from nvalchemi.models.gen.base import (
+    GenerativeModelConfig,
+    GenerativeModelMixin,
+)
+
+
+def _make_atomic_data(num_atoms: int = 3) -> AtomicData:
+    """Build a minimal :class:`AtomicData` for tests.
+
+    Parameters
+    ----------
+    num_atoms
+        Number of atoms in the dummy structure.
+
+    Returns
+    -------
+    AtomicData
+        A small structure with random positions and carbon atomic numbers.
+    """
+    return AtomicData(
+        positions=torch.randn(num_atoms, 3),
+        atomic_numbers=torch.full((num_atoms,), 6, dtype=torch.long),
+    )
+
+
+def _make_batch(num_graphs: int = 2) -> Batch:
+    """Build a small :class:`Batch` for tests.
+
+    Parameters
+    ----------
+    num_graphs
+        Number of graphs to batch.
+
+    Returns
+    -------
+    Batch
+        A batch of dummy structures.
+    """
+    return Batch.from_data_list([_make_atomic_data() for _ in range(num_graphs)])
+
+
+class _DemoGenerativeModel(nn.Module, GenerativeModelMixin):
+    """Tiny generative model for contract tests.
+
+    A constant-velocity flow model: the state is one 3-vector per graph
+    (shape ``(B, 1, 3)``), and the predicted velocity drives the state toward
+    a fixed target. It implements the full required surface plus the optional
+    ``to_batch`` and ``prior_template`` hooks.
+    """
+
+    def __init__(self, target: Tensor | None = None) -> None:
+        super().__init__()
+        self.target = target if target is not None else torch.tensor([[1.0, 0.0, 0.0]])
+        self.model_config = GenerativeModelConfig(
+            intents={GenerativeIntent.CREATE, GenerativeIntent.SAMPLE},
+            supports_variable_atoms=True,
+            output_artifact=Modality.CRYSTAL,
+            intent_modality_map={
+                GenerativeIntent.CREATE: frozenset({Modality.CRYSTAL}),
+                GenerativeIntent.SAMPLE: frozenset({Modality.CRYSTAL}),
+            },
+            consumes_fields=frozenset({"positions", "atomic_numbers"}),
+            produces_fields=frozenset({"positions", "atomic_numbers"}),
+        )
+
+    def forward(
+        self,
+        data: Batch,
+        *,
+        x: Tensor,
+        t: Tensor | float,
+        xsc: Tensor | None = None,
+        **kwargs,
+    ) -> Tensor:
+        """Return a raw velocity toward ``self.target``.
+
+        Parameters
+        ----------
+        data
+            Conditioning batch (unused by this toy model).
+        x
+            Current flow state ``(B, 1, 3)``.
+        t
+            Flow timestep (unused).
+        xsc
+            Self-conditioning state (unused).
+        **kwargs
+            Forwarded arguments (unused).
+
+        Returns
+        -------
+        Tensor
+            Velocity ``target - x`` broadcast over the batch.
+        """
+        del data, t, xsc, kwargs
+        target = self.target.to(x.device, dtype=x.dtype).expand_as(x)
+        return target - x
+
+    def to_batch(self, sample: TensorDict, cond_batch: Batch) -> Batch:
+        """Reconstruct by returning the conditioning batch unchanged.
+
+        Parameters
+        ----------
+        sample
+            Sample TensorDict (unused by this toy model).
+        cond_batch
+            Conditioning batch.
+
+        Returns
+        -------
+        Batch
+            ``cond_batch`` unchanged.
+        """
+        del sample
+        return cond_batch
+
+    def prior_template(self, cond_batch: Batch) -> Tensor:
+        """Return a zero template state ``(B, 1, 3)``.
+
+        Parameters
+        ----------
+        cond_batch
+            Conditioning batch.
+
+        Returns
+        -------
+        Tensor
+            Zeros shaped ``(num_graphs, 1, 3)``.
+        """
+        return torch.zeros(cond_batch.num_graphs, 1, 3)
+
+
+class TestGenerativeModelConfig:
+    """Tests for :class:`GenerativeModelConfig`."""
+
+    @staticmethod
+    def _build_cfg() -> GenerativeModelConfig:
+        """Build a representative config used across the tests.
+
+        Returns
+        -------
+        GenerativeModelConfig
+            A config with create/sample (output) and condition (input) intents.
+        """
+        return GenerativeModelConfig(
+            intents={
+                GenerativeIntent.CREATE,
+                GenerativeIntent.SAMPLE,
+                GenerativeIntent.CONDITION,
+            },
+            supports_variable_atoms=True,
+            output_artifact=Modality.CRYSTAL,
+            intent_modality_map={
+                GenerativeIntent.CREATE: frozenset({Modality.CRYSTAL}),
+                GenerativeIntent.SAMPLE: frozenset({Modality.CRYSTAL}),
+                GenerativeIntent.CONDITION: frozenset({Modality.TEXT}),
+            },
+            consumes_fields=frozenset({"positions", "atomic_numbers"}),
+            produces_fields=frozenset({"positions", "atomic_numbers"}),
+        )
+
+    def test_construction(self) -> None:
+        """Config accepts the documented fields and defaults."""
+        cfg = self._build_cfg()
+        assert cfg.supports_variable_atoms is True
+        assert cfg.output_artifact is Modality.CRYSTAL
+        assert cfg.active_prediction_outputs is None
+
+    def test_intents_in_map_validator_rejects_mismatch(self) -> None:
+        """A missing intent in the map raises :class:`ValueError`."""
+        with pytest.raises(ValueError, match="missing from intent_modality_map"):
+            GenerativeModelConfig(
+                intents={GenerativeIntent.CREATE, GenerativeIntent.PROPOSE},
+                supports_variable_atoms=True,
+                output_artifact=Modality.CRYSTAL,
+                intent_modality_map={
+                    GenerativeIntent.CREATE: frozenset({Modality.CRYSTAL}),
+                },
+                consumes_fields=frozenset(),
+                produces_fields=frozenset({"positions"}),
+            )
+
+    def test_input_and_output_modalities(self) -> None:
+        """``output_modalities`` covers output intents + artifact; input covers the rest."""
+        cfg = self._build_cfg()
+        assert cfg.output_modalities == frozenset({Modality.CRYSTAL})
+        assert cfg.input_modalities == frozenset({Modality.TEXT})
+
+    def test_config_round_trip(self) -> None:
+        """Serialize -> deserialize -> equality ."""
+        cfg = self._build_cfg()
+        restored = GenerativeModelConfig.model_validate(cfg.model_dump())
+        assert restored == cfg
+        assert restored.input_modalities == cfg.input_modalities
+        assert restored.output_modalities == cfg.output_modalities
+
+    def test_active_prediction_outputs_round_trip(self) -> None:
+        """A non-default ``active_prediction_outputs`` survives a round-trip."""
+        cfg = GenerativeModelConfig(
+            intents={GenerativeIntent.CREATE},
+            supports_variable_atoms=False,
+            output_artifact=Modality.POINT_CLOUD,
+            intent_modality_map={
+                GenerativeIntent.CREATE: frozenset({Modality.POINT_CLOUD}),
+            },
+            consumes_fields=frozenset(),
+            produces_fields=frozenset({"positions"}),
+            active_prediction_outputs={"flow"},
+        )
+        restored = GenerativeModelConfig.model_validate(cfg.model_dump())
+        assert restored == cfg
+        assert restored.active_prediction_outputs == {"flow"}
+
+    def test_field_declarations_required(self) -> None:
+        """Omitting ``consumes_fields``/``produces_fields`` raises."""
+        with pytest.raises(ValueError, match="consumes_fields"):
+            GenerativeModelConfig(
+                intents={GenerativeIntent.CREATE},
+                supports_variable_atoms=True,
+                output_artifact=Modality.CRYSTAL,
+                intent_modality_map={
+                    GenerativeIntent.CREATE: frozenset({Modality.CRYSTAL}),
+                },
+            )
+
+
+class TestGenerativeModelMixin:
+    """Tests for :class:`GenerativeModelMixin` via the demo subclass."""
+
+    def test_model_config_enforced_at_construction(self) -> None:
+        """A subclass that forgets ``model_config`` raises :class:`TypeError`."""
+
+        class _BadModel(nn.Module, GenerativeModelMixin):
+            def __init__(self) -> None:
+                super().__init__()
+                # intentionally no self.model_config
+
+            def forward(self, data, *, x, t, xsc=None, **kwargs):  # noqa: ANN001
+                del data, x, t, xsc, kwargs
+                return x
+
+        with pytest.raises(TypeError, match="must set"):
+            _BadModel()
+
+    def test_forward_returns_raw_velocity(self) -> None:
+        """``forward`` returns a raw tensor (not ``ModelOutputs``)."""
+        model = _DemoGenerativeModel()
+        batch = _make_batch(num_graphs=2)
+        x = torch.zeros(2, 1, 3)
+        raw = model.forward(batch, x=x, t=0.5)
+        assert isinstance(raw, Tensor)
+        assert raw.shape == (2, 1, 3)
+
+    def test_adapt_output_emits_flow_key(self) -> None:
+        """``adapt_output`` structures raw output under the ``"flow"`` key."""
+        model = _DemoGenerativeModel()
+        batch = _make_batch(num_graphs=2)
+        raw = torch.randn(2, 1, 3)
+        out = model.adapt_output(raw, batch)
+        assert isinstance(out, OrderedDict)
+        assert "flow" in out
+        assert out["flow"] is raw
+
+    def test_condition_replicates_by_num_samples(self) -> None:
+        """``condition`` tiles each conditioning graph ``num_samples`` times."""
+        model = _DemoGenerativeModel()
+        batch = _make_batch(num_graphs=2)
+        cond = model.condition(batch, num_samples=3)
+        assert isinstance(cond, Batch)
+        assert cond.num_graphs == 6
+
+    def test_condition_single_atomic_data(self) -> None:
+        """``condition`` on an :class:`AtomicData` builds a replicated batch."""
+        model = _DemoGenerativeModel()
+        ad = _make_atomic_data()
+        cond = model.condition(ad, num_samples=4)
+        assert cond is not None
+        assert cond.num_graphs == 4
+
+    def test_condition_passes_through_tensor_containers(self) -> None:
+        """The default condition passes a TensorDict through unchanged."""
+        model = _DemoGenerativeModel()
+        container = TensorDict({"emb": torch.randn(4, 8)}, batch_size=[4])
+        assert model.condition(container, num_samples=3) is container
+
+    def test_to_batch_and_prior_template_hooks(self) -> None:
+        """Optional ``to_batch`` and ``prior_template`` hooks work as documented."""
+        model = _DemoGenerativeModel()
+        batch = _make_batch(num_graphs=3)
+        template = model.prior_template(batch)
+        assert template.shape == (3, 1, 3)
+        sample = TensorDict({"x1": torch.randn(3, 1, 3)}, batch_size=[3])
+        recon = model.to_batch(sample, batch)
+        assert recon is batch
+
+    def test_extra_repr_uses_config(self) -> None:
+        """``extra_repr`` summarizes the generative config."""
+        model = _DemoGenerativeModel()
+        rep = model.extra_repr()
+        assert "create" in rep
+        assert "crystal" in rep


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

Introduces the **core** of the abstract interface for generative workflows (`nvalchemi.gen`) — PR 1 of a 3-PR stack. The design intention: generation (diffusion/flow matching, GANs, VAEs, non-neural methods) plugs into the same machinery the toolkit already uses for dynamics and training — a fixed driver with lifecycle hooks and batch-first data flow. The family-specific sampling procedure lives in a user-supplied `GeneratingFunction`; the function owns the model (when there is one), and the driver runs the condition → generate → materialize pipeline around it.

Reconciled per the review discussion (see the review-response commit `32cd8c1d`): the driver absorbs the model rather than wrapping it, conditioning is optional and function-owned with a driver-level `condition_func` override (no default condition), `batch_mapping` (formerly `output_to_batch_func`) is optional with raw-sample passthrough, and the model config slims to a four-field frozen capability declaration with the `Modality`/`GenerativeIntent` enums removed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

First PR of the generative-workflows series. Stack: **this PR** (core driver + pipeline) → docs (laserkelvin#33) → serialization (laserkelvin#34).

## Changes Made

- `AtomisticGenerator` (`nvalchemi.gen`): the abstract inference driver — condition (optional) → generate → materialize (optional) with hook dispatch at the `GenerationStage` points of the steps that ran, sharing a per-call `GenerationContext` (centralized in `nvalchemi.hooks` with the dynamics/training contexts); `stream()` for iterative consumption; session context managers (dedicated CUDA stream with `dedicated_stream=False` opt-out, seeded per-draw RNG, lazy `torch.compile` of the generating function); `device` validated at construction against the host.
- `GeneratingFunction` protocol: one calling convention per family, `(inputs=None, *, num_samples=1, rng=None, **kwargs)`; the function owns the model, its field declarations, and its conditioning. `ConditionFunction` protocol for the condition step. `MaterializationFunction` (`batch_mapping`) maps the raw sample to a `Batch`; unset, the call returns the raw sample.
- `GenerationPipeline` (`gen_a | gen_b`): sequential composition of generators, dynamics engines, and `Batch -> Batch` callables, with construction-time field-contract validation and a shared CUDA stream across stages in a session.
- Model-side contract: `GenerativeModelMixin` + `GenerativeModelConfig` (the non-energy counterpart to `BaseModelMixin`) — a frozen four-field declaration (`supports_variable_atoms`, `consumes_fields`, `produces_fields`, `prediction_outputs`).
- Demo placeholders for testing and debugging (`DemoGANModel`, `DemoDiffusionModel` with `make_demo_*_generate` factories, `demo_nonparametric_generation`), the generative counterpart to `DemoModel`/`DemoModelWrapper`.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Notes: `make` targets default to a CUDA extra unavailable on macOS, so the equivalent direct invocations were used (`uv run pytest`, `uv run ruff check/format`, `uv run interrogate` at 100%). This branch's suites (driver, pipeline, model contract, demos, hooks): 106 tests passing, 11 skipped (CUDA legs run on GPU CI); 1756 across the gen/models/hooks/training sweep.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The generating-function factories and the demo procedures are designed to be spec-compatible (module-level, dotted-path importable); the serialization surface itself lands in the stack's final PR.
