### PR TITLE
feat(gen): spec-based construction and to_spec round-trip (4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@
   `GenerationContext`, `stream()`, and session context managers (dedicated
   CUDA stream, session RNG, lazy `torch.compile`). Generating functions
   return `TensorDict` samples. Sequential composition via `gen_a | gen_b`
-  (`GenerationPipeline`, with construction-time field-contract validation).
+  (`GenerationPipeline`, with construction-time field-contract validation)
+  and JSON spec construction (`AtomGeneratorSpec`, `GenerationPipelineSpec`),
+  with `to_spec()` on both classes for the reverse direction (capturing a
+  live generator/pipeline back to a spec for serialization and
+  reproducibility).
 - Demo generative models (`nvalchemi.models.gen.demo`): `DemoGANModel` and
   `DemoDiffusionModel` — minimal `GenerativeModelMixin` placeholders for
   testing and debugging (the generative counterpart to
   `DemoModel`/`DemoModelWrapper`) — plus `demo_nonparametric_generation`, a
-  synthetic-structure source for tests and debugging.
+  synthetic-structure source usable standalone or as a pipeline stage.
 - Domain decomposition for distributed inference and dynamics: a spatial halo
   strategy and a graph-parallel strategy, both driven by a declarative
   `MLIPSpec` a model wrapper publishes as `distribution_spec`. Ewald, PME,

--- a/docs/modules/gen.rst
+++ b/docs/modules/gen.rst
@@ -59,3 +59,16 @@ Model-side API
 
    GenerativeModelConfig
    GenerativeModelMixin
+
+Specs (opt-in import from ``nvalchemi.gen.spec``)
+-------------------------------------------------
+
+.. currentmodule:: nvalchemi.gen.spec
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   AtomGeneratorSpec
+   GenerationPipelineSpec

--- a/docs/userguide/generative.md
+++ b/docs/userguide/generative.md
@@ -31,6 +31,7 @@ all below; this table is the map.
 | {class}`~nvalchemi.models.gen.base.GenerativeModelMixin` / {class}`~nvalchemi.models.gen.base.GenerativeModelConfig` | The model side: what a generative model provides, and what it declares |
 | {class}`~nvalchemi.gen.enums.Modality` / {class}`~nvalchemi.gen.enums.GenerativeIntent` | The vocabulary for what a model ingests or emits, and how it is used |
 | {class}`~nvalchemi.gen.pipeline.GenerationPipeline` | Sequential composition of generators and other batch stages (`\|` sugar) |
+| {class}`~nvalchemi.gen.spec.AtomGeneratorSpec` / {class}`~nvalchemi.gen.spec.GenerationPipelineSpec` | JSON-serializable construction for config-driven workflows |
 
 ## The two steps: condition and generate
 
@@ -237,6 +238,45 @@ declares a field that the immediately upstream generator does not produce,
 pipeline construction fails fast — the same contract pattern as
 `ModelConfig.required_inputs` elsewhere in the toolkit.
 
+(generative-specs)=
+
+## Spec-based construction
+
+Generators and pipelines can be built from JSON specs, mirroring the
+training {mod}`nvalchemi.training` spec machinery (dotted import paths +
+JSON-safe kwargs, no pickle). The unit of spec-ability is the importable
+factory: bind family config in a module-level function, spec it with
+{func}`~nvalchemi.training._spec.create_model_spec`, and compose the pieces
+into {class}`~nvalchemi.gen.spec.AtomGeneratorSpec` /
+{class}`~nvalchemi.gen.spec.GenerationPipelineSpec`:
+
+```python
+from nvalchemi.gen.spec import AtomGeneratorSpec
+from nvalchemi.training._spec import create_model_spec
+
+func_spec = create_model_spec(make_gan_generate, latent_dim=256)
+spec = AtomGeneratorSpec(generator_func=func_spec, num_samples_per_batch=4)
+blob = spec.model_dump_json()                     # plain JSON; safe to store
+
+restored = AtomGeneratorSpec.model_validate_json(blob)
+gen = restored.build(model=model)                 # weights come from checkpoints
+```
+
+Weights are never part of a spec — models are injected at `build` time from
+the checkpoint machinery. The spec module is an opt-in import
+(`from nvalchemi.gen.spec import ...`) so that importing
+{mod}`nvalchemi.gen` stays light.
+
+The reverse direction works too:
+{meth}`~nvalchemi.gen.generator.AtomGenerator.to_spec` (and
+{meth}`~nvalchemi.gen.pipeline.GenerationPipeline.to_spec`) capture a live
+generator or pipeline back to a spec — handy for logging the exact
+construction alongside a checkpoint. Callables are captured by dotted import
+path (module-level only — lambdas, closures, and partials raise
+`TypeError`), and hooks by attribute-faithful class construction: each
+`__init__` parameter must be stored as a same-named attribute
+(`self.factor = factor`), which spec-able hooks already do.
+
 ## Building your own model
 
 Putting the pieces together: a small learned decoder that generates a
@@ -343,6 +383,9 @@ with gen.compile(backend="eager"):                    # session: stream + RNG + 
 
 pipe = gen | other_generator                          # composed; links validated
 ```
+
+(If `toy_generate` lives in an importable module, the same workflow is
+spec-able: `create_model_spec(my_module.make_toy_generate, ...)`.)
 
 ## Examples
 
@@ -528,3 +571,5 @@ def vae_generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
 - {class}`~nvalchemi.hooks.GenerationContext`
 - {class}`~nvalchemi.gen.pipeline.GenerationPipeline`
 - {func}`~nvalchemi.gen.default_condition`
+- {class}`~nvalchemi.gen.spec.AtomGeneratorSpec`
+- {class}`~nvalchemi.gen.spec.GenerationPipelineSpec`

--- a/nvalchemi/gen/__init__.py
+++ b/nvalchemi/gen/__init__.py
@@ -20,6 +20,10 @@ condition → generate pipeline with lifecycle hooks
 (:class:`~nvalchemi.gen.stages.GenerationStage`,
 :class:`~nvalchemi.hooks.GenerationContext`) — plus sequential
 composition via :class:`~nvalchemi.gen.pipeline.GenerationPipeline`.
+
+Spec-based construction lives in :mod:`nvalchemi.gen.spec`, which is
+deliberately not re-exported here: importing it pulls in the training spec
+machinery, so it stays an opt-in concrete-module import.
 """
 
 from __future__ import annotations

--- a/nvalchemi/gen/generator.py
+++ b/nvalchemi/gen/generator.py
@@ -111,6 +111,7 @@ from nvalchemi.hooks import GenerationContext, Hook, HookRegistryMixin
 
 if TYPE_CHECKING:
     from nvalchemi.gen.pipeline import GenerationPipeline
+    from nvalchemi.gen.spec import AtomGeneratorSpec
 
 __all__ = ["GeneratingFunction", "AtomGenerator", "default_condition"]
 
@@ -225,7 +226,8 @@ class AtomGenerator(BaseModel, HookRegistryMixin):
         Non-serializable (weights live in the checkpoint machinery).
     generator_func
         User-supplied :class:`GeneratingFunction`; takes precedence over
-        ``model.generate``. Non-serializable.
+        ``model.generate``. Non-serializable (see
+        :class:`~nvalchemi.gen.spec.AtomGeneratorSpec` for the spec path).
     output_to_batch_func
         Optional callable ``output_to_batch_func(sample, batch) -> Batch``
         overriding ``model.to_batch`` for mapping a sample
@@ -523,6 +525,63 @@ class AtomGenerator(BaseModel, HookRegistryMixin):
         )
         self._compiled_generate = torch.compile(target, **merged)
         return self
+
+    def to_spec(self) -> AtomGeneratorSpec:
+        """Capture this generator's construction surface as a spec.
+
+        The reverse of
+        :meth:`~nvalchemi.gen.spec.AtomGeneratorSpec.build` — the result
+        round-trips through ``model_dump_json`` and rebuilds an equivalent
+        generator with ``build(model=...)``. The model is never captured
+        (weights come from the checkpoint machinery). ``generator_func`` and
+        ``output_to_batch_func`` are captured by dotted import path and must
+        be module-level importable callables; each hook's class must store
+        its ``__init__`` parameters as same-named attributes. Lambdas,
+        closures, and partials raise ``TypeError``.
+
+        The spec module stays an opt-in import; this method imports it
+        lazily.
+
+        Returns
+        -------
+        AtomGeneratorSpec
+            The construction spec.
+        """
+        from nvalchemi.gen.spec import (
+            AtomGeneratorSpec,
+            _spec_from_callable,
+            _spec_from_hook,
+        )
+
+        return AtomGeneratorSpec(
+            generator_func=(
+                _spec_from_callable(self.generator_func, name="generator_func")
+                if self.generator_func is not None
+                else None
+            ),
+            output_to_batch_func=(
+                _spec_from_callable(
+                    self.output_to_batch_func, name="output_to_batch_func"
+                )
+                if self.output_to_batch_func is not None
+                else None
+            ),
+            hooks=[_spec_from_hook(hook) for hook in self.hooks],
+            consumes_fields=(
+                sorted(self.consumes_fields)
+                if self.consumes_fields is not None
+                else None
+            ),
+            produces_fields=(
+                sorted(self.produces_fields)
+                if self.produces_fields is not None
+                else None
+            ),
+            num_samples_per_batch=self.num_samples_per_batch,
+            seed=self.seed,
+            compile_generate=self.compile_generate,
+            compile_kwargs=dict(self.compile_kwargs),
+        )
 
     def _infer_device(self) -> torch.device | None:
         """Best-effort device inference from the model (parameters first).

--- a/nvalchemi/gen/pipeline.py
+++ b/nvalchemi/gen/pipeline.py
@@ -58,13 +58,16 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nvalchemi.data import Batch
 from nvalchemi.gen.generator import AtomGenerator
+
+if TYPE_CHECKING:
+    from nvalchemi.gen.spec import GenerationPipelineSpec
 
 __all__ = ["GenerationPipeline"]
 
@@ -184,6 +187,33 @@ class GenerationPipeline(BaseModel):
             if isinstance(stage, AtomGenerator):
                 stage.compile(**kwargs)
         return self
+
+    def to_spec(self) -> GenerationPipelineSpec:
+        """Capture this pipeline's construction surface as a spec.
+
+        The reverse of
+        :meth:`~nvalchemi.gen.spec.GenerationPipelineSpec.build` —
+        :class:`AtomGenerator` stages are captured via their own
+        :meth:`~nvalchemi.gen.generator.AtomGenerator.to_spec`; other
+        stages (plain ``Batch -> Batch`` callables) by dotted import path.
+        Callable *instances* (e.g. dynamics engines) carry no import path
+        and raise ``TypeError``. The spec module stays an opt-in import;
+        this method imports it lazily.
+
+        Returns
+        -------
+        GenerationPipelineSpec
+            The construction spec.
+        """
+        from nvalchemi.gen.spec import GenerationPipelineSpec, _spec_from_callable
+
+        stage_specs: list[Any] = []
+        for stage in self.stages:
+            if isinstance(stage, AtomGenerator):
+                stage_specs.append(stage.to_spec())
+            else:
+                stage_specs.append(_spec_from_callable(stage, name="pipeline stage"))
+        return GenerationPipelineSpec(stages=stage_specs)
 
     def _infer_device(self) -> torch.device | None:
         """Infer the session device from the first AtomGenerator stage's model.

--- a/nvalchemi/gen/spec.py
+++ b/nvalchemi/gen/spec.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Spec-based construction for generators and pipelines.
+
+Mirrors the training spec machinery
+(:class:`~nvalchemi.training._spec.BaseSpec`,
+:func:`~nvalchemi.training._spec.create_model_spec` — dotted import paths +
+JSON-safe kwargs, no pickle) so generation workflows can be driven from
+config files and, eventually, a CLI.
+
+This module is deliberately **not** re-exported from
+:mod:`nvalchemi.gen` — importing it pulls in the training spec machinery, so
+it stays an opt-in concrete-module import (``from nvalchemi.gen.spec import
+AtomGeneratorSpec``).
+
+The unit of spec-ability is the **importable factory**. Family config (latent
+dimensions, step counts, sampler paths) is bound by a module-level factory
+function, which is then specced with
+:func:`~nvalchemi.training._spec.create_model_spec` — never a raw
+:class:`functools.partial`, which is not importable::
+
+    # my_project/generation.py  (dotted-path importable)
+    def make_gan_generate(latent_dim: int = 128):
+        def _generate(model, *, num_samples=1, rng=None, cond=None, **kwargs):
+            z = torch.randn(num_samples, latent_dim, generator=rng)
+            return TensorDict({"x1": model.decode(z)}, batch_size=[num_samples])
+
+        return _generate
+
+    # config layer
+    func_spec = create_model_spec(make_gan_generate, latent_dim=256)
+    spec = AtomGeneratorSpec(generator_func=func_spec, num_samples_per_batch=4)
+    blob = spec.model_dump_json()                 # plain JSON; safe to store
+    spec2 = AtomGeneratorSpec.model_validate_json(blob)
+    gen = spec2.build(model=model)                # model comes from checkpoints
+
+Weights are never part of a spec — the model is supplied at :meth:`build`
+time from the checkpoint machinery (``torch.load(..., weights_only=True)``).
+
+The reverse direction — capturing a live generator or pipeline — is
+:meth:`~nvalchemi.gen.generator.AtomGenerator.to_spec` /
+:meth:`~nvalchemi.gen.pipeline.GenerationPipeline.to_spec`: callables are
+captured by dotted import path, hooks by attribute-faithful class
+construction (each ``__init__`` parameter read back from the same-named
+attribute).
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializeAsAny,
+    field_validator,
+)
+
+from nvalchemi._serialization import _import_callable
+from nvalchemi.gen.generator import AtomGenerator
+from nvalchemi.gen.pipeline import GenerationPipeline
+from nvalchemi.training._spec import (
+    BaseSpec,
+    create_model_spec,
+    create_model_spec_from_json,
+)
+
+__all__ = ["GenerationPipelineSpec", "AtomGeneratorSpec"]
+
+
+def _rehydrate_spec(value: Any) -> Any:
+    """Rehydrate a spec-dict to its dynamic :class:`BaseSpec` subclass."""
+    if isinstance(value, dict):
+        return create_model_spec_from_json(value)
+    return value
+
+
+def _return_importable(path: str) -> Callable[..., Any]:
+    """Identity factory: return the callable at ``path``.
+
+    Exists so a bare module-level callable (not a factory) can live in a
+    spec: ``create_model_spec(_return_importable, path=...)`` builds back to
+    the callable itself. Referenced by dotted path inside stored specs — do
+    not rename or move.
+
+    Parameters
+    ----------
+    path
+        Dotted import path of the callable to return.
+
+    Returns
+    -------
+    Callable
+        The imported callable.
+    """
+    return _import_callable(path)
+
+
+def _spec_from_callable(fn: Callable[..., Any], *, name: str) -> BaseSpec:
+    """Capture a live callable as a spec via its dotted import path.
+
+    The callable must be module-level and importable; lambdas, closures,
+    ``functools.partial`` objects, and callable instances carry no import
+    path and raise ``TypeError``. The spec builds back to the callable
+    itself (through the :func:`_return_importable` identity factory), so it
+    round-trips whether the callable was factory-made or not.
+
+    Parameters
+    ----------
+    fn
+        The live callable to capture.
+    name
+        The field/role name used in error messages.
+
+    Returns
+    -------
+    BaseSpec
+        A spec whose ``build()`` returns ``fn`` (re-imported).
+
+    Raises
+    ------
+    TypeError
+        If ``fn`` has no importable dotted path.
+    """
+    if isinstance(fn, functools.partial):
+        raise TypeError(
+            f"{name} cannot be captured in a spec: functools.partial objects "
+            "have no import path. Bind arguments in a module-level factory "
+            "function instead."
+        )
+    module = getattr(fn, "__module__", None)
+    qualname = getattr(fn, "__qualname__", None)
+    if not module or not qualname or "<locals>" in qualname or qualname == "<lambda>":
+        raise TypeError(
+            f"{name} cannot be captured in a spec: {fn!r} is not a "
+            "module-level importable callable (lambdas, closures, and "
+            "callable instances have no dotted path). Define it at module "
+            "level, or bind config in a module-level factory."
+        )
+    return create_model_spec(_return_importable, path=f"{module}.{qualname}")
+
+
+def _spec_from_hook(hook: Any) -> BaseSpec:
+    """Capture a live hook as a spec of its class plus ``__init__`` kwargs.
+
+    Each ``__init__`` parameter is read back from the same-named attribute
+    on the instance — the convention spec-able hooks already follow
+    (``self.x = x``). Parameters that are positional-only, variadic, or not
+    stored as a same-named attribute raise ``TypeError``. Attribute values
+    must be JSON-safe (enums serialize by value).
+
+    Parameters
+    ----------
+    hook
+        The live hook instance.
+
+    Returns
+    -------
+    BaseSpec
+        A spec whose ``build()`` reconstructs the hook.
+
+    Raises
+    ------
+    TypeError
+        If the hook's constructor is not attribute-faithful.
+    """
+    cls = type(hook)
+    if cls.__init__ is object.__init__:
+        return create_model_spec(cls)
+    sig = inspect.signature(cls.__init__)
+    kwargs: dict[str, Any] = {}
+    for pname, param in sig.parameters.items():
+        if pname == "self":
+            continue
+        if param.kind not in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            raise TypeError(
+                f"{cls.__qualname__} is not spec-able: __init__ parameter "
+                f"{pname!r} is positional-only or variadic; spec-able hooks "
+                "use keyword-able parameters only."
+            )
+        if not hasattr(hook, pname):
+            raise TypeError(
+                f"{cls.__qualname__} is not spec-able: __init__ parameter "
+                f"{pname!r} is not stored as a same-named attribute on the "
+                "instance (the self.x = x convention)."
+            )
+        kwargs[pname] = getattr(hook, pname)
+    return create_model_spec(cls, **kwargs)
+
+
+class AtomGeneratorSpec(BaseModel):
+    """JSON-serializable construction spec for a :class:`AtomGenerator`.
+
+    Attributes
+    ----------
+    generator_func
+        Spec for a dotted-path factory returning the
+        :class:`~nvalchemi.gen.generator.GeneratingFunction` (e.g. from
+        :func:`~nvalchemi.training._spec.create_model_spec`). ``None`` when
+        the model's own ``generate`` is the generation source.
+    output_to_batch_func
+        Spec for a dotted-path materialization callable/factory. ``None``
+        when the model's own ``to_batch`` is the materialization target.
+    hooks
+        Specs for the generation hooks (hook classes must have
+        keyword-only, JSON-safe constructors — the
+        :func:`~nvalchemi.training._spec.create_model_spec` constraint).
+    consumes_fields, produces_fields
+        Field declarations forwarded to the :class:`AtomGenerator` (``None``
+        leaves the AtomGenerator-side defaulting from ``model.model_config``
+        in place).
+    num_samples_per_batch
+        Draws per conditioning entry.
+    seed
+        Base seed for per-draw RNGs.
+
+    Notes
+    -----
+    ``revalidate_instances="never"`` matches
+    :class:`~nvalchemi.training._spec.BaseSpec`: specs are immutable records
+    of construction config.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, revalidate_instances="never"
+    )
+
+    spec_kind: Literal["generator"] = "generator"
+    generator_func: SerializeAsAny[BaseSpec] | None = None
+    output_to_batch_func: SerializeAsAny[BaseSpec] | None = None
+    hooks: list[SerializeAsAny[BaseSpec]] = Field(default_factory=list)
+    consumes_fields: list[str] | None = None
+    produces_fields: list[str] | None = None
+    num_samples_per_batch: int = Field(default=1, ge=1)
+    seed: int | None = None
+    compile_generate: bool = False
+    compile_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("generator_func", "output_to_batch_func", mode="before")
+    @classmethod
+    def _rehydrate_callable(cls, value: Any) -> Any:
+        """Rehydrate JSON spec-dicts for the callable fields."""
+        return _rehydrate_spec(value)
+
+    @field_validator("hooks", mode="before")
+    @classmethod
+    def _rehydrate_hooks(cls, value: Any) -> Any:
+        """Rehydrate JSON spec-dicts for the hook list."""
+        return [_rehydrate_spec(item) for item in value]
+
+    def build(self, *, model: Any = None, **overrides: Any) -> AtomGenerator:
+        """Build the :class:`AtomGenerator`, injecting the runtime model.
+
+        Parameters
+        ----------
+        model
+            The generative model (weights from the checkpoint machinery).
+            Required — specs cover construction, not parameters.
+        **overrides
+            Extra keyword arguments forwarded to the
+            :class:`~nvalchemi.gen.generator.AtomGenerator` constructor,
+            overriding spec-stored values of the same name.
+
+        Returns
+        -------
+        AtomGenerator
+            The constructed generator.
+
+        Raises
+        ------
+        TypeError
+            If no model is supplied.
+        """
+        if model is None and "model" not in overrides:
+            raise TypeError(
+                "AtomGeneratorSpec.build requires a model; weights come from the "
+                "checkpoint machinery, not the spec."
+            )
+        kwargs: dict[str, Any] = {
+            "generator_func": (
+                self.generator_func.build() if self.generator_func is not None else None
+            ),
+            "output_to_batch_func": (
+                self.output_to_batch_func.build()
+                if self.output_to_batch_func is not None
+                else None
+            ),
+            "hooks": [hook.build() for hook in self.hooks],
+            "consumes_fields": (
+                frozenset(self.consumes_fields)
+                if self.consumes_fields is not None
+                else None
+            ),
+            "produces_fields": (
+                frozenset(self.produces_fields)
+                if self.produces_fields is not None
+                else None
+            ),
+            "num_samples_per_batch": self.num_samples_per_batch,
+            "seed": self.seed,
+            "compile_generate": self.compile_generate,
+            "compile_kwargs": dict(self.compile_kwargs),
+        }
+        kwargs.update(overrides)
+        return AtomGenerator(model=model, **kwargs)
+
+
+class GenerationPipelineSpec(BaseModel):
+    """JSON-serializable construction spec for a :class:`GenerationPipeline`.
+
+    Attributes
+    ----------
+    stages
+        Ordered stage specs: :class:`AtomGeneratorSpec` entries and/or
+        :class:`~nvalchemi.training._spec.BaseSpec` entries that build
+        ``Batch -> Batch`` stages (dynamics engines, callables).
+
+    Notes
+    -----
+    JSON rehydration distinguishes entries by shape: dicts with a
+    ``cls_path`` key are callable specs (rebuilt via
+    :func:`~nvalchemi.training._spec.create_model_spec_from_json`); any
+    other dict is a :class:`AtomGeneratorSpec`.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, revalidate_instances="never"
+    )
+
+    spec_kind: Literal["generation_pipeline"] = "generation_pipeline"
+    stages: list[SerializeAsAny[BaseSpec] | AtomGeneratorSpec] = Field(min_length=1)
+
+    @field_validator("stages", mode="before")
+    @classmethod
+    def _rehydrate_stages(cls, value: Any) -> Any:
+        """Rehydrate JSON dicts to stage specs (see class Notes)."""
+        out: list[Any] = []
+        for item in value:
+            if isinstance(item, dict):
+                if "cls_path" in item:
+                    out.append(create_model_spec_from_json(item))
+                else:
+                    out.append(AtomGeneratorSpec.model_validate(item))
+            else:
+                out.append(item)
+        return out
+
+    def build(self, *, models: Any = None) -> GenerationPipeline:
+        """Build the pipeline, injecting runtime models for generator stages.
+
+        Parameters
+        ----------
+        models
+            One model per :class:`AtomGeneratorSpec` stage, in stage order.
+
+        Returns
+        -------
+        GenerationPipeline
+            The constructed pipeline.
+
+        Raises
+        ------
+        TypeError
+            If fewer models than generator stages are supplied.
+        """
+        model_iter = iter(models or [])
+        stages: list[Any] = []
+        for spec in self.stages:
+            if isinstance(spec, AtomGeneratorSpec):
+                try:
+                    model = next(model_iter)
+                except StopIteration:
+                    raise TypeError(
+                        "GenerationPipelineSpec.build needs one model per "
+                        "AtomGeneratorSpec stage, in stage order."
+                    ) from None
+                stages.append(spec.build(model=model))
+            else:
+                stages.append(spec.build())
+        return GenerationPipeline(stages=stages)

--- a/test/gen/test_gen_spec.py
+++ b/test/gen/test_gen_spec.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structural tests for spec-based construction of generators and pipelines.
+
+Covers :class:`~nvalchemi.gen.spec.AtomGeneratorSpec` and
+:class:`~nvalchemi.gen.spec.GenerationPipelineSpec`: JSON round-trips,
+factory-based spec-ability (importable factories, not
+:func:`functools.partial`), hook specs with enum-stage rehydration, and
+runtime model injection at ``build`` time. CPU-only, GPU-free, no optional
+deps.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+
+import pytest
+import torch
+
+from nvalchemi.data import Batch
+from nvalchemi.gen.generator import AtomGenerator
+from nvalchemi.gen.spec import AtomGeneratorSpec, GenerationPipelineSpec
+from nvalchemi.gen.stages import GenerationStage
+from nvalchemi.models.gen.demo import DemoGANModel, demo_nonparametric_generation
+from nvalchemi.training._spec import create_model_spec
+from test.gen.conftest import make_batch, trivial_generate, zeros_to_batch
+
+
+def make_trivial_generate():
+    """Factory returning the trivial generating function (spec-able).
+
+    Returns
+    -------
+    Callable
+        ``trivial_generate``.
+    """
+    return trivial_generate
+
+
+def make_zeros_recon():
+    """Factory returning the zeros reconstruction (spec-able).
+
+    Returns
+    -------
+    Callable
+        ``zeros_to_batch``.
+    """
+    return zeros_to_batch
+
+
+def make_passthrough_stage():
+    """Factory returning a Batch -> Batch identity stage (spec-able).
+
+    Returns
+    -------
+    Callable
+        A pass-through pipeline stage.
+    """
+
+    def stage(batch: Batch) -> Batch:
+        """Pass the batch through unchanged."""
+        return batch
+
+    return stage
+
+
+class ScaleSampleHook:
+    """Spec-able demo hook: scale the generated positions at AFTER_GENERATE."""
+
+    def __init__(
+        self,
+        factor: float = 2.0,
+        frequency: int = 1,
+        stage: GenerationStage | None = None,
+    ) -> None:
+        self.factor = factor
+        self.frequency = frequency
+        self.stage = stage if stage is not None else GenerationStage.AFTER_GENERATE
+
+    def __call__(self, ctx, stage) -> None:
+        """Scale the materialized batch's positions by ``self.factor``."""
+        ctx.batch.positions = ctx.batch.positions * self.factor
+
+
+class TestGeneratorSpec:
+    """``AtomGeneratorSpec`` construction, JSON round-trip, and build."""
+
+    def _spec(self) -> AtomGeneratorSpec:
+        """Build a representative spec with a hook and field declarations.
+
+        Returns
+        -------
+        AtomGeneratorSpec
+            A fully populated spec.
+        """
+        return AtomGeneratorSpec(
+            generator_func=create_model_spec(make_trivial_generate),
+            output_to_batch_func=create_model_spec(make_zeros_recon),
+            hooks=[
+                create_model_spec(
+                    ScaleSampleHook, factor=3.0, stage=GenerationStage.AFTER_GENERATE
+                )
+            ],
+            consumes_fields=["positions"],
+            produces_fields=["positions", "atomic_numbers"],
+            num_samples_per_batch=2,
+            seed=11,
+            compile_generate=True,
+            compile_kwargs={"backend": "eager"},
+        )
+
+    def test_spec_builds_working_generator(self) -> None:
+        """A spec builds a generator whose pieces match the spec."""
+        gen = self._spec().build(model=torch.nn.Module())
+        assert gen.num_samples_per_batch == 2
+        assert gen.seed == 11
+        assert gen.consumes_fields == frozenset({"positions"})
+        assert gen.produces_fields == frozenset({"positions", "atomic_numbers"})
+        assert len(gen.hooks) == 1
+        hook = gen.hooks[0]
+        assert isinstance(hook, ScaleSampleHook)
+        assert hook.factor == 3.0
+        assert gen.compile_generate is True
+        assert gen.compile_kwargs == {"backend": "eager"}
+        out = gen(make_batch(num_graphs=1))
+        assert out.num_graphs == 2
+
+    def test_spec_json_round_trip(self) -> None:
+        """``model_dump_json`` -> ``model_validate_json`` preserves the spec."""
+        spec = self._spec()
+        blob = spec.model_dump_json()
+        raw = json.loads(blob)  # genuinely plain JSON
+        assert raw["generator_func"]["cls_path"].endswith("make_trivial_generate")
+        restored = AtomGeneratorSpec.model_validate_json(blob)
+        assert restored.compile_generate is True
+        assert restored.compile_kwargs == {"backend": "eager"}
+        gen = restored.build(model=torch.nn.Module())
+        assert gen.num_samples_per_batch == 2
+        hook = gen.hooks[0]
+        assert isinstance(hook, ScaleSampleHook)
+        assert hook.factor == 3.0
+        # The enum stage survived JSON (as its int value) and was coerced back.
+        assert hook.stage is GenerationStage.AFTER_GENERATE
+        out = gen(make_batch(num_graphs=1))
+        assert out.num_graphs == 2
+
+    def test_build_requires_model(self) -> None:
+        """``build`` without a model raises ``TypeError`` (weights are external)."""
+        with pytest.raises(TypeError, match="requires a model"):
+            self._spec().build()
+
+    def test_build_overrides(self) -> None:
+        """``build(**overrides)`` forwards runtime overrides to the constructor."""
+        gen = self._spec().build(model=torch.nn.Module(), num_samples_per_batch=5)
+        assert gen.num_samples_per_batch == 5
+
+    def test_spec_without_funcs_relies_on_model_methods(self) -> None:
+        """A spec with no callables needs ``model.generate``/``to_batch``."""
+        spec = AtomGeneratorSpec()
+        with pytest.raises(TypeError, match="generation source"):
+            spec.build(model=torch.nn.Module())
+
+
+class TestGenerationPipelineSpec:
+    """``GenerationPipelineSpec`` round-trip and model injection."""
+
+    def _stage_spec(self, **kwargs) -> AtomGeneratorSpec:
+        """Build a minimal generator stage spec.
+
+        Parameters
+        ----------
+        **kwargs
+            Extra :class:`AtomGeneratorSpec` fields.
+
+        Returns
+        -------
+        AtomGeneratorSpec
+            The stage spec.
+        """
+        return AtomGeneratorSpec(
+            generator_func=create_model_spec(make_trivial_generate),
+            output_to_batch_func=create_model_spec(make_zeros_recon),
+            consumes_fields=kwargs.pop("consumes_fields", []),
+            produces_fields=kwargs.pop("produces_fields", ["positions"]),
+            **kwargs,
+        )
+
+    def test_pipeline_spec_builds_pipeline(self) -> None:
+        """Specs build into a working pipeline; models inject in stage order."""
+        spec = GenerationPipelineSpec(
+            stages=[self._stage_spec(), self._stage_spec(consumes_fields=["positions"])]
+        )
+        pipe = spec.build(models=[torch.nn.Module(), torch.nn.Module()])
+        out = pipe(make_batch(num_graphs=1))
+        assert out.num_graphs == 1
+
+    def test_pipeline_spec_json_round_trip(self) -> None:
+        """Pipeline specs survive JSON, including non-generator stage specs."""
+        spec = GenerationPipelineSpec(
+            stages=[
+                self._stage_spec(),
+                create_model_spec(make_passthrough_stage),
+                self._stage_spec(consumes_fields=["positions"]),
+            ]
+        )
+        blob = spec.model_dump_json()
+        restored = GenerationPipelineSpec.model_validate_json(blob)
+        models = [torch.nn.Module(), torch.nn.Module()]
+        pipe = restored.build(models=models)
+        assert len(pipe.stages) == 3
+        out = pipe(make_batch(num_graphs=2))
+        assert out.num_graphs == 2
+
+    def test_pipeline_spec_missing_model_raises(self) -> None:
+        """Too few models for the generator stages raises ``TypeError``."""
+        spec = GenerationPipelineSpec(
+            stages=[self._stage_spec(), self._stage_spec(consumes_fields=["positions"])]
+        )
+        with pytest.raises(TypeError, match="one model per"):
+            spec.build(models=[torch.nn.Module()])
+
+
+class TestToSpec:
+    """``to_spec`` — the reverse direction of spec construction."""
+
+    def _generator(self, **kwargs) -> AtomGenerator:
+        """Build a demo generator with spec-able wiring plus overrides.
+
+        Parameters
+        ----------
+        **kwargs
+            Constructor overrides.
+
+        Returns
+        -------
+        AtomGenerator
+            A DemoGANModel-backed generator.
+        """
+        defaults: dict = {
+            "model": DemoGANModel(),
+            "generator_func": trivial_generate,
+            "output_to_batch_func": zeros_to_batch,
+        }
+        defaults.update(kwargs)
+        return AtomGenerator(**defaults)
+
+    def test_round_trip_full(self) -> None:
+        """A fully wired generator round-trips through JSON and rebuilds."""
+        gen = self._generator(
+            hooks=[ScaleSampleHook(factor=3.0)],
+            consumes_fields=frozenset({"positions"}),
+            produces_fields=frozenset({"positions", "atomic_numbers"}),
+            num_samples_per_batch=2,
+            seed=11,
+            compile_kwargs={"backend": "eager"},
+        )
+        blob = gen.to_spec().model_dump_json()
+        rebuilt = AtomGeneratorSpec.model_validate_json(blob).build(
+            model=DemoGANModel()
+        )
+        assert rebuilt.generator_func is trivial_generate
+        assert rebuilt.output_to_batch_func is zeros_to_batch
+        assert rebuilt.num_samples_per_batch == 2
+        assert rebuilt.seed == 11
+        assert rebuilt.compile_kwargs == {"backend": "eager"}
+        assert rebuilt.consumes_fields == frozenset({"positions"})
+        assert rebuilt.produces_fields == frozenset({"positions", "atomic_numbers"})
+        hook = rebuilt.hooks[0]
+        assert isinstance(hook, ScaleSampleHook)
+        assert hook.factor == 3.0
+        assert hook.stage is GenerationStage.AFTER_GENERATE
+        assert rebuilt(make_batch(num_graphs=1)).num_graphs == 2
+
+    def test_round_trip_model_fallbacks(self) -> None:
+        """A generator on model ``generate``/``to_batch`` specs no callables."""
+        gen = AtomGenerator(model=DemoGANModel(), seed=3)
+        spec = gen.to_spec()
+        assert spec.generator_func is None
+        assert spec.output_to_batch_func is None
+        rebuilt = AtomGeneratorSpec.model_validate_json(spec.model_dump_json()).build(
+            model=DemoGANModel()
+        )
+        assert rebuilt(make_batch(num_graphs=2)).num_graphs == 2
+
+    def test_lambda_and_closure_rejected(self) -> None:
+        """Callables without a dotted path raise ``TypeError``."""
+        gen = self._generator(generator_func=lambda model, **kw: None)
+        with pytest.raises(TypeError, match="module-level"):
+            gen.to_spec()
+
+        def _closure(model, **kw):
+            """A closure is not importable."""
+
+        with pytest.raises(TypeError, match="module-level"):
+            self._generator(generator_func=_closure).to_spec()
+
+    def test_partial_rejected(self) -> None:
+        """``functools.partial`` has no import path — rejected."""
+        gen = self._generator(generator_func=functools.partial(trivial_generate))
+        with pytest.raises(TypeError, match="functools.partial"):
+            gen.to_spec()
+
+    def test_hook_not_attribute_faithful_rejected(self) -> None:
+        """A hook that does not store an ``__init__`` param raises."""
+
+        class _UnfaithfulHook:
+            def __init__(self, threshold: float = 1.0) -> None:
+                self.stage = GenerationStage.AFTER_GENERATE
+                self.frequency = 1
+
+            def __call__(self, ctx, stage) -> None:
+                """No-op."""
+
+        gen = self._generator(hooks=[_UnfaithfulHook(threshold=0.5)])
+        with pytest.raises(TypeError, match="same-named attribute"):
+            gen.to_spec()
+
+    def test_pipeline_round_trip(self) -> None:
+        """Pipelines spec their generator stages and callable stages."""
+        pipe = AtomGenerator(model=DemoGANModel()) | demo_nonparametric_generation
+        blob = pipe.to_spec().model_dump_json()
+        rebuilt = GenerationPipelineSpec.model_validate_json(blob).build(
+            models=[DemoGANModel()]
+        )
+        assert len(rebuilt.stages) == 2
+        assert isinstance(rebuilt.stages[0], AtomGenerator)
+        assert rebuilt.stages[1] is demo_nonparametric_generation
+        assert rebuilt(None).num_graphs == 1


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

PR 4 of the generative-workflows stack (on top of #186). Adds JSON spec-based construction for generators and pipelines — mirroring the training spec machinery (dotted import paths + JSON-safe kwargs, no pickle) — plus the reverse direction: `to_spec()` captures a live generator or pipeline back to a spec for serialization and reproducibility.

The unit of spec-ability is the importable factory; models are never part of a spec (weights come from the checkpoint machinery at `build` time). Callables are captured by dotted path through an identity factory, so bare module-level functions round-trip as themselves; hooks are captured by attribute-faithful reconstruction (each `__init__` parameter read from the same-named attribute). Lambdas, closures, partials, and callable instances raise a `TypeError` with guidance.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Stacked on #186 (docs) ← #185 (pipelines) ← #184 (generative core). Tip of this branch is byte-identical to the fully-tested combined tree.

## Changes Made

- `AtomGeneratorSpec` / `GenerationPipelineSpec` (`nvalchemi.gen.spec`, an opt-in import): JSON-serializable construction; `build(model=...)` / `build(models=...)` inject runtime weights.
- `AtomGenerator.to_spec()` / `GenerationPipeline.to_spec()`: the reverse direction, with clear errors for un-speccable callables and hooks.
- The user guide gains the spec-based-construction section (with the round-trip pattern); the API page gains the spec entries.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Notes: verified via `uv run pytest` / `uv run ruff` (make targets default to a CUDA extra unavailable on macOS). New tests cover construction, JSON round-trips (including enum stage coercion), model injection and overrides, `to_spec` round-trips asserting object identity of re-imported callables, and the rejection paths (lambda/closure/partial/non-attribute-faithful hooks).

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

Draft for parallel review. This PR is the top of the stack; its tree equals the fully-tested combined state (885 tests passing across the gen/models/hooks suites).
