### PR TITLE
docs(models): correct stale stress pre-allocation note in lj wrapper

### DIFF
--- a/nvalchemi/models/lj.py
+++ b/nvalchemi/models/lj.py
@@ -45,13 +45,17 @@ Notes
 * Only a **single species** is supported in this wrapper.  Epsilon and sigma
   are scalar parameters shared across all atom pairs.
 * Stress/virial computation (needed for NPT/NPH) is available via
-  ``model_config.active_outputs`` including ``"stress"``.  When enabled, the
-  wrapper returns a ``"stress"`` key containing the tensile-positive Cauchy
-  stress ``-W/V`` in energy units.  After calling ``Batch.from_data_list``, set
-  the placeholder directly:
-  ``batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)``.  This is
-  required because ``"stress"`` is not a named ``AtomicData`` field and is
-  therefore not carried through batching automatically.
+  ``model_config.active_outputs`` including ``"stress"`` (e.g. via
+  ``model.set_config("active_outputs", {"energy", "forces", "stress"})``).
+  When enabled, the wrapper returns a ``"stress"`` key containing the
+  tensile-positive Cauchy stress ``-W/V`` in energy units.  After calling
+  ``Batch.from_data_list``, set the placeholder directly:
+  ``batch["stress"] = torch.zeros(batch.num_graphs, 3, 3)``.  NPT/NPH
+  integrators read ``batch.stress`` before the first model evaluation and
+  the compute loop updates it in place, so the tensor must already exist.
+  It can be omitted only when the source data already carries ``stress``,
+  which is a named :class:`~nvalchemi.data.AtomicData` field and survives
+  batching.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

Corrects a stale note in the LJ model wrapper's module docstring about stress pre-allocation. The requirement itself is unchanged — NPT/NPH integrators read `batch.stress` before the first model evaluation and the compute loop only updates the tensor in place, so it must already exist. What was stale is the rationale: `"stress"` is now a named `AtomicData` field and survives batching, so the placeholder can be omitted when the source data already carries it. Also adds the `set_config("active_outputs", ...)` usage example.

Found during the torch.compile enablement campaign (finding F-005). No behavior change.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

None — finding F-005 from the torch.compile enablement campaign.

## Changes Made

<!-- List the key changes made in this PR -->

- Fixed the stale rationale in the stress pre-allocation note in `nvalchemi/models/lj.py`: `"stress"` is a named `AtomicData` field and survives batching.
- Kept the pre-allocation requirement, now justified by the actual reason: integrators read `batch.stress` before the first compute and update it in place.
- Added the `model.set_config("active_outputs", {"energy", "forces", "stress"})` example.

## Testing

<!-- Describe the tests you ran to verify your changes -->

Docs-only change to a module docstring; no code paths touched. Pre-commit hooks pass (ruff check/format, interrogate, license header, markdownlint).

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

CHANGELOG intentionally not updated: this is a docs-only docstring fix with no behavior or API change.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
