### PR TITLE
feat(gen): GenerationPipeline — sequential composition (2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   before `AFTER_GENERATE` hooks fire — lifecycle hooks sharing a per-call
   `GenerationContext`, `stream()`, and session context managers (dedicated
   CUDA stream, session RNG, lazy `torch.compile`). Generating functions
-  return `TensorDict` samples.
+  return `TensorDict` samples. Sequential composition via `gen_a | gen_b`
+  (`GenerationPipeline`, with construction-time field-contract validation).
 - Demo generative models (`nvalchemi.models.gen.demo`): `DemoGANModel` and
   `DemoDiffusionModel` — minimal `GenerativeModelMixin` placeholders for
   testing and debugging (the generative counterpart to

--- a/nvalchemi/gen/__init__.py
+++ b/nvalchemi/gen/__init__.py
@@ -18,7 +18,8 @@ This package provides the abstract
 :class:`~nvalchemi.gen.generator.AtomGenerator` inference driver — a fixed
 condition → generate pipeline with lifecycle hooks
 (:class:`~nvalchemi.gen.stages.GenerationStage`,
-:class:`~nvalchemi.hooks.GenerationContext`).
+:class:`~nvalchemi.hooks.GenerationContext`) — plus sequential
+composition via :class:`~nvalchemi.gen.pipeline.GenerationPipeline`.
 """
 
 from __future__ import annotations
@@ -29,12 +30,14 @@ from nvalchemi.gen.generator import (
     GeneratingFunction,
     default_condition,
 )
+from nvalchemi.gen.pipeline import GenerationPipeline
 from nvalchemi.gen.stages import GenerationStage
 from nvalchemi.hooks import GenerationContext
 
 __all__ = [
     "AtomGenerator",
     "GenerationContext",
+    "GenerationPipeline",
     "GenerationStage",
     "GenerativeIntent",
     "GeneratingFunction",

--- a/nvalchemi/gen/generator.py
+++ b/nvalchemi/gen/generator.py
@@ -75,6 +75,12 @@ repeated unconditional draws::
     for batch in gan.stream(conds=None, max_batches=10):
         ...
 
+**Composition** — sequential pipelines mirror the dynamics ``|`` sugar
+(:class:`~nvalchemi.gen.pipeline.GenerationPipeline`)::
+
+    pipe = gen_a | gen_b
+    out = pipe(cond)
+
 **Sessions: streams, RNG, and compile** — an ``AtomGenerator`` is a context
 manager. Entering a session (``with gen:``) creates a dedicated CUDA stream
 when the model is CUDA-resident, seeds a session-scoped
@@ -93,7 +99,7 @@ import inspect
 import itertools
 from collections.abc import Iterator
 from contextlib import nullcontext
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 import torch
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -102,6 +108,9 @@ from tensordict import TensorDict, TensorDictBase
 from nvalchemi.data import AtomicData, Batch
 from nvalchemi.gen.stages import GenerationStage
 from nvalchemi.hooks import GenerationContext, Hook, HookRegistryMixin
+
+if TYPE_CHECKING:
+    from nvalchemi.gen.pipeline import GenerationPipeline
 
 __all__ = ["GeneratingFunction", "AtomGenerator", "default_condition"]
 
@@ -844,3 +853,27 @@ class AtomGenerator(BaseModel, HookRegistryMixin):
             ``self.stream()`` — an unbounded stream of unconditional draws.
         """
         return self.stream()
+
+    def __or__(self, other: Any) -> GenerationPipeline:
+        """Compose sequentially into a :class:`GenerationPipeline`.
+
+        Mirrors :meth:`nvalchemi.dynamics.base.BaseDynamics.__or__`. (``+``
+        stays reserved for concurrent/fused composition, as in dynamics.)
+
+        Parameters
+        ----------
+        other
+            A :class:`AtomGenerator`, a dynamics engine, a ``Batch -> Batch``
+            callable, or an existing pipeline.
+
+        Returns
+        -------
+        GenerationPipeline
+            ``self`` followed by ``other`` (prepended when ``other`` is
+            already a pipeline).
+        """
+        from nvalchemi.gen.pipeline import GenerationPipeline
+
+        if isinstance(other, GenerationPipeline):
+            return GenerationPipeline(stages=[self, *other.stages])
+        return GenerationPipeline(stages=[self, other])

--- a/nvalchemi/gen/pipeline.py
+++ b/nvalchemi/gen/pipeline.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sequential composition of generators and other batch-processing stages.
+
+A :class:`GenerationPipeline` is a thin orchestrator: it folds a
+conditioning input through an ordered list of stages — generators, dynamics
+engines, or any ``Batch -> Batch`` callable — mirroring the dynamics
+``|`` sugar (:meth:`nvalchemi.dynamics.base.BaseDynamics.__or__` builds a
+``DistributedPipeline``; here ``AtomGenerator.__or__`` builds a
+``GenerationPipeline``).
+
+Example
+-------
+::
+
+    pipe = gen_a | gen_b | optimizer
+    out = pipe(cond)                      # one fold through the stages
+    for batch in pipe.stream(conds):      # lazy per-item fold
+        ...
+
+Semantics:
+
+* **Stage 1 consumes the ``cond``** (via its ``condition``); every later
+  stage maps Batch → Batch.
+* **1→1 cardinality** per stage: filters may shrink a batch; nothing fans
+  out. (A filter may not shrink a batch to *empty* today —
+  :class:`~nvalchemi.data.Batch` raises ``IndexError`` on zero-graph
+  selections; empty-batch support is a separate data-layer decision.)
+* **Empty batches short-circuit** (defensive contract): should a stage ever
+  yield a zero-graph batch, remaining stages are skipped for that item and
+  the empty batch is returned as-is. No shipped path currently produces one.
+* **Per-stage hooks**: each :class:`~nvalchemi.gen.generator.AtomGenerator`
+  stage keeps its own hooks and
+  :class:`~nvalchemi.hooks.GenerationContext`; the pipeline passes only
+  the batch between stages.
+* **Sessions and compile**: ``with pipe:`` creates one dedicated CUDA
+  stream (when the first AtomGenerator stage's model is CUDA-resident) shared by
+  every AtomGenerator stage — sequential stages serialize on it with no
+  cross-stream sync. :meth:`compile` compiles each AtomGenerator stage's
+  generating function (non-AtomGenerator stages are skipped); there is
+  deliberately no whole-fold compile, since the Batch plumbing between
+  stages would graph-break for no real capture.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+from typing import Any
+
+import torch
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from nvalchemi.data import Batch
+from nvalchemi.gen.generator import AtomGenerator
+
+__all__ = ["GenerationPipeline"]
+
+
+class GenerationPipeline(BaseModel):
+    """Sequential composition of generation and batch-processing stages.
+
+    Attributes
+    ----------
+    stages
+        Ordered pipeline stages: :class:`~nvalchemi.gen.generator.AtomGenerator`
+        instances, dynamics engines, or ``Batch -> Batch`` callables.
+
+    Notes
+    -----
+    **Field-contract validation.** Every ``AtomGenerator`` stage must declare
+    ``consumes_fields`` / ``produces_fields`` (set on the AtomGenerator directly
+    or defaulted from ``model.model_config``); construction raises otherwise.
+    For each adjacent AtomGenerator → AtomGenerator link, the downstream stage's
+    ``consumes_fields`` must be covered by the upstream stage's
+    ``produces_fields`` — the ``ModelConfig.required_inputs`` pattern
+    (AIMNet2 ``charges`` → Ewald) applied to generation. Authors of custom
+    ``output_to_batch_func`` callables own keeping their stage's declaration in sync
+    with what the callable actually writes. Non-AtomGenerator stages carry no
+    declarations and are not validated (their outputs are unknown at
+    construction).
+
+    The first stage's ``consumes_fields`` describe its *conditioning* input
+    and are not validated (the pipeline cannot know what a user's ``cond``
+    carries).
+
+    **Sessions and compile.** ``GenerationPipeline`` is a context manager:
+    entry creates one dedicated CUDA stream (when the first
+    :class:`~nvalchemi.gen.generator.AtomGenerator` stage's model is
+    CUDA-resident) and shares it with every AtomGenerator stage, then enters
+    each AtomGenerator stage's own session (session RNG, lazy compile,
+    context-manager hooks). Non-AtomGenerator stages manage their own contexts.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    stages: list[Any] = Field(
+        min_length=1,
+        description=(
+            "Ordered stages: Generators, dynamics engines, or Batch -> Batch callables."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_links(self) -> GenerationPipeline:
+        """Validate declarations and adjacent AtomGenerator→AtomGenerator links.
+
+        Returns
+        -------
+        GenerationPipeline
+            The validated pipeline.
+
+        Raises
+        ------
+        ValueError
+            If a AtomGenerator stage lacks field declarations, or a stage's
+            ``consumes_fields`` are not covered by the immediately
+            upstream AtomGenerator's ``produces_fields``.
+        """
+        for index, stage in enumerate(self.stages):
+            if not isinstance(stage, AtomGenerator):
+                continue
+            consumes = stage.consumes_fields
+            produces = stage.produces_fields
+            if consumes is None or produces is None:
+                raise ValueError(
+                    f"Pipeline stage {index} ({type(stage.model).__name__} "
+                    "generator) declares neither consumes_fields nor "
+                    "produces_fields: set them on the AtomGenerator or on the "
+                    "model's GenerativeModelConfig."
+                )
+            prev = self.stages[index - 1] if index > 0 else None
+            if isinstance(prev, AtomGenerator):
+                # Validated non-None on the previous iteration.
+                produced = prev.produces_fields or frozenset()
+                missing = set(consumes) - set(produced)
+                if missing:
+                    raise ValueError(
+                        f"Pipeline stage {index} consumes fields "
+                        f"{sorted(missing)} that the upstream stage does not "
+                        "produce (produces_fields="
+                        f"{sorted(produced)}). Fix the "
+                        "declarations or insert a stage that writes them."
+                    )
+        return self
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize session state."""
+        self._stream: torch.cuda.Stream | None = None
+        self._stream_ctx: Any = None
+
+    def compile(self, **kwargs: Any) -> GenerationPipeline:
+        """Compile every AtomGenerator stage's generating function.
+
+        Per-stage compilation (see :meth:`AtomGenerator.compile`); non-AtomGenerator
+        stages are skipped. There is deliberately no whole-fold compile: the
+        Batch plumbing and hook dispatch between stages would graph-break for
+        no real capture. (Cross-stage tensor fusion is a separate research
+        item.)
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to each stage's :meth:`AtomGenerator.compile`.
+
+        Returns
+        -------
+        GenerationPipeline
+            This instance, for fluent chaining.
+        """
+        for stage in self.stages:
+            if isinstance(stage, AtomGenerator):
+                stage.compile(**kwargs)
+        return self
+
+    def _infer_device(self) -> torch.device | None:
+        """Infer the session device from the first AtomGenerator stage's model.
+
+        Returns
+        -------
+        torch.device | None
+            The device, or ``None`` when no AtomGenerator stage can provide one.
+        """
+        for stage in self.stages:
+            if isinstance(stage, AtomGenerator):
+                return stage._infer_device()
+        return None
+
+    def __enter__(self) -> GenerationPipeline:
+        """Enter a pipeline session: one CUDA stream shared across stages.
+
+        Creates one dedicated CUDA stream (when the first AtomGenerator stage's
+        model is CUDA-resident), points every AtomGenerator stage at it, and
+        enters each AtomGenerator stage's own session (session RNG, lazy
+        compile, context-manager hooks — stream creation is skipped because
+        ``stage._stream`` is already set). Non-AtomGenerator stages manage their
+        own contexts.
+
+        Returns
+        -------
+        GenerationPipeline
+            This instance.
+        """
+        device = self._infer_device()
+        if device is not None and device.type == "cuda":
+            self._stream = torch.cuda.Stream(device=device)
+            self._stream_ctx = torch.cuda.stream(self._stream)
+            self._stream_ctx.__enter__()
+        for stage in self.stages:
+            if isinstance(stage, AtomGenerator):
+                stage._stream = self._stream
+                stage.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the session: exit each AtomGenerator stage, then the stream.
+
+        Parameters
+        ----------
+        exc_type, exc_val, exc_tb
+            The active exception, if any.
+        """
+        for stage in self.stages:
+            if isinstance(stage, AtomGenerator):
+                stage.__exit__(exc_type, exc_val, exc_tb)
+        if self._stream_ctx is not None:
+            self._stream_ctx.__exit__(exc_type, exc_val, exc_tb)
+        self._stream = None
+        self._stream_ctx = None
+
+    def __call__(self, cond: Any = None, **kwargs: Any) -> Batch:
+        """Fold ``cond`` through the stages.
+
+        Parameters
+        ----------
+        cond
+            Conditioning input for the first stage (a
+            :class:`~nvalchemi.data.Batch`, another tensor container, or
+            ``None``).
+        **kwargs
+            Per-call options forwarded to every stage (e.g. generator
+            function options).
+
+        Returns
+        -------
+        Batch
+            The final stage's output. Should a stage ever yield a zero-graph
+            batch, remaining stages are skipped and it is returned as-is
+            (defensive; no current :class:`~nvalchemi.data.Batch` path
+            produces one).
+        """
+        result: Any = cond
+        for stage in self.stages:
+            if isinstance(result, Batch) and result.num_graphs == 0:
+                break
+            result = stage(result, **kwargs)
+        return result
+
+    def stream(
+        self,
+        conds: Any = None,
+        *,
+        max_batches: int | None = None,
+        **kwargs: Any,
+    ) -> Iterator[Batch]:
+        """Stream pipeline outputs, mirroring :meth:`AtomGenerator.stream`.
+
+        One fold per conditioning item; ``conds`` is the data source.
+
+        Parameters
+        ----------
+        conds
+            Iterable of conditioning inputs, or ``None`` for repeated
+            unconditional draws.
+        max_batches
+            Cap on batches yielded (``None`` means unbounded).
+        **kwargs
+            Per-call options forwarded to :meth:`__call__`.
+
+        Yields
+        ------
+        Batch
+            One batch per fold, exactly as produced.
+        """
+        if conds is None:
+            conds = itertools.repeat(None)
+        for index, cond in enumerate(conds):
+            if max_batches is not None and index >= max_batches:
+                return
+            yield self(cond, **kwargs)
+
+    def __or__(self, other: Any) -> GenerationPipeline:
+        """Append a stage, returning a new pipeline.
+
+        Parameters
+        ----------
+        other
+            A stage to append (AtomGenerator, dynamics engine, or callable).
+
+        Returns
+        -------
+        GenerationPipeline
+            A pipeline of ``self.stages`` followed by ``other``.
+        """
+        return GenerationPipeline(stages=[*self.stages, other])

--- a/test/gen/test_gen_pipeline.py
+++ b/test/gen/test_gen_pipeline.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structural tests for :class:`~nvalchemi.gen.pipeline.GenerationPipeline`.
+
+Covers the ``|`` composition sugar, fold/stream semantics, empty-batch
+short-circuiting, and construction-time field-contract validation
+(``consumes_fields`` / ``produces_fields``). CPU-only, GPU-free, no optional
+deps.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nvalchemi.data import Batch
+from nvalchemi.gen.generator import AtomGenerator
+from nvalchemi.gen.pipeline import GenerationPipeline
+from nvalchemi.gen.stages import GenerationStage
+from nvalchemi.models.gen.demo import DemoGANModel
+from test.gen.conftest import make_batch, trivial_generate, zeros_to_batch
+
+
+def _generator(
+    *,
+    consumes: frozenset[str] | None = None,
+    produces: frozenset[str] | None = None,
+    hooks: list | None = None,
+    device: str = "cpu",
+) -> AtomGenerator:
+    """Build a minimal pipeline-ready generator with field declarations.
+
+    Parameters
+    ----------
+    consumes, produces
+        Field declarations (default to empty frozensets, i.e. declared).
+    hooks
+        Optional generation hooks.
+
+    Returns
+    -------
+    AtomGenerator
+        A declared, ``DemoGANModel``-backed generator.
+    """
+    return AtomGenerator(
+        model=DemoGANModel().to(device),
+        consumes_fields=frozenset() if consumes is None else consumes,
+        produces_fields=frozenset() if produces is None else produces,
+        hooks=hooks or [],
+    )
+
+
+class _KeepFirst:
+    """Hook that keeps only the first graph at AFTER_GENERATE."""
+
+    stage = GenerationStage.AFTER_GENERATE
+    frequency = 1
+
+    def __call__(self, ctx, stage) -> None:
+        """Subset the batch to its first graph."""
+        ctx.batch = ctx.batch[[0]]
+
+
+class TestCompositionSugar:
+    """``|`` operator behavior."""
+
+    def test_generator_or_generator_builds_pipeline(self) -> None:
+        """``gen_a | gen_b`` is a two-stage pipeline."""
+        gen_a, gen_b = _generator(), _generator()
+        pipe = gen_a | gen_b
+        assert isinstance(pipe, GenerationPipeline)
+        assert pipe.stages == [gen_a, gen_b]
+
+    def test_generator_or_pipeline_prepends(self) -> None:
+        """``gen | pipe`` prepends the generator."""
+        gen_a, gen_b, gen_c = _generator(), _generator(), _generator()
+        pipe = gen_a | (gen_b | gen_c)
+        assert pipe.stages == [gen_a, gen_b, gen_c]
+
+    def test_pipeline_or_stage_appends(self) -> None:
+        """``pipe | stage`` appends."""
+        gen_a, gen_b = _generator(), _generator()
+        tagger_calls = []
+
+        def tagger(batch: Batch) -> Batch:
+            """Record a call and pass the batch through."""
+            tagger_calls.append(batch.num_graphs)
+            return batch
+
+        pipe = (gen_a | gen_b) | tagger
+        assert len(pipe.stages) == 3
+        pipe(make_batch(num_graphs=1))
+        assert tagger_calls == [1]
+
+
+class TestFoldAndStream:
+    """Fold and stream semantics."""
+
+    def test_call_folds_stages(self, device: str) -> None:
+        """Stage 2 receives stage 1's output batch."""
+        gen_a = _generator(produces=frozenset({"positions"}), device=device)
+        gen_b = _generator(consumes=frozenset({"positions"}), device=device)
+        pipe = GenerationPipeline(stages=[gen_a, gen_b])
+        out = pipe(make_batch(num_graphs=2).to(device))
+        assert isinstance(out, Batch)
+        assert out.num_graphs == 2
+        assert out["positions"].device.type == device
+
+    def test_stream_mirrors_generator_stream(self) -> None:
+        """``stream`` folds lazily, one pipeline call per cond item."""
+        pipe = _generator() | _generator()
+        conds = [make_batch(num_graphs=1), make_batch(num_graphs=2)]
+        out = list(pipe.stream(conds))
+        assert [b.num_graphs for b in out] == [1, 2]
+
+    def test_stream_caps_with_max_batches(self) -> None:
+        """``max_batches`` bounds a cond stream."""
+        pipe = _generator() | _generator()
+        conds = [make_batch(num_graphs=1)] * 3
+        out = list(pipe.stream(conds, max_batches=2))
+        assert len(out) == 2
+
+    def test_subset_filter_flows_through_pipeline(self) -> None:
+        """A mid-pipeline filter shrinks the batch downstream stages see."""
+        calls: list = []
+
+        class _Mark:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Record the batch size this stage produced."""
+                calls.append(ctx.batch.num_graphs)
+
+        gen_filter = _generator(hooks=[_KeepFirst()])
+        gen_downstream = _generator(hooks=[_Mark()])
+        pipe = GenerationPipeline(stages=[gen_filter, gen_downstream])
+        out = pipe(make_batch(num_graphs=3))
+        assert out.num_graphs == 1
+        assert calls == [1]
+
+    def test_filter_to_empty_raises(self) -> None:
+        """Filtering to zero graphs raises ``IndexError`` (data-layer limit)."""
+
+        class _RejectAll:
+            stage = GenerationStage.AFTER_GENERATE
+            frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Reject every graph."""
+                ctx.batch = ctx.batch[
+                    torch.zeros(ctx.batch.num_graphs, dtype=torch.bool)
+                ]
+
+        pipe = GenerationPipeline(
+            stages=[_generator(hooks=[_RejectAll()]), _generator()]
+        )
+        with pytest.raises(IndexError, match="Index is empty"):
+            pipe(make_batch(num_graphs=2))
+
+    def test_per_stage_hooks_are_isolated(self) -> None:
+        """Each stage's hooks see that stage's own context."""
+        seen: list = []
+
+        class _Mark:
+            def __init__(self, name: str) -> None:
+                self.name = name
+                self.stage = GenerationStage.AFTER_GENERATE
+                self.frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """Record the stage's workflow identity."""
+                seen.append((self.name, ctx.workflow))
+
+        gen_a = _generator(hooks=[_Mark("a")])
+        gen_b = _generator(hooks=[_Mark("b")])
+        pipe = GenerationPipeline(stages=[gen_a, gen_b])
+        pipe(make_batch(num_graphs=1))
+        assert seen[0][1] is gen_a
+        assert seen[1][1] is gen_b
+
+
+class TestFieldContractValidation:
+    """Construction-time validation of AtomGenerator stage links."""
+
+    def test_undeclared_generator_stage_raises(self) -> None:
+        """A AtomGenerator with no declaration source is rejected in a pipeline."""
+        undeclared = AtomGenerator(
+            model=torch.nn.Module(),
+            generator_func=trivial_generate,
+            output_to_batch_func=zeros_to_batch,
+        )
+        with pytest.raises(ValueError, match="declares neither"):
+            GenerationPipeline(stages=[_generator(), undeclared])
+
+    def test_missing_upstream_field_raises(self) -> None:
+        """``consumes ⊄ upstream produces`` fails fast at construction."""
+        producer = _generator(produces=frozenset({"positions"}))
+        consumer = _generator(consumes=frozenset({"charges"}))
+        with pytest.raises(ValueError, match="charges"):
+            GenerationPipeline(stages=[producer, consumer])
+
+    def test_satisfied_link_passes(self) -> None:
+        """A declared, covered link constructs cleanly."""
+        producer = _generator(produces=frozenset({"charges", "positions"}))
+        consumer = _generator(consumes=frozenset({"charges"}))
+        pipe = GenerationPipeline(stages=[producer, consumer])
+        assert isinstance(pipe, GenerationPipeline)
+
+    def test_first_stage_consumes_unvalidated(self) -> None:
+        """The first stage reads ``cond``; its consumes_fields are not checked."""
+        first = _generator(consumes=frozenset({"anything"}))
+        pipe = GenerationPipeline(stages=[first, _generator()])
+        assert isinstance(pipe, GenerationPipeline)
+
+    def test_non_generator_stage_unvalidated(self) -> None:
+        """A Batch -> Batch callable between Generators carries no contract."""
+        producer = _generator(produces=frozenset({"positions"}))
+        consumer = _generator(consumes=frozenset({"charges"}))
+
+        def passthrough(batch: Batch) -> Batch:
+            """Identity stage with no field declarations."""
+            return batch
+
+        # The non-AtomGenerator stage breaks adjacency, so the link is not checked.
+        pipe = GenerationPipeline(stages=[producer, passthrough, consumer])
+        assert isinstance(pipe, GenerationPipeline)
+
+
+class TestPipelineSessionAndCompile:
+    """Pipeline-level compile orchestration and shared-stream sessions."""
+
+    def test_compile_compiles_generator_stages(self) -> None:
+        """``pipe.compile()`` compiles each AtomGenerator stage; skips others."""
+        gen_a, gen_b = _generator(), _generator()
+
+        def passthrough(batch: Batch) -> Batch:
+            """Identity stage (not compilable by the pipeline)."""
+            return batch
+
+        pipe = GenerationPipeline(stages=[gen_a, passthrough, gen_b])
+        out = pipe.compile(backend="eager")
+        assert out is pipe
+        assert gen_a._compiled_generate is not None
+        assert gen_b._compiled_generate is not None
+
+    def test_session_enters_generator_stages(self) -> None:
+        """``with pipe:`` opens/closes each AtomGenerator stage's session."""
+        log: list = []
+
+        class _CMHook:
+            def __init__(self, name: str) -> None:
+                self.name = name
+                self.stage = GenerationStage.AFTER_GENERATE
+                self.frequency = 1
+
+            def __enter__(self) -> None:
+                """Record entry."""
+                log.append(f"enter-{self.name}")
+
+            def __exit__(self, *args) -> None:
+                """Record exit."""
+                log.append(f"exit-{self.name}")
+
+            def __call__(self, ctx, stage) -> None:
+                """No-op."""
+
+        gen_a = _generator(hooks=[_CMHook("a")])
+        gen_b = _generator(hooks=[_CMHook("b")])
+        pipe = GenerationPipeline(stages=[gen_a, gen_b])
+        with pipe:
+            out = pipe(make_batch(num_graphs=1))
+            assert out.num_graphs == 1
+            # CPU: no stream anywhere.
+            assert pipe._stream is None and gen_a._stream is None
+        assert log == ["enter-a", "enter-b", "exit-a", "exit-b"]
+
+    def test_session_lazy_compiles_marked_stages(self) -> None:
+        """A stage with ``compile_generate=True`` compiles at pipeline entry."""
+        gen_a = _generator()
+        gen_b = _generator()
+        gen_b.compile_generate = True
+        gen_b.compile_kwargs = {"backend": "eager"}
+        pipe = GenerationPipeline(stages=[gen_a, gen_b])
+        assert gen_b._compiled_generate is None
+        with pipe:
+            assert gen_a._compiled_generate is None
+            assert gen_b._compiled_generate is not None
+
+    def test_session_stream_sharing_matches_device(self, device: str) -> None:
+        """Stages share the pipeline's one stream on CUDA; no streams on CPU."""
+        gen_a = _generator(device=device)
+        gen_b = _generator(device=device)
+        pipe = GenerationPipeline(stages=[gen_a, gen_b])
+        with pipe:
+            out = pipe(make_batch(num_graphs=1).to(device))
+            assert out.num_graphs == 1
+            if device == "cuda":
+                assert pipe._stream is not None
+                assert gen_a._stream is pipe._stream
+                assert gen_b._stream is pipe._stream
+            else:
+                assert pipe._stream is None and gen_a._stream is None
+        assert pipe._stream is None and gen_a._stream is None

--- a/test/models/test_gen_demo.py
+++ b/test/models/test_gen_demo.py
@@ -139,3 +139,10 @@ class TestDemoNonparametricGeneration:
         )
         assert torch.equal(a["positions"], b["positions"])
         assert torch.equal(a["atomic_numbers"], b["atomic_numbers"])
+
+    def test_pipeline_source_stage(self) -> None:
+        """The function folds into a pipeline as a plain Batch -> Batch stage."""
+        pipe = AtomGenerator(model=DemoGANModel()) | demo_nonparametric_generation
+        out = pipe(None)
+        assert isinstance(out, Batch)
+        assert out.num_graphs == 1


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

PR 2 of the generative-workflows stack (on top of #184 — only the last commit's diff is new). Adds `GenerationPipeline`: sequential composition of generators, dynamics engines, and plain `Batch -> Batch` callables via the `|` operator, mirroring the dynamics sugar. Generated structures fold straight into relaxation/MD, and generators chain into each other (e.g. structure generation followed by in-painting).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Stacked on #184 (generative core). Followed by draft PRs for docs and specs.

## Changes Made

- `GenerationPipeline`: a thin orchestrator folding a conditioning input through heterogeneous stages; 1→1 per stage (a filter may shrink a batch; nothing fans out). Each `AtomGenerator` stage keeps its own hooks and context.
- `AtomGenerator.__or__` — `gen_a | gen_b` sugar, mirroring `BaseDynamics.__or__`.
- Construction-time field-contract validation: a stage declaring a field the immediately upstream generator does not produce fails fast (the `ModelConfig.required_inputs` pattern applied to generation).
- `pipe.compile(**kwargs)` compiles each generator stage's generating function; `with pipe:` runs the fold on one CUDA stream shared by all stages.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Notes: verified via `uv run pytest` / `uv run ruff` (make targets default to a CUDA extra unavailable on macOS). New suite covers the `|` sugar, fold/stream semantics, per-stage hook isolation, filter flow-through, field-contract validation, and session stream sharing (CUDA leg runs on GPU CI).

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

Part of the generative-workflows stack: #184 (core) → **this PR** → docs (draft) → specs (draft).
